### PR TITLE
Adding Tensor Vector Multiplication

### DIFF
--- a/blaze_tensor/config/BLAS.h
+++ b/blaze_tensor/config/BLAS.h
@@ -1,0 +1,126 @@
+//=================================================================================================
+/*!
+//  \file blaze_tensor/config/BLAS.h
+//  \brief Configuration of the BLAS mode
+//
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
+//
+//  This file is part of the Blaze library. You can redistribute it and/or modify it under
+//  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
+//  forms, with or without modification, are permitted provided that the following conditions
+//  are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list
+//     of conditions and the following disclaimer in the documentation and/or other materials
+//     provided with the distribution.
+//  3. Neither the names of the Blaze development group nor the names of its contributors
+//     may be used to endorse or promote products derived from this software without specific
+//     prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+//  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+*/
+//=================================================================================================
+
+
+//*************************************************************************************************
+/*!\brief Compilation switch for the BLAS mode.
+// \ingroup config
+//
+// This compilation switch enables/disables the BLAS mode. In case the BLAS mode is enabled,
+// several basic linear algebra functions (such as for instance matrix-matrix multiplications
+// between two dense matrices) are handled by performance optimized BLAS functions. Note that
+// in this case it is mandatory to provide the according BLAS header file for the compilation
+// of the Blaze library. In case the BLAS mode is disabled, all linear algebra functions use
+// the default implementations of the Blaze library and therefore BLAS is not a requirement
+// for the compilation process.
+//
+// Possible settings for the BLAS switch:
+//  - Disabled: \b 0
+//  - Enabled : \b 1
+//
+// \warning Changing the setting of the BLAS mode requires a recompilation of all code using
+// the Blaze library!
+//
+// \note It is possible to (de-)activate the BLAS mode via command line or by defining this
+// symbol manually before including any Blaze header file:
+
+   \code
+   #define BLAZE_BLAS_MODE 1
+   #include <blaze/Blaze.h>
+   \endcode
+*/
+#ifndef BLAZE_BLAS_MODE
+#define BLAZE_BLAS_MODE 0
+#endif
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Compilation switch for the BLAS matrix/vector multiplication kernels (gemv).
+// \ingroup config
+//
+// This compilation switch enables/disables the BLAS matrix/vector multiplication kernels. If the
+// switch is enabled, multiplications between dense matrices and dense vectors are computed by
+// BLAS kernels, if it is disabled the multiplications are handled by the default Blaze kernels.
+//
+// Possible settings for the switch:
+//  - Disabled: \b 0 (default)
+//  - Enabled : \b 1
+//
+// \warning Changing the setting of this compilation switch requires a recompilation of all code
+// using the Blaze library!
+//
+// \note It is possible to (de-)activate the use of the BLAS matrix/vector multiplication kernels
+// via command line or by defining this symbol manually before including any Blaze header file:
+
+   \code
+   #define BLAZE_USE_BLAS_MATRIX_VECTOR_MULTIPLICATION 1
+   #include <blaze/Blaze.h>
+   \endcode
+*/
+#ifndef BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION
+#define BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION 0
+#endif
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Compilation switch for the BLAS matrix/matrix multiplication kernels (gemv).
+// \ingroup config
+//
+// This compilation switch enables/disables the BLAS matrix/matrix multiplication kernels. If the
+// switch is enabled, multiplications between dense matrices are computed by BLAS kernels, if it
+// is disabled the multiplications are handled by the default Blaze kernels.
+//
+// Possible settings for the switch:
+//  - Disabled: \b 0
+//  - Enabled : \b 1 (default)
+//
+// \warning Changing the setting of this compilation switch requires a recompilation of all code
+// code using the Blaze library!
+//
+// \note It is possible to (de-)activate the use of the BLAS matrix/matrix multiplication kernels
+// via command line or by defining this symbol manually before including any Blaze header file:
+
+   \code
+   #define BLAZE_USE_BLAS_MATRIX_MATRIX_MULTIPLICATION 1
+   #include <blaze/Blaze.h>
+   \endcode
+*/
+#ifndef BLAZE_USE_BLAS_TENSOR_TENSOR_MULTIPLICATION
+#define BLAZE_USE_BLAS_TENSOR_TENSOR_MULTIPLICATION 1
+#endif
+//*************************************************************************************************

--- a/blaze_tensor/config/Thresholds.h
+++ b/blaze_tensor/config/Thresholds.h
@@ -1,0 +1,102 @@
+//=================================================================================================
+/*!
+//  \file blaze_tensor/config/Thresholds.h
+//  \brief Configuration of the thresholds for matrix/vector and matrix/matrix multiplications
+//
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
+//
+//  This file is part of the Blaze library. You can redistribute it and/or modify it under
+//  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
+//  forms, with or without modification, are permitted provided that the following conditions
+//  are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list
+//     of conditions and the following disclaimer in the documentation and/or other materials
+//     provided with the distribution.
+//  3. Neither the names of the Blaze development group nor the names of its contributors
+//     may be used to endorse or promote products derived from this software without specific
+//     prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+//  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+*/
+//=================================================================================================
+
+
+//=================================================================================================
+//
+//  BLAS THRESHOLDS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Row-major dense matrix/dense vector multiplication threshold.
+// \ingroup config
+//
+// This setting specifies the threshold between the application of the custom Blaze kernels
+// and the BLAS kernels for the row-major dense matrix/dense vector multiplication. In case
+// the number of elements in the dense matrix is equal or higher than this value, the BLAS
+// kernels are preferred over the custom Blaze kernels. In case the number of elements in the
+// dense matrix is smaller, the Blaze kernels are used.
+//
+// The default setting for this threshold is 4000000 (which for instance corresponds to a matrix
+// size of \f$ 2000 \times 2000 \f$). Note that in case the Blaze debug mode is active, this
+// threshold will be replaced by the blaze::DMATDVECMULT_DEBUG_THRESHOLD value.
+//
+// \note It is possible to specify this threshold via command line or by defining this symbol
+// manually before including any Blaze header file:
+
+   \code
+   #define BLAZE_DTENSDVECMULT_THRESHOLD 4000000UL
+   #include <blaze/Blaze.h>
+   \endcode
+*/
+#ifndef BLAZE_DTENSDVECMULT_THRESHOLD
+#define BLAZE_DTENSDVECMULT_THRESHOLD 4000000UL
+#endif
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief SMP row-major dense matrix/dense vector multiplication threshold.
+// \ingroup config
+//
+// This threshold specifies when a row-major dense matrix/dense vector multiplication can be
+// executed in parallel. In case the number of elements of the target vector is larger or equal
+// to this threshold, the operation is executed in parallel. If the number of elements is below
+// this threshold the operation is executed single-threaded.
+//
+// Please note that this threshold is highly sensitiv to the used system architecture and the
+// shared memory parallelization technique. Therefore the default value cannot guarantee maximum
+// performance for all possible situations and configurations. It merely provides a reasonable
+// standard for the current generation of CPUs. Also note that the provided default has been
+// determined using the OpenMP parallelization and requires individual adaption for the C++11
+// and Boost thread parallelization or the HPX-based parallelization.
+//
+// The default setting for this threshold is 330. In case the threshold is set to 0, the operation
+// is unconditionally executed in parallel.
+//
+// \note It is possible to specify this threshold via command line or by defining this symbol
+// manually before including any Blaze header file:
+
+   \code
+   #define BLAZE_SMP_DTENSDVECMULT_THRESHOLD 330UL
+   #include <blaze/Blaze.h>
+   \endcode
+*/
+#ifndef BLAZE_SMP_DTENSDVECMULT_THRESHOLD
+#define BLAZE_SMP_DTENSDVECMULT_THRESHOLD 330UL
+#endif
+//*************************************************************************************************

--- a/blaze_tensor/math/TypeTraits.h
+++ b/blaze_tensor/math/TypeTraits.h
@@ -43,6 +43,7 @@
 
 #include <blaze/math/TypeTraits.h>
 
+#include <blaze_tensor/math/typetraits/HasMult.h>
 #include <blaze_tensor/math/typetraits/IsColumnMajorTensor.h>
 #include <blaze_tensor/math/typetraits/IsColumnSlice.h>
 #include <blaze_tensor/math/typetraits/IsDenseTensor.h>

--- a/blaze_tensor/math/Vector.h
+++ b/blaze_tensor/math/Vector.h
@@ -1,10 +1,11 @@
 //=================================================================================================
 /*!
-//  \file blaze_tensor/math/DenseMatrix.h
-//  \brief Header file for all basic DenseMatrix functionality
+//  \file blaze_tensor/math/Vector.h
+//  \brief Header file for all basic Vector functionality
 //
-//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
-//  Copyright (C) 2018 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
 //  This file is part of the Blaze library. You can redistribute it and/or modify it under
 //  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
@@ -33,33 +34,16 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_DENSETENSOR_H_
-#define _BLAZE_TENSOR_MATH_DENSETENSOR_H_
+#ifndef _BLAZE_TENSOR_MATH_VECTOR_H_
+#define _BLAZE_TENSOR_MATH_VECTOR_H_
 
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/DenseMatrix.h>
+#include <blaze/math/Vector.h>
 
-#include <blaze_tensor/math/Tensor.h>
-#include <blaze_tensor/math/dense/DenseTensor.h>
-#include <blaze_tensor/math/expressions/DMatExpandExpr.h>
-#include <blaze_tensor/math/expressions/DMatRavelExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensAddExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensEqualExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensSchurExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensSubExpr.h>
-#include <blaze_tensor/math/expressions/DTensDVecMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensMapExpr.h>
-#include <blaze_tensor/math/expressions/DTensRavelExpr.h>
-#include <blaze_tensor/math/expressions/DTensScalarDivExpr.h>
-#include <blaze_tensor/math/expressions/DTensScalarMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensSerialExpr.h>
-#include <blaze_tensor/math/expressions/DTensTransExpr.h>
-#include <blaze_tensor/math/expressions/DenseTensor.h>
-#include <blaze_tensor/math/smp/DenseTensor.h>
+
 
 #endif

--- a/blaze_tensor/math/dense/DynamicMatrix.h
+++ b/blaze_tensor/math/dense/DynamicMatrix.h
@@ -43,12 +43,17 @@
 //*************************************************************************************************
 
 #include <blaze/math/dense/DynamicMatrix.h>
+#include <blaze/math/dense/DynamicVector.h>
 #include <blaze/math/traits/ExpandTrait.h>
+#include <blaze/math/typetraits/IsColumnVector.h>
+#include <blaze/math/typetraits/IsDenseMatrix.h>
 
 #include <blaze_tensor/math/dense/Forward.h>
 #include <blaze_tensor/math/traits/DilatedSubmatrixTrait.h>
 #include <blaze_tensor/math/traits/MultTrait.h>
 #include <blaze_tensor/math/traits/RavelTrait.h>
+#include <blaze_tensor/math/typetraits/IsDenseTensor.h>
+#include <blaze_tensor/math/typetraits/IsTensor.h>
 
 namespace blaze {
 
@@ -127,22 +132,28 @@ struct DilatedSubmatrixTraitEval2< MT, inf, inf, inf, inf, inf, inf
 //*************************************************************************************************
 /*! \cond BLAZE_INTERNAL */
 template< typename T1, typename T2 >
-struct MultTraitEval2< T1, T2
+struct MultTraitEval2<  T1, T2
                      , EnableIf_t< IsTensor_v<T1> &&
                                    IsColumnVector_v<T2> &&
                                    ( IsDenseTensor_v<T1> || IsDenseVector_v<T2> ) &&
-                                   ( Size_v<T1,0UL> == DefaultSize_v &&
-                                     Size_v<T2,0UL> == DefaultSize_v ) &&
-                                   ( MaxSize_v<T1,0UL> == DefaultMaxSize_v &&
-                                     MaxSize_v<T2,0UL> == DefaultMaxSize_v ) /*&&
-                                   ( Size_v<T1,1UL> == DefaultSize_v ) &&
-                                   ( MaxSize_v<T1,1UL> == DefaultMaxSize_v )*/> >
+                                   ( (Size_v<T1,0UL> == DefaultSize_v && Size_v<T1,1UL> == DefaultSize_v
+                                      && Size_v<T2,1UL> == DefaultSize_v) ||
+                                        Size_v<T2,0UL> == DefaultSize_v ) &&
+                                   ( (MaxSize_v<T1,0UL> == DefaultMaxSize_v && MaxSize_v<T1,1UL> == DefaultMaxSize_v
+                                      && MaxSize_v<T1,2UL> == DefaultMaxSize_v) ||
+                                       MaxSize_v<T2,0UL> == DefaultMaxSize_v )> >
 {
    using ET1 = ElementType_t<T1>;
    using ET2 = ElementType_t<T2>;
 
-   using Type = DynamicMatrix< MultTrait_t<ET1,ET2>, true >;
+   using Type = DynamicMatrix< MultTrait_t<ET1,ET2>, false >;
 };
+
+//template< typename ET1, typename ET2 >
+//struct MultTraitEval2<DynamicTensor<ET1>, DynamicVector<ET2, true> >
+//{
+//      using Type = DynamicMatrix< MultTrait_t<ET1,ET2>, true >;
+//};
 
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/dense/HybridMatrix.h
+++ b/blaze_tensor/math/dense/HybridMatrix.h
@@ -102,28 +102,28 @@ struct DilatedSubmatrixTraitEval2< MT, inf, inf, inf, inf, inf, inf
 //
 //=================================================================================================
 
-////*************************************************************************************************
-///*! \cond BLAZE_INTERNAL */
-//template< typename T1, typename T2 >
-//struct MultTraitEval2< T1, T2
-//                     , EnableIf_t< IsTensor_v<T1> &&
-//                                   IsColumnVector_v<T2> &&
-//                                   ( Size_v<T1,0UL> == DefaultSize_v ||
-//                                     Size_v<T2,0UL> == DefaultSize_v ) &&
-//                                   ( MaxSize_v<T1,0UL> != DefaultMaxSize_v ||
-//                                     MaxSize_v<T2,0UL> != DefaultMaxSize_v ) > >
-//{
-//   using ET1 = ElementType_t<T1>;
-//   using ET2 = ElementType_t<T2>;
-//
-//   static constexpr size_t M = ( MaxSize_v<T1,0UL> != DefaultMaxSize_v ? MaxSize_v<T1,0UL> : MaxSize_v<T2,0UL> );
-//   static constexpr size_t N = ( MaxSize_v<T1,1UL> != DefaultMaxSize_v ? MaxSize_v<T1,1UL> : MaxSize_v<T2,0UL> );
-//
-//   using Type = HybridMatrix< MultTrait_t<ET1,ET2>, M, N, false >;
-//};
-//
-///*! \endcond */
-////*************************************************************************************************
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+template< typename T1, typename T2 >
+struct MultTraitEval2< T1, T2
+                     , EnableIf_t< IsTensor_v<T1> &&
+                                   IsColumnVector_v<T2> &&
+                                   ( Size_v<T1,0UL> == DefaultSize_v ||
+                                     Size_v<T2,0UL> == DefaultSize_v ) &&
+                                   ( MaxSize_v<T1,0UL> != DefaultMaxSize_v &&
+                                     MaxSize_v<T2,0UL> != DefaultMaxSize_v ) > >
+{
+   using ET1 = ElementType_t<T1>;
+   using ET2 = ElementType_t<T2>;
+
+   static constexpr size_t M = ( MaxSize_v<T1,0UL> != DefaultMaxSize_v ? MaxSize_v<T1,0UL> : MaxSize_v<T2,0UL> );
+   static constexpr size_t N = ( MaxSize_v<T1,1UL> != DefaultMaxSize_v ? MaxSize_v<T1,1UL> : MaxSize_v<T2,0UL> );
+
+   using Type = HybridMatrix< MultTrait_t<ET1,ET2>, M, N, false >;
+};
+
+/*! \endcond */
+//*************************************************************************************************
 
 } // namespace blaze
 

--- a/blaze_tensor/math/dense/HybridMatrix.h
+++ b/blaze_tensor/math/dense/HybridMatrix.h
@@ -93,6 +93,38 @@ struct DilatedSubmatrixTraitEval2< MT, inf, inf, inf, inf, inf, inf
 /*! \endcond */
 //*************************************************************************************************
 
+
+
+
+//=================================================================================================
+//
+//  MULTTRAIT SPECIALIZATIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+template< typename T1, typename T2 >
+struct MultTraitEval2< T1, T2
+                     , EnableIf_t< IsTensor_v<T1> &&
+                                   IsColumnVector_v<T2> &&
+                                   ( Size_v<T1,0UL> == DefaultSize_v &&
+                                     Size_v<T2,0UL> == DefaultSize_v ) &&
+                                   ( MaxSize_v<T1,0UL> != DefaultMaxSize_v &&
+                                     MaxSize_v<T2,0UL> != DefaultMaxSize_v ) > >
+{
+   using ET1 = ElementType_t<T1>;
+   using ET2 = ElementType_t<T2>;
+
+   static constexpr size_t M = ( MaxSize_v<T1,0UL> != DefaultMaxSize_v ? MaxSize_v<T1,0UL> : MaxSize_v<T2,0UL> );
+   static constexpr size_t N = ( MaxSize_v<T1,1UL> != DefaultMaxSize_v ? MaxSize_v<T1,1UL> : MaxSize_v<T2,0UL> );
+
+   using Type = HybridMatrix< MultTrait_t<ET1,ET2>, M, N, true >;
+};
+
+/*! \endcond */
+//*************************************************************************************************
+
 } // namespace blaze
 
 #endif

--- a/blaze_tensor/math/dense/HybridMatrix.h
+++ b/blaze_tensor/math/dense/HybridMatrix.h
@@ -102,28 +102,28 @@ struct DilatedSubmatrixTraitEval2< MT, inf, inf, inf, inf, inf, inf
 //
 //=================================================================================================
 
-//*************************************************************************************************
-/*! \cond BLAZE_INTERNAL */
-template< typename T1, typename T2 >
-struct MultTraitEval2< T1, T2
-                     , EnableIf_t< IsTensor_v<T1> &&
-                                   IsColumnVector_v<T2> &&
-                                   ( Size_v<T1,0UL> == DefaultSize_v &&
-                                     Size_v<T2,0UL> == DefaultSize_v ) &&
-                                   ( MaxSize_v<T1,0UL> != DefaultMaxSize_v &&
-                                     MaxSize_v<T2,0UL> != DefaultMaxSize_v ) > >
-{
-   using ET1 = ElementType_t<T1>;
-   using ET2 = ElementType_t<T2>;
-
-   static constexpr size_t M = ( MaxSize_v<T1,0UL> != DefaultMaxSize_v ? MaxSize_v<T1,0UL> : MaxSize_v<T2,0UL> );
-   static constexpr size_t N = ( MaxSize_v<T1,1UL> != DefaultMaxSize_v ? MaxSize_v<T1,1UL> : MaxSize_v<T2,0UL> );
-
-   using Type = HybridMatrix< MultTrait_t<ET1,ET2>, M, N, true >;
-};
-
-/*! \endcond */
-//*************************************************************************************************
+////*************************************************************************************************
+///*! \cond BLAZE_INTERNAL */
+//template< typename T1, typename T2 >
+//struct MultTraitEval2< T1, T2
+//                     , EnableIf_t< IsTensor_v<T1> &&
+//                                   IsColumnVector_v<T2> &&
+//                                   ( Size_v<T1,0UL> == DefaultSize_v ||
+//                                     Size_v<T2,0UL> == DefaultSize_v ) &&
+//                                   ( MaxSize_v<T1,0UL> != DefaultMaxSize_v ||
+//                                     MaxSize_v<T2,0UL> != DefaultMaxSize_v ) > >
+//{
+//   using ET1 = ElementType_t<T1>;
+//   using ET2 = ElementType_t<T2>;
+//
+//   static constexpr size_t M = ( MaxSize_v<T1,0UL> != DefaultMaxSize_v ? MaxSize_v<T1,0UL> : MaxSize_v<T2,0UL> );
+//   static constexpr size_t N = ( MaxSize_v<T1,1UL> != DefaultMaxSize_v ? MaxSize_v<T1,1UL> : MaxSize_v<T2,0UL> );
+//
+//   using Type = HybridMatrix< MultTrait_t<ET1,ET2>, M, N, false >;
+//};
+//
+///*! \endcond */
+////*************************************************************************************************
 
 } // namespace blaze
 

--- a/blaze_tensor/math/dense/StaticMatrix.h
+++ b/blaze_tensor/math/dense/StaticMatrix.h
@@ -124,6 +124,35 @@ struct DilatedSubmatrixTraitEval2< MT, I, J, M, N, RowDilation, ColumnDilation
 //*************************************************************************************************
 
 
+
+
+//=================================================================================================
+//
+//  MULTTRAIT SPECIALIZATIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+template< typename T1, typename T2 >
+struct MultTraitEval2< T1, T2
+                     , EnableIf_t< IsTensor_v<T1> &&
+                                   IsColumnVector_v<T2> &&
+                                   ( Size_v<T1,0UL> != DefaultSize_v ||
+                                   ( Size_v<T2,0UL> != DefaultSize_v ) ) > >
+{
+   using ET1 = ElementType_t<T1>;
+   using ET2 = ElementType_t<T2>;
+
+   static constexpr size_t M = ( Size_v<T1,0UL> != DefaultSize_v ? Size_v<T1,0UL> : Size_v<T2,0UL> );
+   static constexpr size_t N = ( Size_v<T1,1UL> != DefaultSize_v ? Size_v<T1,1UL> : Size_v<T2,0UL> );
+
+   using Type = StaticMatrix< MultTrait_t<ET1,ET2>, M, N, true >;
+};
+
+/*! \endcond */
+//*************************************************************************************************
+
 } // namespace blaze
 
 #endif

--- a/blaze_tensor/math/dense/StaticMatrix.h
+++ b/blaze_tensor/math/dense/StaticMatrix.h
@@ -45,11 +45,15 @@
 #include <blaze/math/dense/StaticMatrix.h>
 #include <blaze/math/dense/StaticVector.h>
 #include <blaze/math/traits/ExpandTrait.h>
+#include <blaze/math/typetraits/IsColumnVector.h>
+#include <blaze/math/typetraits/IsDenseMatrix.h>
 
 #include <blaze_tensor/math/dense/Forward.h>
 #include <blaze_tensor/math/traits/DilatedSubmatrixTrait.h>
+#include <blaze_tensor/math/traits/MultTrait.h>
 #include <blaze_tensor/math/traits/RavelTrait.h>
-
+#include <blaze_tensor/math/typetraits/IsDenseTensor.h>
+#include <blaze_tensor/math/typetraits/IsTensor.h>
 
 namespace blaze {
 
@@ -138,7 +142,7 @@ template< typename T1, typename T2 >
 struct MultTraitEval2< T1, T2
                      , EnableIf_t< IsTensor_v<T1> &&
                                    IsColumnVector_v<T2> &&
-                                   ( Size_v<T1,0UL> != DefaultSize_v ||
+                                   ( Size_v<T1,0UL> != DefaultSize_v &&
                                    ( Size_v<T2,0UL> != DefaultSize_v ) ) > >
 {
    using ET1 = ElementType_t<T1>;
@@ -147,7 +151,7 @@ struct MultTraitEval2< T1, T2
    static constexpr size_t M = ( Size_v<T1,0UL> != DefaultSize_v ? Size_v<T1,0UL> : Size_v<T2,0UL> );
    static constexpr size_t N = ( Size_v<T1,1UL> != DefaultSize_v ? Size_v<T1,1UL> : Size_v<T2,0UL> );
 
-   using Type = StaticMatrix< MultTrait_t<ET1,ET2>, M, N, true >;
+   using Type = StaticMatrix< MultTrait_t<ET1,ET2>, M, N, false >;
 };
 
 /*! \endcond */

--- a/blaze_tensor/math/dense/UniformMatrix.h
+++ b/blaze_tensor/math/dense/UniformMatrix.h
@@ -45,10 +45,15 @@
 #include <blaze/math/dense/UniformMatrix.h>
 #include <blaze/math/dense/UniformVector.h>
 #include <blaze/math/traits/ExpandTrait.h>
+#include <blaze/math/typetraits/IsColumnVector.h>
+#include <blaze/math/typetraits/IsDenseMatrix.h>
 
 #include <blaze_tensor/math/dense/Forward.h>
 #include <blaze_tensor/math/traits/DilatedSubmatrixTrait.h>
+#include <blaze_tensor/math/traits/MultTrait.h>
 #include <blaze_tensor/math/traits/RavelTrait.h>
+#include <blaze_tensor/math/typetraits/IsDenseTensor.h>
+#include <blaze_tensor/math/typetraits/IsTensor.h>
 
 
 namespace blaze {
@@ -131,10 +136,7 @@ struct MultTraitEval2< T1, T2
    using ET1 = ElementType_t<T1>;
    using ET2 = ElementType_t<T2>;
 
-   static constexpr size_t M = ( Size_v<T1,0UL> != DefaultSize_v ? Size_v<T1,0UL> : Size_v<T2,0UL> );
-   static constexpr size_t N = ( Size_v<T1,1UL> != DefaultSize_v ? Size_v<T1,1UL> : Size_v<T2,0UL> );
-
-   using Type = UniformMatrix< MultTrait_t<ET1,ET2>, true >;
+   using Type = UniformMatrix< MultTrait_t<ET1,ET2>, false >;
 };
 
 /*! \endcond */

--- a/blaze_tensor/math/expressions/DTensDVecMultExpr.h
+++ b/blaze_tensor/math/expressions/DTensDVecMultExpr.h
@@ -1,0 +1,5419 @@
+//=================================================================================================
+/*!
+//  \file blaze_tensor/tensh/expressions/DTensDVecMultExpr.h
+//  \brief Header file for the dense tensor/dense vector multiplication expression
+//
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
+//
+//  This file is part of the Blaze library. You can redistribute it and/or modify it under
+//  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
+//  forms, with or without modification, are permitted provided that the following conditions
+//  are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list
+//     of conditions and the following disclaimer in the documentation and/or other tenserials
+//     provided with the distribution.
+//  3. Neither the names of the Blaze development group nor the names of its contributors
+//     may be used to endorse or promote products derived from this software without specific
+//     prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+//  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+*/
+//=================================================================================================
+
+#ifndef _BLAZE_TENSOR_MATH_EXPRESSIONS_DTENSDVECMULTEXPR_H_
+#define _BLAZE_TENSOR_MATH_EXPRESSIONS_DTENSDVECMULTEXPR_H_
+
+
+//*************************************************************************************************
+// Includes
+//*************************************************************************************************
+
+#include <blaze/math/blas/gemv.h>
+#include <blaze/math/blas/trmv.h>
+#include <blaze/math/Aliases.h>
+#include <blaze/math/constraints/ColumnVector.h>
+#include <blaze/math/constraints/DenseVector.h>
+//#include <blaze/math/constraints/MatMatMultExpr.h>
+#include <blaze/math/constraints/RequiresEvaluation.h>
+//#include <blaze/math/constraints/RowMajorTensor.h>
+#include <blaze/math/Exception.h>
+#include <blaze/math/expressions/Computation.h>
+#include <blaze/math/expressions/DenseVector.h>
+#include <blaze/math/expressions/Forward.h>
+//#include <blaze/math/expressions/MatMatMultExpr.h>
+#include <blaze/math/expressions/VecScalarMultExpr.h>
+#include <blaze/math/shims/Reset.h>
+#include <blaze/math/shims/Serial.h>
+#include <blaze/math/SIMD.h>
+#include <blaze/math/traits/MultTrait.h>
+#include <blaze/math/typetraits/HasConstDataAccess.h>
+#include <blaze/math/typetraits/HasMutableDataAccess.h>
+#include <blaze/math/typetraits/HasSIMDAdd.h>
+#include <blaze/math/typetraits/HasSIMDMult.h>
+#include <blaze/math/typetraits/IsAligned.h>
+#include <blaze/math/typetraits/IsBLASCompatible.h>
+#include <blaze/math/typetraits/IsComputation.h>
+#include <blaze/math/typetraits/IsContiguous.h>
+#include <blaze/math/typetraits/IsDiagonal.h>
+#include <blaze/math/typetraits/IsExpression.h>
+//#include <blaze/math/typetraits/IsLower.h>
+#include <blaze/math/typetraits/IsPadded.h>
+#include <blaze/math/typetraits/IsSIMDCombinable.h>
+//#include <blaze/math/typetraits/IsStrictlyLower.h>
+//#include <blaze/math/typetraits/IsStrictlyUpper.h>
+//#include <blaze/math/typetraits/IsTriangular.h>
+//#include <blaze/math/typetraits/IsUpper.h>
+#include <blaze/math/typetraits/RequiresEvaluation.h>
+#include <blaze/math/views/Check.h>
+#include <blaze/system/BLAS.h>
+#include <blaze/system/Optimizations.h>
+#include <blaze/system/Thresholds.h>
+#include <blaze/util/Assert.h>
+#include <blaze/util/Complex.h>
+#include <blaze/util/constraints/SameType.h>
+#include <blaze/util/DisableIf.h>
+#include <blaze/util/EnableIf.h>
+#include <blaze/util/FunctionTrace.h>
+#include <blaze/util/IntegralConstant.h>
+#include <blaze/util/mpl/If.h>
+#include <blaze/util/Types.h>
+#include <blaze/util/typetraits/IsBuiltin.h>
+#include <blaze/util/typetraits/IsComplex.h>
+#include <blaze/util/typetraits/IsComplexDouble.h>
+#include <blaze/util/typetraits/IsComplexFloat.h>
+#include <blaze/util/typetraits/IsDouble.h>
+#include <blaze/util/typetraits/IsFloat.h>
+#include <blaze/util/typetraits/IsSame.h>
+
+#include <blaze_tensor/config/BLAS.h>
+#include <blaze_tensor/math/constraints/DenseTensor.h>
+#include <blaze_tensor/math/constraints/TensVecMultExpr.h>
+#include <blaze_tensor/math/expressions/DTensDVecMultExpr.h>
+#include <blaze_tensor/math/expressions/TensVecMultExpr.h>
+#include <blaze_tensor/system/Thresholds.h>
+
+namespace blaze {
+
+//=================================================================================================
+//
+//  CLASS DTENSDVECMULTEXPR
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Expression object for dense tensor-dense vector multiplications.
+// \ingroup dense_vector_expression
+//
+// The DTensDVecMultExpr class represents the compile time expression for multiplications
+// between row-major dense tensors and dense vectors.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+class DTensDVecMultExpr
+   : public TensVecMultExpr< DenseVector< DTensDVecMultExpr<TT,VT>, false > >
+   , private Computation
+{
+ private:
+   //**Type definitions****************************************************************************
+   using TRT = ResultType_t<TT>;     //!< Result type of the left-hand side dense tensor expression.
+   using VRT = ResultType_t<VT>;     //!< Result type of the right-hand side dense vector expression.
+   using TET = ElementType_t<TRT>;   //!< Element type of the left-hand side dense tensor expression.
+   using VET = ElementType_t<VRT>;   //!< Element type of the right-hand side dense vector expression.
+   using TCT = CompositeType_t<TT>;  //!< Composite type of the left-hand side dense tensor expression.
+   using VCT = CompositeType_t<VT>;  //!< Composite type of the right-hand side dense vector expression.
+   //**********************************************************************************************
+
+   //**********************************************************************************************
+   //! Compilation switch for the composite type of the left-hand side dense tensor expression.
+   static constexpr bool evaluateTensor =
+      ( ( IsComputation_v<TT> && IsSame_v<TET,VET> &&
+          IsBLASCompatible_v<TET> ) || RequiresEvaluation_v<TT> );
+   //**********************************************************************************************
+
+   //**********************************************************************************************
+   //! Compilation switch for the composite type of the right-hand side dense vector expression.
+   static constexpr bool evaluateVector = ( IsComputation_v<VT> || RequiresEvaluation_v<VT> );
+   //**********************************************************************************************
+
+   //**********************************************************************************************
+   /*! \cond BLAZE_INTERNAL */
+   //! Helper variable template for the explicit application of the SFINAE principle.
+   /*! This variable template is a helper for the selection of the parallel evaluation strategy.
+       In case either the tensor or the vector operand requires an intermediate evaluation, the
+       variable will be set to 1, otherwise it will be 0. */
+   template< typename T1 >
+   static constexpr bool UseSMPAssign_v = ( evaluateTensor || evaluateVector );
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**********************************************************************************************
+   /*! \cond BLAZE_INTERNAL */
+   //! Helper variable template for the explicit application of the SFINAE principle.
+   /*! In case the tensor type and the two involved vector types are suited for a BLAS kernel,
+       the variable will be set to 1, otherwise it will be 0. */
+   template< typename T1, typename T2, typename T3 >
+   static constexpr bool UseBlasKernel_v =
+      ( BLAZE_BLAS_MODE && BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION &&
+        IsContiguous_v<T1> && HasMutableDataAccess_v<T1> &&
+        IsContiguous_v<T2> && HasConstDataAccess_v<T2> &&
+        IsContiguous_v<T3> && HasConstDataAccess_v<T3> &&
+        !IsDiagonal_v<T2> &&
+        T1::simdEnabled && T2::simdEnabled && T3::simdEnabled &&
+        IsBLASCompatible_v< ElementType_t<T1> > &&
+        IsBLASCompatible_v< ElementType_t<T2> > &&
+        IsBLASCompatible_v< ElementType_t<T3> > &&
+        IsSame_v< ElementType_t<T1>, ElementType_t<T2> > &&
+        IsSame_v< ElementType_t<T1>, ElementType_t<T3> > );
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**********************************************************************************************
+   /*! \cond BLAZE_INTERNAL */
+   //! Helper variable template for the explicit application of the SFINAE principle.
+   /*! In case the tensor type and the two involved vector types are suited for a vectorized
+       computation of the tensor/vector multiplication, the variable will be set to 1, otherwise
+       it will be 0. */
+   template< typename T1, typename T2, typename T3 >
+   static constexpr bool UseVectorizedDefaultKernel_v =
+      ( useOptimizedKernels &&
+        !IsDiagonal_v<T2> &&
+        T1::simdEnabled && T2::simdEnabled && T3::simdEnabled &&
+        IsSIMDCombinable_v< ElementType_t<T1>
+                          , ElementType_t<T2>
+                          , ElementType_t<T3> > &&
+        HasSIMDAdd_v< ElementType_t<T2>, ElementType_t<T3> > &&
+        HasSIMDMult_v< ElementType_t<T2>, ElementType_t<T3> > );
+   /*! \endcond */
+   //**********************************************************************************************
+
+ public:
+   //**Type definitions****************************************************************************
+   using This          = DTensDVecMultExpr<TT,VT>;      //!< Type of this DTensDVecMultExpr instance.
+   using BaseType      = DenseVector<This,false>;      //!< Base type of this DTensDVecMultExpr instance.
+   using ResultType    = MultTrait_t<TRT,VRT>;         //!< Result type for expression template evaluations.
+   using TransposeType = TransposeType_t<ResultType>;  //!< Transpose type for expression template evaluations.
+   using ElementType   = ElementType_t<ResultType>;    //!< Resulting element type.
+   using SIMDType      = SIMDTrait_t<ElementType>;     //!< Resulting SIMD element type.
+   using ReturnType    = const ElementType;            //!< Return type for expression template evaluations.
+   using CompositeType = const ResultType;             //!< Data type for composite expression templates.
+
+   //! Composite type of the left-hand side dense tensor expression.
+   using LeftOperand = If_t< IsExpression_v<TT>, const TT, const TT& >;
+
+   //! Composite type of the right-hand side dense vector expression.
+   using RightOperand = If_t< IsExpression_v<VT>, const VT, const VT& >;
+
+   //! Type for the assignment of the left-hand side dense tensor operand.
+   using LT = If_t< evaluateTensor, const TRT, TCT >;
+
+   //! Type for the assignment of the right-hand side dense vector operand.
+   using RT = If_t< evaluateVector, const VRT, VCT >;
+   //**********************************************************************************************
+
+   //**Compilation flags***************************************************************************
+   //! Compilation switch for the expression template evaluation strategy.
+   static constexpr bool simdEnabled =
+      ( !IsDiagonal_v<TT> &&
+        TT::simdEnabled && VT::simdEnabled &&
+        HasSIMDAdd_v<TET,VET> &&
+        HasSIMDMult_v<TET,VET> );
+
+   //! Compilation switch for the expression template assignment strategy.
+   static constexpr bool smpAssignable =
+      ( !evaluateTensor && TT::smpAssignable && !evaluateVector && VT::smpAssignable );
+   //**********************************************************************************************
+
+   //**SIMD properties*****************************************************************************
+   //! The number of elements packed within a single SIMD element.
+   static constexpr size_t SIMDSIZE = SIMDTrait<ElementType>::size;
+   //**********************************************************************************************
+
+   //**Constructor*********************************************************************************
+   /*!\brief Constructor for the DTensDVecMultExpr class.
+   //
+   // \param tens The left-hand side tensor operand of the multiplication expression.
+   // \param vec The right-hand side vector operand of the multiplication expression.
+   */
+   explicit inline DTensDVecMultExpr( const TT& tens, const VT& vec ) noexcept
+      : tens_( tens )  // Left-hand side dense tensor of the multiplication expression
+      , vec_( vec )  // Right-hand side dense vector of the multiplication expression
+   {
+      BLAZE_INTERNAL_ASSERT( tens_.columns() == vec_.size(), "Incompatible tensor and vector sizes" );
+   }
+   //**********************************************************************************************
+
+   //**Subscript operator**************************************************************************
+   /*!\brief Subscript operator for the direct access to the vector elements.
+   //
+   // \param index Access index. The index has to be in the range \f$[0..N-1]\f$.
+   // \return The resulting value.
+   */
+   inline ReturnType operator()( size_t i, size_t j ) const {
+      BLAZE_INTERNAL_ASSERT( i < tens_.pages(), "Invalid row access index" );
+      BLAZE_INTERNAL_ASSERT( j < tens_.rows() , "Invalid column access index" );
+
+      return pageslice( tens_, index, unchecked ) * vec_;
+   }
+   //**********************************************************************************************
+
+   //**At function*********************************************************************************
+   /*!\brief Checked access to the vector elements.
+   //
+   // \param index Access index. The index has to be in the range \f$[0..N-1]\f$.
+   // \return The resulting value.
+   // \exception std::out_of_range Invalid vector access index.
+   */
+   inline ReturnType at( size_t i, size_t j ) const {
+      if( j >= tens_.pages() ) {
+         BLAZE_THROW_OUT_OF_RANGE( "Invalid row access index" );
+      }
+      if( j >= tens_.rows() ) {
+         BLAZE_THROW_OUT_OF_RANGE( "Invalid column access index" );
+      }
+      return (*this)(i,j);
+   }
+   //**********************************************************************************************
+
+   //**Rows function*******************************************************************************
+   /*!\brief Returns the current size/dimension of the vector.
+   //
+   // \return The size of the vector.
+   */
+   inline size_t rows() const noexcept {
+      return tens_.pages();
+   }
+   //**********************************************************************************************
+
+   //**Columns function*******************************************************************************
+   /*!\brief Returns the current size/dimension of the vector.
+   //
+   // \return The size of the vector.
+   */
+   inline size_t columns() const noexcept {
+      return tens_.rows();
+   }
+   //**********************************************************************************************
+
+   //**Left operand access*************************************************************************
+   /*!\brief Returns the left-hand side dense tensor operand.
+   //
+   // \return The left-hand side dense tensor operand.
+   */
+   inline LeftOperand leftOperand() const  noexcept{
+      return tens_;
+   }
+   //**********************************************************************************************
+
+   //**Right operand access************************************************************************
+   /*!\brief Returns the right-hand side dense vector operand.
+   //
+   // \return The right-hand side dense vector operand.
+   */
+   inline RightOperand rightOperand() const noexcept {
+      return vec_;
+   }
+   //**********************************************************************************************
+
+   //**********************************************************************************************
+   /*!\brief Returns whether the expression can alias with the given address \a alias.
+   //
+   // \param alias The alias to be checked.
+   // \return \a true in case an aliasing effect is possible, \a false if not.
+   */
+   template< typename T >
+   inline bool canAlias( const T* alias ) const noexcept {
+      return ( tens_.isAliased( alias ) || vec_.isAliased( alias ) );
+   }
+   //**********************************************************************************************
+
+   //**********************************************************************************************
+   /*!\brief Returns whether the expression is aliased with the given address \a alias.
+   //
+   // \param alias The alias to be checked.
+   // \return \a true in case the given alias is contained in this expression, \a false if not.
+   */
+   template< typename T >
+   inline bool isAliased( const T* alias ) const noexcept {
+      return ( tens_.isAliased( alias ) || vec_.isAliased( alias ) );
+   }
+   //**********************************************************************************************
+
+   //**********************************************************************************************
+   /*!\brief Returns whether the operands of the expression are properly aligned in memory.
+   //
+   // \return \a true in case the operands are aligned, \a false if not.
+   */
+   inline bool isAligned() const noexcept {
+      return tens_.isAligned() && vec_.isAligned();
+   }
+   //**********************************************************************************************
+
+   //**********************************************************************************************
+   /*!\brief Returns whether the expression can be used in SMP assignments.
+   //
+   // \return \a true in case the expression can be used in SMP assignments, \a false if not.
+   */
+   inline bool canSMPAssign() const noexcept {
+      return ( !BLAZE_BLAS_MODE ||
+               !BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION ||
+               !BLAZE_BLAS_IS_PARALLEL ||
+               ( IsComputation_v<TT> && !evaluateTensor ) ||
+               ( tens_.pages() * tens_.rows() * tens_.columns() < DTENSDVECMULT_THRESHOLD ) ) &&
+               ( rows() * columns() > SMP_DTENSDVECMULT_THRESHOLD );
+   }
+   //**********************************************************************************************
+
+ private:
+   //**Member variables****************************************************************************
+   LeftOperand  tens_;  //!< Left-hand side dense tensor of the multiplication expression.
+   RightOperand vec_;  //!< Right-hand side dense vector of the multiplication expression.
+   //**********************************************************************************************
+
+   //**Assignment to dense vectors*****************************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Assignment of a dense tensor-dense vector multiplication to a dense row-major matrix
+   //        (\f$ \vec{y}=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression to be assigned.
+   // \return void
+   //
+   // This function implements the performance optimized assignment of a dense tensor-dense
+   // vector multiplication expression to a dense vector.
+   */
+   template< typename MT1 >  // Type of the target dense vector
+   friend inline void assign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+
+      if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL ) {
+         return;
+      }
+      else if( rhs.tens_.columns() == 0UL ) {
+         reset( ~lhs );
+         return;
+      }
+
+      LT A( serial( rhs.tens_ ) );  // Evaluation of the left-hand side dense tensor operand
+      RT x( serial( rhs.vec_ ) );  // Evaluation of the right-hand side dense vector operand
+
+      BLAZE_INTERNAL_ASSERT( A.pages()   == rhs.tens_.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+
+      DTensDVecMultExpr::selectAssignKernel( ~lhs, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Assignment to dense vectors (kernel selection)**********************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Selection of the kernel for an assignment of a dense tensor-dense vector multiplication
+   //        to a dense matrix (\f$ \vec{y}=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline void selectAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   {
+      if( A.pages() * A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD )
+         selectSmallAssignKernel( y, A, x );
+      else
+         selectBlasAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Default assignment to dense vectors*********************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default assignment of a dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense matrix.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function implements the default assignment kernel for the dense tensor-dense vector
+   // multiplication.
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline void selectDefaultAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   {
+      y.assign( A * x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Default assignment to dense vectors (small tensors)****************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default assignment of a small dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense matrix.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function relays to the default implementation of the assignment of a dense tensor-
+   // dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectSmallAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> DisableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   {
+      selectDefaultAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   ////**Vectorized default assignment to dense vectors (small tensors)*****************************
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief Vectorized default assignment of a small dense tensor-dense vector multiplication
+   ////        (\f$ \vec{y}=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param y The target left-hand side dense matrix.
+   //// \param A The left-hand side dense tensor operand.
+   //// \param x The right-hand side dense vector operand.
+   //// \return void
+   ////
+   //// This function implements the vectorized default assignment kernel for the dense tensor-
+   //// dense vector multiplication. This kernel is optimized for small tensors.
+   //*/
+   //template< typename MT1    // Type of the left-hand side target vector
+   //        , typename TT1    // Type of the left-hand side tensor operand
+   //        , typename VT1 >  // Type of the right-hand side vector operand
+   //static inline auto selectSmallAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   //{
+   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+
+   //   const size_t M( A.rows()    );
+   //   const size_t N( A.columns() );
+
+   //   size_t i( 0UL );
+
+   //   for( ; (i+8UL) <= M; i+=8UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //         xmm3 += A.load(i+2UL,j) * x1;
+   //         xmm4 += A.load(i+3UL,j) * x1;
+   //         xmm5 += A.load(i+4UL,j) * x1;
+   //         xmm6 += A.load(i+5UL,j) * x1;
+   //         xmm7 += A.load(i+6UL,j) * x1;
+   //         xmm8 += A.load(i+7UL,j) * x1;
+   //      }
+
+   //      y[i    ] = sum( xmm1 );
+   //      y[i+1UL] = sum( xmm2 );
+   //      y[i+2UL] = sum( xmm3 );
+   //      y[i+3UL] = sum( xmm4 );
+   //      y[i+4UL] = sum( xmm5 );
+   //      y[i+5UL] = sum( xmm6 );
+   //      y[i+6UL] = sum( xmm7 );
+   //      y[i+7UL] = sum( xmm8 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //         y[i+3UL] += A(i+3UL,j) * x[j];
+   //         y[i+4UL] += A(i+4UL,j) * x[j];
+   //         y[i+5UL] += A(i+5UL,j) * x[j];
+   //         y[i+6UL] += A(i+6UL,j) * x[j];
+   //         y[i+7UL] += A(i+7UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+4UL) <= M; i+=4UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2, xmm3, xmm4;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //         xmm3 += A.load(i+2UL,j) * x1;
+   //         xmm4 += A.load(i+3UL,j) * x1;
+   //      }
+
+   //      y[i    ] = sum( xmm1 );
+   //      y[i+1UL] = sum( xmm2 );
+   //      y[i+2UL] = sum( xmm3 );
+   //      y[i+3UL] = sum( xmm4 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //         y[i+3UL] += A(i+3UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+3UL) <= M; i+=3UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2, xmm3;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //         xmm3 += A.load(i+2UL,j) * x1;
+   //      }
+
+   //      y[i    ] = sum( xmm1 );
+   //      y[i+1UL] = sum( xmm2 );
+   //      y[i+2UL] = sum( xmm3 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+2UL) <= M; i+=2UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //      }
+
+   //      y[i    ] = sum( xmm1 );
+   //      y[i+1UL] = sum( xmm2 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //      }
+   //   }
+
+   //   if( i < M )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         xmm1 += A.load(i,j) * x.load(j);
+   //      }
+
+   //      y[i] = sum( xmm1 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i] += A(i,j) * x[j];
+   //      }
+   //   }
+   //}
+   ///*! \endcond */
+   ////**********************************************************************************************
+
+   //**Default assignment to dense vectors (large tensors)****************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default assignment of a large dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function relays to the default implementation of the assignment of a dense tensor-
+   // dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectLargeAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> DisableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   {
+      selectDefaultAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   ////**Vectorized default assignment to dense vectors (large tensors)*****************************
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief Vectorized default assignment of a large dense tensor-dense vector multiplication
+   ////        (\f$ \vec{y}=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param y The target left-hand side dense vector.
+   //// \param A The left-hand side dense tensor operand.
+   //// \param x The right-hand side dense vector operand.
+   //// \return void
+   ////
+   //// This function implements the vectorized default assignment kernel for the dense tensor-
+   //// dense vector multiplication. This kernel is optimized for large tensors.
+   //*/
+   //template< typename MT1    // Type of the left-hand side target matrix
+   //        , typename TT1    // Type of the left-hand side tensor operand
+   //        , typename VT1 >  // Type of the right-hand side vector operand
+   //static inline auto selectLargeAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   //{
+   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+
+   //   const size_t M( A.rows()    );
+   //   const size_t N( A.columns() );
+
+   //   reset( y );
+
+   //   size_t i( 0UL );
+
+   //   for( ; (i+8UL) <= M; i+=8UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
+   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 );
+   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 );
+   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 );
+   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
+   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 );
+   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 );
+   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 );
+   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
+   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 );
+   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 );
+   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 );
+   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //         y[i+3UL] += A(i+3UL,j) * x[j];
+   //         y[i+4UL] += A(i+4UL,j) * x[j];
+   //         y[i+5UL] += A(i+5UL,j) * x[j];
+   //         y[i+6UL] += A(i+6UL,j) * x[j];
+   //         y[i+7UL] += A(i+7UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+4UL) <= M; i+=4UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //         y[i+3UL] += A(i+3UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+2UL) <= M; i+=2UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //      }
+   //   }
+
+   //   if( i < M )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i] += sum( A.load(i,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i] += A(i,j) * x[j];
+   //      }
+   //   }
+   //}
+   ///*! \endcond */
+   ////**********************************************************************************************
+
+   //**BLAS-based assignment to dense vectors (default)********************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default assignment of a dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense matrix.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function relays to the default implementation of the assignment of a large dense
+   // tensor-dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectBlasAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> DisableIf_t< UseBlasKernel_v<MT1,TT1,VT1> >
+   {
+      selectLargeAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**BLAS-based assignment to dense vectors******************************************************
+#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_MATRIX_VECTOR_MULTIPLICATION
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief BLAS-based assignment of a dense tensor-dense vector multiplication
+   ////        (\f$ \vec{y}=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param y The target left-hand side dense vector.
+   //// \param A The left-hand side dense tensor operand.
+   //// \param x The right-hand side dense vector operand.
+   //// \return void
+   ////
+   //// This function performs the dense tensor-dense vector multiplication based on the according
+   //// BLAS functionality.
+   //*/
+   //template< typename MT1    // Type of the left-hand side target vector
+   //        , typename TT1    // Type of the left-hand side tensor operand
+   //        , typename VT1 >  // Type of the right-hand side vector operand
+   //static inline auto selectBlasAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   //   -> EnableIf_t< UseBlasKernel_v<MT1,TT1,VT1> >
+   //{
+   //   using ET = ElementType_t<MT1>;
+
+   //   if( IsTriangular_v<TT1> ) {
+   //      assign( y, x );
+   //      trmv( y, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
+   //   }
+   //   else {
+   //      gemv( y, A, x, ET(1), ET(0) );
+   //   }
+   //}
+   ///*! \endcond */
+#endif
+   //**********************************************************************************************
+
+   ////**Assignment to sparse matrices***************************************************************
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief Assignment of a dense tensor-dense vector multiplication to a sparse vector
+   ////        (\f$ \vec{y}=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param lhs The target left-hand side sparse vector.
+   //// \param rhs The right-hand side multiplication expression to be assigned.
+   //// \return void
+   ////
+   //// This function implements the performance optimized assignment of a dense tensor-dense
+   //// vector multiplication expression to a sparse vector.
+   //*/
+   //template< typename VT1 >  // Type of the target sparse vector
+   //friend inline void assign( SparseVector<VT1,false>& lhs, const DTensDVecMultExpr& rhs )
+   //{
+   //   BLAZE_FUNCTION_TRACE;
+
+   //   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE( ResultType );
+   //   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( ResultType );
+   //   BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+
+   //   BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+
+   //   const ResultType tmp( serial( rhs ) );
+   //   assign( ~lhs, tmp );
+   //}
+   ///*! \endcond */
+   ////**********************************************************************************************
+
+   //**Addition assignment to dense matrices*********************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Addition assignment of a dense tensor-dense vector multiplication to a dense vector
+   //        (\f$ \vec{y}+=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression to be added.
+   // \return void
+   //
+   // This function implements the performance optimized addition assignment of a dense tensor-
+   // dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1 >  // Type of the target dense matrix
+   friend inline void addAssign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_INTERNAL_ASSERT(((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+
+      if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL || rhs.tens_.columns() == 0UL ) {
+         return;
+      }
+
+      LT A( serial( rhs.tens_ ) );  // Evaluation of the left-hand side dense tensor operand
+      RT x( serial( rhs.vec_ ) );  // Evaluation of the right-hand side dense vector operand
+
+      BLAZE_INTERNAL_ASSERT( A.pages()   == rhs.tens_.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+
+      DTensDVecMultExpr::selectAddAssignKernel( ~lhs, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Addition assignment to dense vectors (kernel selection)*************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Selection of the kernel for an addition assignment of a dense tensor-dense vector
+   //        multiplication to a dense vector (\f$ \vec{y}+=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline void selectAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   {
+      if ( A.pages() * A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD )
+         selectSmallAddAssignKernel( y, A, x );
+      else
+         selectBlasAddAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Default addition assignment to dense matrices***********************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default addition assignment of a dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}+=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function implements the default addition assignment kernel for the dense tensor-dense
+   // vector multiplication.
+   */
+   template< typename MT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline void selectDefaultAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   {
+      y.addAssign( A * x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Default addition assignment to dense vectors (small tensors)*******************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default addition assignment of a small dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}+=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function relays to the default implementation of the addition assignment of a
+   // dense tensor-dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectSmallAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> DisableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   {
+      selectDefaultAddAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   ////**Vectorized default addition assignment to dense vectors (small tensors)********************
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief Vectorized default addition assignment of a small dense tensor-dense vector
+   ////        multiplication (\f$ \vec{y}+=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param y The target left-hand side dense vector.
+   //// \param A The left-hand side dense tensor operand.
+   //// \param x The right-hand side dense vector operand.
+   //// \return void
+   ////
+   //// This function implements the vectorized default addition assignment kernel for the dense
+   //// tensor-dense vector multiplication. This kernel is optimized for small tensors.
+   //*/
+   //template< typename MT1    // Type of the left-hand side target vector
+   //        , typename TT1    // Type of the left-hand side tensor operand
+   //        , typename VT1 >  // Type of the right-hand side vector operand
+   //static inline auto selectSmallAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   //{
+   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+
+   //   const size_t M( A.rows()    );
+   //   const size_t N( A.columns() );
+
+   //   size_t i( 0UL );
+
+   //   for( ; (i+8UL) <= M; i+=8UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //         xmm3 += A.load(i+2UL,j) * x1;
+   //         xmm4 += A.load(i+3UL,j) * x1;
+   //         xmm5 += A.load(i+4UL,j) * x1;
+   //         xmm6 += A.load(i+5UL,j) * x1;
+   //         xmm7 += A.load(i+6UL,j) * x1;
+   //         xmm8 += A.load(i+7UL,j) * x1;
+   //      }
+
+   //      y[i    ] += sum( xmm1 );
+   //      y[i+1UL] += sum( xmm2 );
+   //      y[i+2UL] += sum( xmm3 );
+   //      y[i+3UL] += sum( xmm4 );
+   //      y[i+4UL] += sum( xmm5 );
+   //      y[i+5UL] += sum( xmm6 );
+   //      y[i+6UL] += sum( xmm7 );
+   //      y[i+7UL] += sum( xmm8 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //         y[i+3UL] += A(i+3UL,j) * x[j];
+   //         y[i+4UL] += A(i+4UL,j) * x[j];
+   //         y[i+5UL] += A(i+5UL,j) * x[j];
+   //         y[i+6UL] += A(i+6UL,j) * x[j];
+   //         y[i+7UL] += A(i+7UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+4UL) <= M; i+=4UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2, xmm3, xmm4;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //         xmm3 += A.load(i+2UL,j) * x1;
+   //         xmm4 += A.load(i+3UL,j) * x1;
+   //      }
+
+   //      y[i    ] += sum( xmm1 );
+   //      y[i+1UL] += sum( xmm2 );
+   //      y[i+2UL] += sum( xmm3 );
+   //      y[i+3UL] += sum( xmm4 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //         y[i+3UL] += A(i+3UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+3UL) <= M; i+=3UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2, xmm3;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //         xmm3 += A.load(i+2UL,j) * x1;
+   //      }
+
+   //      y[i    ] += sum( xmm1 );
+   //      y[i+1UL] += sum( xmm2 );
+   //      y[i+2UL] += sum( xmm3 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+2UL) <= M; i+=2UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //      }
+
+   //      y[i    ] += sum( xmm1 );
+   //      y[i+1UL] += sum( xmm2 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //      }
+   //   }
+
+   //   if( i < M )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         xmm1 += A.load(i,j) * x.load(j);
+   //      }
+
+   //      y[i] += sum( xmm1 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i] += A(i,j) * x[j];
+   //      }
+   //   }
+   //}
+   ///*! \endcond */
+   ////**********************************************************************************************
+
+   //**Default addition assignment to dense vectors (large tensors)*******************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default addition assignment of a large dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}+=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function relays to the default implementation of the addition assignment of a
+   // dense tensor-dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectLargeAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> DisableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   {
+      selectDefaultAddAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   ////**Vectorized default addition assignment to dense vectors (large tensors)********************
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief Vectorized default addition assignment of a large dense tensor-dense vector
+   ////        multiplication (\f$ \vec{y}+=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param y The target left-hand side dense vector.
+   //// \param A The left-hand side dense tensor operand.
+   //// \param x The right-hand side dense vector operand.
+   //// \return void
+   ////
+   //// This function implements the vectorized default addition assignment kernel for the dense
+   //// tensor-dense vector multiplication. This kernel is optimized for large tensors.
+   //*/
+   //template< typename MT1    // Type of the left-hand side target vector
+   //        , typename TT1    // Type of the left-hand side tensor operand
+   //        , typename VT1 >  // Type of the right-hand side vector operand
+   //static inline auto selectLargeAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   //{
+   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+
+   //   const size_t M( A.rows()    );
+   //   const size_t N( A.columns() );
+
+   //   size_t i( 0UL );
+
+   //   for( ; (i+8UL) <= M; i+=8UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
+   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 );
+   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 );
+   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 );
+   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
+   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 );
+   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 );
+   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 );
+   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
+   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 );
+   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 );
+   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 );
+   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //         y[i+3UL] += A(i+3UL,j) * x[j];
+   //         y[i+4UL] += A(i+4UL,j) * x[j];
+   //         y[i+5UL] += A(i+5UL,j) * x[j];
+   //         y[i+6UL] += A(i+6UL,j) * x[j];
+   //         y[i+7UL] += A(i+7UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+4UL) <= M; i+=4UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
+   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
+   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //         y[i+2UL] += A(i+2UL,j) * x[j];
+   //         y[i+3UL] += A(i+3UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+2UL) <= M; i+=2UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i    ] += sum( A.load(i    ,j) * x1 );
+   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] += A(i    ,j) * x[j];
+   //         y[i+1UL] += A(i+1UL,j) * x[j];
+   //      }
+   //   }
+
+   //   if( i < M )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i] += sum( A.load(i,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i] += A(i,j) * x[j];
+   //      }
+   //   }
+   //}
+   ///*! \endcond */
+   ////**********************************************************************************************
+
+   //**BLAS-based addition assignment to dense vectors (default)***********************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default addition assignment of a dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}+=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function relays to the default implementation of the addition assignment of a large
+   // dense tensor-dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectBlasAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> DisableIf_t< UseBlasKernel_v<MT1,TT1,VT1> >
+   {
+      selectLargeAddAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**BLAS-based addition assignment to dense vectors*********************************************
+#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_MATRIX_VECTOR_MULTIPLICATION
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief BLAS-based addition assignment of a tensor-vector multiplication
+   ////        (\f$ \vec{y}+=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param y The target left-hand side dense vector.
+   //// \param A The left-hand side dense tensor operand.
+   //// \param x The right-hand side dense vector operand.
+   //// \return void
+   ////
+   //// This function performs the dense tensor-dense vector multiplication based on the according
+   //// BLAS functionality.
+   //*/
+   //template< typename MT1    // Type of the left-hand side target vector
+   //        , typename TT1    // Type of the left-hand side tensor operand
+   //        , typename VT1 >  // Type of the right-hand side vector operand
+   //static inline auto selectBlasAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   //   -> EnableIf_t< UseBlasKernel_v<MT1,TT1,VT1> >
+   //{
+   //   using ET = ElementType_t<MT1>;
+
+   //   if( IsTriangular_v<TT1> ) {
+   //      ResultType_t<MT1> tmp( serial( x ) );
+   //      trmv( tmp, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
+   //      addAssign( y, tmp );
+   //   }
+   //   else {
+   //      gemv( y, A, x, ET(1), ET(1) );
+   //   }
+   //}
+   ///*! \endcond */
+#endif
+   //**********************************************************************************************
+
+   //**Addition assignment to sparse matrices******************************************************
+   // No special implementation for the addition assignment to sparse vectors.
+   //**********************************************************************************************
+
+   //**Subtraction assignment to dense vectors*****************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Subtraction assignment of a dense tensor-dense vector multiplication to a dense matrix
+   //        (\f$ \vec{y}-=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression to be subtracted.
+   // \return void
+   //
+   // This function implements the performance optimized subtraction assignment of a dense tensor-
+   // dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1 >  // Type of the target dense matrix
+   friend inline void subAssign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_INTERNAL_ASSERT(((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+
+      if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL || rhs.tens_.columns() == 0UL ) {
+         return;
+      }
+
+      LT A( serial( rhs.tens_ ) );  // Evaluation of the left-hand side dense tensor operand
+      RT x( serial( rhs.vec_ ) );  // Evaluation of the right-hand side dense vector operand
+
+      BLAZE_INTERNAL_ASSERT( A.pages()   == rhs.tens_.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+
+      DTensDVecMultExpr::selectSubAssignKernel( ~lhs, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Subtraction assignment to dense vectors (kernel selection)**********************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Selection of the kernel for a subtraction assignment of a dense tensor-dense vector
+   //        multiplication to a dense vector (\f$ \vec{y}-=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   */
+   template< typename MT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline void selectSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   {
+      if( A.pages() * A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD )
+         selectSmallSubAssignKernel( y, A, x );
+      else
+         selectBlasSubAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Default subtraction assignment to dense matrices********************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default subtraction assignment of a dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}-=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function implements the default subtraction assignment kernel for the dense tensor-
+   // dense vector multiplication.
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline void selectDefaultSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   {
+      y.subAssign( A * x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Default subtraction assignment to dense vectors (small tensors)****************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default subtraction assignment of a small dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}-=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function relays to the default implementation of the subtraction assignment of a
+   // dense tensor-dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectSmallSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> DisableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   {
+      selectDefaultSubAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   ////**Vectorized default subtraction assignment to dense vectors (small tensors)*****************
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief Vectorized default subtraction assignment of a small dense tensor-dense vector
+   ////        multiplication (\f$ \vec{y}-=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param y The target left-hand side dense vector.
+   //// \param A The left-hand side dense tensor operand.
+   //// \param x The right-hand side dense vector operand.
+   //// \return void
+   ////
+   //// This function implements the vectorized default subtraction assignment kernel for the dense
+   //// tensor-dense vector multiplication. This kernel is optimized for small tensors.
+   //*/
+   //template< typename MT1    // Type of the left-hand side target vector
+   //        , typename TT1    // Type of the left-hand side tensor operand
+   //        , typename VT1 >  // Type of the right-hand side vector operand
+   //static inline auto selectSmallSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   //{
+   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+
+   //   const size_t M( A.rows()    );
+   //   const size_t N( A.columns() );
+
+   //   size_t i( 0UL );
+
+   //   for( ; (i+8UL) <= M; i+=8UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //         xmm3 += A.load(i+2UL,j) * x1;
+   //         xmm4 += A.load(i+3UL,j) * x1;
+   //         xmm5 += A.load(i+4UL,j) * x1;
+   //         xmm6 += A.load(i+5UL,j) * x1;
+   //         xmm7 += A.load(i+6UL,j) * x1;
+   //         xmm8 += A.load(i+7UL,j) * x1;
+   //      }
+
+   //      y[i    ] -= sum( xmm1 );
+   //      y[i+1UL] -= sum( xmm2 );
+   //      y[i+2UL] -= sum( xmm3 );
+   //      y[i+3UL] -= sum( xmm4 );
+   //      y[i+4UL] -= sum( xmm5 );
+   //      y[i+5UL] -= sum( xmm6 );
+   //      y[i+6UL] -= sum( xmm7 );
+   //      y[i+7UL] -= sum( xmm8 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] -= A(i    ,j) * x[j];
+   //         y[i+1UL] -= A(i+1UL,j) * x[j];
+   //         y[i+2UL] -= A(i+2UL,j) * x[j];
+   //         y[i+3UL] -= A(i+3UL,j) * x[j];
+   //         y[i+4UL] -= A(i+4UL,j) * x[j];
+   //         y[i+5UL] -= A(i+5UL,j) * x[j];
+   //         y[i+6UL] -= A(i+6UL,j) * x[j];
+   //         y[i+7UL] -= A(i+7UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+4UL) <= M; i+=4UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2, xmm3, xmm4;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //         xmm3 += A.load(i+2UL,j) * x1;
+   //         xmm4 += A.load(i+3UL,j) * x1;
+   //      }
+
+   //      y[i    ] -= sum( xmm1 );
+   //      y[i+1UL] -= sum( xmm2 );
+   //      y[i+2UL] -= sum( xmm3 );
+   //      y[i+3UL] -= sum( xmm4 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] -= A(i    ,j) * x[j];
+   //         y[i+1UL] -= A(i+1UL,j) * x[j];
+   //         y[i+2UL] -= A(i+2UL,j) * x[j];
+   //         y[i+3UL] -= A(i+3UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+3UL) <= M; i+=3UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2, xmm3;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //         xmm3 += A.load(i+2UL,j) * x1;
+   //      }
+
+   //      y[i    ] -= sum( xmm1 );
+   //      y[i+1UL] -= sum( xmm2 );
+   //      y[i+2UL] -= sum( xmm3 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] -= A(i    ,j) * x[j];
+   //         y[i+1UL] -= A(i+1UL,j) * x[j];
+   //         y[i+2UL] -= A(i+2UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+2UL) <= M; i+=2UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1, xmm2;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         xmm1 += A.load(i    ,j) * x1;
+   //         xmm2 += A.load(i+1UL,j) * x1;
+   //      }
+
+   //      y[i    ] -= sum( xmm1 );
+   //      y[i+1UL] -= sum( xmm2 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] -= A(i    ,j) * x[j];
+   //         y[i+1UL] -= A(i+1UL,j) * x[j];
+   //      }
+   //   }
+
+   //   if( i < M )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      SIMDType xmm1;
+   //      size_t j( jbegin );
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         xmm1 += A.load(i,j) * x.load(j);
+   //      }
+
+   //      y[i] -= sum( xmm1 );
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i] -= A(i,j) * x[j];
+   //      }
+   //   }
+   //}
+   ///*! \endcond */
+   ////**********************************************************************************************
+
+   //**Default subtraction assignment to dense vectors (large tensors)****************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default subtraction assignment of a large dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}-=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function relays to the default implementation of the subtraction assignment of a
+   // dense tensor-dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1    // Type of the left-hand side target matrix
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectLargeSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> DisableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   {
+      selectDefaultSubAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   ////**Vectorized default subtraction assignment to dense vectors (large tensors)*****************
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief Vectorized default subtraction assignment of a large dense tensor-dense vector
+   ////        multiplication (\f$ \vec{y}-=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param y The target left-hand side dense vector.
+   //// \param A The left-hand side dense tensor operand.
+   //// \param x The right-hand side dense vector operand.
+   //// \return void
+   ////
+   //// This function implements the vectorized default subtraction assignment kernel for the dense
+   //// tensor-dense vector multiplication. This kernel is optimized for large tensors.
+   //*/
+   //template< typename MT1    // Type of the left-hand side target vector
+   //        , typename TT1    // Type of the left-hand side tensor operand
+   //        , typename VT1 >  // Type of the right-hand side vector operand
+   //static inline auto selectLargeSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   //{
+   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+
+   //   const size_t M( A.rows()    );
+   //   const size_t N( A.columns() );
+
+   //   size_t i( 0UL );
+
+   //   for( ; (i+8UL) <= M; i+=8UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
+   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
+   //         y[i+4UL] -= sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 );
+   //         y[i+5UL] -= sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 );
+   //         y[i+6UL] -= sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 );
+   //         y[i+7UL] -= sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
+   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
+   //         y[i+4UL] -= sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 );
+   //         y[i+5UL] -= sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 );
+   //         y[i+6UL] -= sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 );
+   //         y[i+7UL] -= sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i    ] -= sum( A.load(i    ,j) * x1 );
+   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 );
+   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 );
+   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 );
+   //         y[i+4UL] -= sum( A.load(i+4UL,j) * x1 );
+   //         y[i+5UL] -= sum( A.load(i+5UL,j) * x1 );
+   //         y[i+6UL] -= sum( A.load(i+6UL,j) * x1 );
+   //         y[i+7UL] -= sum( A.load(i+7UL,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] -= A(i    ,j) * x[j];
+   //         y[i+1UL] -= A(i+1UL,j) * x[j];
+   //         y[i+2UL] -= A(i+2UL,j) * x[j];
+   //         y[i+3UL] -= A(i+3UL,j) * x[j];
+   //         y[i+4UL] -= A(i+4UL,j) * x[j];
+   //         y[i+5UL] -= A(i+5UL,j) * x[j];
+   //         y[i+6UL] -= A(i+6UL,j) * x[j];
+   //         y[i+7UL] -= A(i+7UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+4UL) <= M; i+=4UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
+   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
+   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i    ] -= sum( A.load(i    ,j) * x1 );
+   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 );
+   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 );
+   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] -= A(i    ,j) * x[j];
+   //         y[i+1UL] -= A(i+1UL,j) * x[j];
+   //         y[i+2UL] -= A(i+2UL,j) * x[j];
+   //         y[i+3UL] -= A(i+3UL,j) * x[j];
+   //      }
+   //   }
+
+   //   for( ; (i+2UL) <= M; i+=2UL )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i    ] -= sum( A.load(i    ,j) * x1 );
+   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i    ] -= A(i    ,j) * x[j];
+   //         y[i+1UL] -= A(i+1UL,j) * x[j];
+   //      }
+   //   }
+
+   //   if( i < M )
+   //   {
+   //      const size_t jbegin( ( IsUpper_v<TT1> )
+   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+   //                           :( 0UL ) );
+   //      const size_t jend( ( IsLower_v<TT1> )
+   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+   //                         :( N ) );
+   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+   //      size_t j( jbegin );
+
+   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+   //         const size_t j1( j+SIMDSIZE     );
+   //         const size_t j2( j+SIMDSIZE*2UL );
+   //         const size_t j3( j+SIMDSIZE*3UL );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         const SIMDType x3( x.load(j2) );
+   //         const SIMDType x4( x.load(j3) );
+   //         y[i] -= sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 );
+   //      }
+
+   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+   //         const size_t j1( j+SIMDSIZE );
+   //         const SIMDType x1( x.load(j ) );
+   //         const SIMDType x2( x.load(j1) );
+   //         y[i] -= sum( A.load(i,j) * x1 + A.load(i,j1) * x2 );
+   //      }
+
+   //      for( ; j<jpos; j+=SIMDSIZE ) {
+   //         const SIMDType x1( x.load(j) );
+   //         y[i] -= sum( A.load(i,j) * x1 );
+   //      }
+
+   //      for( ; remainder && j<jend; ++j ) {
+   //         y[i] -= A(i,j) * x[j];
+   //      }
+   //   }
+   //}
+   ///*! \endcond */
+   ////**********************************************************************************************
+
+   //**BLAS-based subtraction assignment to dense matrices (default)********************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Default subtraction assignment of a dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}-=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function relays to the default implementation of the subtraction assignment of a large
+   // dense tensor-dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectBlasSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> DisableIf_t< UseBlasKernel_v<MT1,TT1,VT1> >
+   {
+      selectLargeSubAssignKernel( y, A, x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**BLAS-based subtraction assignment to dense vectors******************************************
+#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_MATRIX_VECTOR_MULTIPLICATION
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief BLAS-based subtraction assignment of a tensor-vector multiplication
+   ////        (\f$ \vec{y}-=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param y The target left-hand side dense vector.
+   //// \param A The left-hand side dense tensor operand.
+   //// \param x The right-hand side dense vector operand.
+   //// \return void
+   ////
+   //// This function performs the dense tensor-dense vector multiplication based on the according
+   //// BLAS functionality.
+   //*/
+   //template< typename MT1    // Type of the left-hand side target vector
+   //        , typename TT1    // Type of the left-hand side tensor operand
+   //        , typename VT1 >  // Type of the right-hand side vector operand
+   //static inline auto selectBlasSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+   //   -> EnableIf_t< UseBlasKernel_v<MT1,TT1,VT1> >
+   //{
+   //   using ET = ElementType_t<MT1>;
+
+   //   if( IsTriangular_v<TT1> ) {
+   //      ResultType_t<MT1> tmp( serial( x ) );
+   //      trmv( tmp, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
+   //      subAssign( y, tmp );
+   //   }
+   //   else {
+   //      gemv( y, A, x, ET(-1), ET(1) );
+   //   }
+   //}
+   ///*! \endcond */
+#endif
+   //**********************************************************************************************
+
+   //**Subtraction assignment to sparse vectors****************************************************
+   // No special implementation for the subtraction assignment to sparse vectors.
+   //**********************************************************************************************
+
+   //**Multiplication assignment to dense vectors**************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Multiplication assignment of a dense tensor-dense vector multiplication to a dense vector
+   //        (\f$ \vec{y}*=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression to be multiplied.
+   // \return void
+   //
+   // This function implements the performance optimized multiplication assignment of a dense
+   // tensor-dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1 >  // Type of the target dense matrix
+   friend inline void multAssign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE( ResultType );
+      //BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( ResultType );
+      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+
+      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+
+      const ResultType tmp( serial( rhs ) );
+      multAssign( ~lhs, tmp );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Multiplication assignment to sparse vectors*************************************************
+   // No special implementation for the multiplication assignment to sparse vectors.
+   //**********************************************************************************************
+
+   //**Division assignment to dense vectors********************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Division assignment of a dense tensor-dense vector multiplication to a dense vector
+   //        (\f$ \vec{y}/=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression divisor.
+   // \return void
+   //
+   // This function implements the performance optimized division assignment of a dense tensor-
+   // dense vector multiplication expression to a dense vector.
+   */
+   template< typename MT1 >  // Type of the target dense matrix
+   friend inline void divAssign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE( ResultType );
+      //BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( ResultType );
+      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+
+      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()) , "Invalid matrix sizes" );
+
+      const ResultType tmp( serial( rhs ) );
+      divAssign( ~lhs, tmp );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**Division assignment to sparse vectors*******************************************************
+   // No special implementation for the division assignment to sparse vectors.
+   //**********************************************************************************************
+
+   //**SMP assignment to dense vectors*************************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief SMP assignment of a dense tensor-dense vector multiplication to a dense vector
+   //        (\f$ \vec{y}=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression to be assigned.
+   // \return void
+   //
+   // This function implements the performance optimized SMP assignment of a dense tensor-dense
+   // vector multiplication expression to a dense vector. Due to the explicit application of
+   // the SFINAE principle, this function can only be selected by the compiler in case the
+   // expression specific parallel evaluation strategy is selected.
+   */
+   template< typename MT1 >  // Type of the target dense matrix
+   friend inline auto smpAssign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+      -> EnableIf_t< UseSMPAssign_v<MT1> >
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+
+      if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL ) {
+         return;
+      }
+      else if( rhs.tens_.columns() == 0UL ) {
+         reset( ~lhs );
+         return;
+      }
+
+      LT A( rhs.tens_ );  // Evaluation of the left-hand side dense tensor operand
+      RT x( rhs.vec_ );  // Evaluation of the right-hand side dense vector operand
+
+      BLAZE_INTERNAL_ASSERT( A.pages()   == rhs.tens_.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+
+      smpAssign( ~lhs, A * x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   ////**SMP assignment to sparse vectors************************************************************
+   ///*! \cond BLAZE_INTERNAL */
+   ///*!\brief SMP assignment of a dense tensor-dense vector multiplication to a sparse vector
+   ////        (\f$ \vec{y}=A*\vec{x} \f$).
+   //// \ingroup dense_vector
+   ////
+   //// \param lhs The target left-hand side sparse vector.
+   //// \param rhs The right-hand side multiplication expression to be assigned.
+   //// \return void
+   ////
+   //// This function implements the performance optimized SMP assignment of a dense tensor-dense
+   //// vector multiplication expression to a sparse vector. Due to the explicit application of
+   //// the SFINAE principle, this function can only be selected by the compiler in case the
+   //// expression specific parallel evaluation strategy is selected.
+   //*/
+   //template< typename MT1 >  // Type of the target sparse matrix
+   //friend inline auto smpAssign( SparseMatrix<MT1,false>& lhs, const DTensDVecMultExpr& rhs )
+   //   -> EnableIf_t< UseSMPAssign_v<MT1> >
+   //{
+   //   BLAZE_FUNCTION_TRACE;
+
+   //   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE( ResultType );
+   //   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( ResultType );
+   //   BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+
+   //   BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+
+   //   const ResultType tmp( rhs );
+   //   smpAssign( ~lhs, tmp );
+   //}
+   ///*! \endcond */
+   ////**********************************************************************************************
+
+   //**SMP addition assignment to dense vectors****************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief SMP addition assignment of a dense tensor-dense vector multiplication to a dense vector
+   //        (\f$ \vec{y}+=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression to be added.
+   // \return void
+   //
+   // This function implements the performance optimized SMP addition assignment of a dense tensor-
+   // dense vector multiplication expression to a dense vector. Due to the explicit application
+   // of the SFINAE principle, this function can only be selected by the compiler in case the
+   // expression specific parallel evaluation strategy is selected.
+   */
+   template< typename MT1 >  // Type of the target dense matrix
+   friend inline auto smpAddAssign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+      -> EnableIf_t< UseSMPAssign_v<MT1> >
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+
+      if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL || rhs.tens_.columns() == 0UL ) {
+         return;
+      }
+
+      LT A( rhs.tens_ );  // Evaluation of the left-hand side dense tensor operand
+      RT x( rhs.vec_ );  // Evaluation of the right-hand side dense vector operand
+
+      BLAZE_INTERNAL_ASSERT( A.pages()   == rhs.tens_.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+
+      smpAddAssign( ~lhs, A * x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**SMP addition assignment to sparse vectors***************************************************
+   // No special implementation for the SMP addition assignment to sparse vectors.
+   //**********************************************************************************************
+
+   //**SMP subtraction assignment to dense vectors*************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief SMP subtraction assignment of a dense tensor-dense vector multiplication to a dense
+   //        vector (\f$ \vec{y}-=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression to be subtracted.
+   // \return void
+   //
+   // This function implements the performance optimized SMP subtraction assignment of a dense
+   // tensor-dense vector multiplication expression to a dense vector. Due to the explicit
+   // application of the SFINAE principle, this function can only be selected by the compiler
+   // in case the expression specific parallel evaluation strategy is selected.
+   */
+   template< typename MT1 >  // Type of the target dense matrix
+   friend inline auto smpSubAssign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+      -> EnableIf_t< UseSMPAssign_v<MT1> >
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+
+      if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL || rhs.tens_.columns() == 0UL ) {
+         return;
+      }
+
+      LT A( rhs.tens_ );  // Evaluation of the left-hand side dense tensor operand
+      RT x( rhs.vec_ );  // Evaluation of the right-hand side dense vector operand
+
+      BLAZE_INTERNAL_ASSERT( A.pages()   == rhs.tens_.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+
+      smpSubAssign( ~lhs, A * x );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**SMP subtraction assignment to sparse vectors************************************************
+   // No special implementation for the SMP subtraction assignment to sparse vectors.
+   //**********************************************************************************************
+
+   //**SMP multiplication assignment to dense vectors**********************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief SMP multiplication assignment of a dense tensor-dense vector multiplication to a
+   //        dense vector (\f$ \vec{y}*=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression to be multiplied.
+   // \return void
+   //
+   // This function implements the performance optimized SMP multiplication assignment of a
+   // dense tensor-dense vector multiplication expression to a dense vector. Due to the explicit
+   // application of the SFINAE principle, this function can only be selected by the compiler
+   // in case the expression specific parallel evaluation strategy is selected.
+   */
+   template< typename MT1 >  // Type of the target dense matrix
+   friend inline auto smpMultAssign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+      -> EnableIf_t< UseSMPAssign_v<MT1> >
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE( ResultType );
+      //BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( ResultType );
+      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+
+      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+
+      const ResultType tmp( rhs );
+      smpMultAssign( ~lhs, tmp );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**SMP multiplication assignment to sparse vectors*********************************************
+   // No special implementation for the SMP multiplication assignment to sparse vectors.
+   //**********************************************************************************************
+
+   //**SMP division assignment to dense vectors****************************************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief SMP division assignment of a dense tensor-dense vector multiplication to a dense
+   //        vector (\f$ \vec{y}/=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param lhs The target left-hand side dense vector.
+   // \param rhs The right-hand side multiplication expression divisor.
+   // \return void
+   //
+   // This function implements the performance optimized SMP division assignment of a dense
+   // tensor-dense vector multiplication expression to a dense vector. Due to the explicit
+   // application of the SFINAE principle, this function can only be selected by the compiler
+   // in case the expression specific parallel evaluation strategy is selected.
+   */
+   template< typename MT1 >  // Type of the target dense vector
+   friend inline auto smpDivAssign( DenseMatrix<MT1,true>& lhs, const DTensDVecMultExpr& rhs )
+      -> EnableIf_t< UseSMPAssign_v<MT1> >
+   {
+      BLAZE_FUNCTION_TRACE;
+
+      BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE( ResultType );
+      //BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( ResultType );
+      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+
+      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+
+      const ResultType tmp( rhs );
+      smpDivAssign( ~lhs, tmp );
+   }
+   /*! \endcond */
+   //**********************************************************************************************
+
+   //**SMP division assignment to sparse vectors***************************************************
+   // No special implementation for the SMP division assignment to sparse vectors.
+   //**********************************************************************************************
+
+   //**Compile time checks*************************************************************************
+   /*! \cond BLAZE_INTERNAL */
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( TT );
+   //BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( TT );
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE ( VT );
+   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( VT );
+   BLAZE_CONSTRAINT_MUST_FORM_VALID_TENSVECMULTEXPR( TT, VT );
+   /*! \endcond */
+   //**********************************************************************************************
+};
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  DVECSCALARMULTEXPR SPECIALIZATION
+//
+//=================================================================================================
+//
+////*************************************************************************************************
+///*! \cond BLAZE_INTERNAL */
+///*!\brief Expression object for scaled dense tensor-dense vector multiplications.
+//// \ingroup dense_vector_expression
+////
+//// This specialization of the DVecScalarMultExpr class represents the compile time expression
+//// for scaled multiplications between a row-major dense tensor and a non-transpose dense vector.
+//*/
+//template< typename TT    // Type of the left-hand side dense tensor
+//        , typename VT    // Type of the right-hand side dense vector
+//        , typename ST >  // Type of the scalar value
+//class DVecScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
+//   : public VecScalarMultExpr< DenseVector< DVecScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >, false > >
+//   , private Computation
+//{
+// private:
+//   //**Type definitions****************************************************************************
+//   using MVM = DTensDVecMultExpr<TT,VT>;  //!< Type of the dense tensor-dense vector multiplication expression.
+//   using RES = ResultType_t<MVM>;        //!< Result type of the dense tensor-dense vector multiplication expression.
+//   using TRT = ResultType_t<TT>;         //!< Result type of the left-hand side dense tensor expression.
+//   using VRT = ResultType_t<VT>;         //!< Result type of the right-hand side dense vector expression.
+//   using TET = ElementType_t<TRT>;       //!< Element type of the left-hand side dense tensor expression.
+//   using VET = ElementType_t<VRT>;       //!< Element type of the right-hand side dense vector expression.
+//   using TCT = CompositeType_t<TT>;      //!< Composite type of the left-hand side dense tensor expression.
+//   using VCT = CompositeType_t<VT>;      //!< Composite type of the right-hand side dense vector expression.
+//   //**********************************************************************************************
+//
+//   //**********************************************************************************************
+//   //! Compilation switch for the composite type of the right-hand side dense tensor expression.
+//   static constexpr bool evaluateTensor =
+//      ( ( IsComputation_v<TT> && IsSame_v<TET,VET> &&
+//          IsBLASCompatible_v<TET> ) || RequiresEvaluation_v<TT> );
+//   //**********************************************************************************************
+//
+//   //**********************************************************************************************
+//   //! Compilation switch for the composite type of the right-hand side dense vector expression.
+//   static constexpr bool evaluateVector = ( IsComputation_v<VT> || RequiresEvaluation_v<TT> );
+//   //**********************************************************************************************
+//
+//   //**********************************************************************************************
+//   //! Helper variable template for the explicit application of the SFINAE principle.
+//   /*! This variable template is a helper for the selection of the parallel evaluation strategy.
+//       In case either the tensor or the vector operand requires an intermediate evaluation, the
+//       variable will be set to 1, otherwise it will be 0. */
+//   template< typename T1 >
+//   static constexpr bool UseSMPAssign_v = ( evaluateTensor || evaluateVector );
+//   //**********************************************************************************************
+//
+//   //**********************************************************************************************
+//   //! Helper variable template for the explicit application of the SFINAE principle.
+//   /*! In case the tensor type, the two involved vector types, and the scalar type are suited
+//       for a BLAS kernel, the variable will be set to 1, otherwise it will be 0. */
+//   template< typename T1, typename T2, typename T3, typename T4 >
+//   static constexpr bool UseBlasKernel_v =
+//      ( BLAZE_BLAS_MODE && BLAZE_USE_BLAS_MATRIX_VECTOR_MULTIPLICATION &&
+//        IsContiguous_v<T1> && HasMutableDataAccess_v<T1> &&
+//        IsContiguous_v<T2> && HasConstDataAccess_v<T2> &&
+//        IsContiguous_v<T3> && HasConstDataAccess_v<T3> &&
+//        !IsDiagonal_v<T2> &&
+//        T1::simdEnabled && T2::simdEnabled && T3::simdEnabled &&
+//        IsBLASCompatible_v< ElementType_t<T1> > &&
+//        IsBLASCompatible_v< ElementType_t<T2> > &&
+//        IsBLASCompatible_v< ElementType_t<T3> > &&
+//        IsSame_v< ElementType_t<T1>, ElementType_t<T2> > &&
+//        IsSame_v< ElementType_t<T1>, ElementType_t<T3> > &&
+//        !( IsBuiltin_v< ElementType_t<T1> > && IsComplex_v<T4> ) );
+//   //**********************************************************************************************
+//
+//   //**********************************************************************************************
+//   //! Helper variable template for the explicit application of the SFINAE principle.
+//   /*! In case the two involved vector types, the tensor type, and the scalar type are suited
+//       for a vectorized computation of the scaled vector/tensor multiplication, the variable
+//       will be set to 1, otherwise it will be 0. */
+//   template< typename T1, typename T2, typename T3, typename T4 >
+//   static constexpr bool UseVectorizedDefaultKernel_v =
+//      ( useOptimizedKernels &&
+//        !IsDiagonal_v<T2> &&
+//        T1::simdEnabled && T2::simdEnabled && T3::simdEnabled &&
+//        IsSIMDCombinable_v< ElementType_t<T1>
+//                          , ElementType_t<T2>
+//                          , ElementType_t<T3>
+//                          , T4 > &&
+//        HasSIMDAdd_v< ElementType_t<T2>, ElementType_t<T3> > &&
+//        HasSIMDMult_v< ElementType_t<T2>, ElementType_t<T3> > );
+//   //**********************************************************************************************
+//
+// public:
+//   //**Type definitions****************************************************************************
+//   using This          = DVecScalarMultExpr<MVM,ST,false>;  //!< Type of this DVecScalarMultExpr instance.
+//   using BaseType      = DenseVector<This,false>;           //!< Base type of this DVecScalarMultExpr instance.
+//   using ResultType    = MultTrait_t<RES,ST>;               //!< Result type for expression template evaluations.
+//   using TransposeType = TransposeType_t<ResultType>;       //!< Transpose type for expression template evaluations.
+//   using ElementType   = ElementType_t<ResultType>;         //!< Resulting element type.
+//   using SIMDType      = SIMDTrait_t<ElementType>;          //!< Resulting SIMD element type.
+//   using ReturnType    = const ElementType;                 //!< Return type for expression template evaluations.
+//   using CompositeType = const ResultType;                  //!< Data type for composite expression templates.
+//
+//   //! Composite type of the left-hand side dense vector expression.
+//   using LeftOperand = const DTensDVecMultExpr<TT,VT>;
+//
+//   //! Composite type of the right-hand side scalar value.
+//   using RightOperand = ST;
+//
+//   //! Type for the assignment of the dense tensor operand of the left-hand side expression.
+//   using LT = If_t< evaluateTensor, const TRT, TCT >;
+//
+//   //! Type for the assignment of the dense vector operand of the left-hand side expression.
+//   using RT = If_t< evaluateVector, const VRT, VCT >;
+//   //**********************************************************************************************
+//
+//   //**Compilation flags***************************************************************************
+//   //! Compilation switch for the expression template evaluation strategy.
+//   static constexpr bool simdEnabled =
+//      ( !IsDiagonal_v<TT> &&
+//        TT::simdEnabled && VT::simdEnabled &&
+//        IsSIMDCombinable_v<TET,VET,ST> &&
+//        HasSIMDAdd_v<TET,VET> &&
+//        HasSIMDMult_v<TET,VET> );
+//
+//   //! Compilation switch for the expression template assignment strategy.
+//   static constexpr bool smpAssignable =
+//      ( !evaluateTensor && TT::smpAssignable && !evaluateVector && VT::smpAssignable );
+//   //**********************************************************************************************
+//
+//   //**SIMD properties*****************************************************************************
+//   //! The number of elements packed within a single SIMD element.
+//   static constexpr size_t SIMDSIZE = SIMDTrait<ElementType>::size;
+//   //**********************************************************************************************
+//
+//   //**Constructor*********************************************************************************
+//   /*!\brief Constructor for the DVecScalarMultExpr class.
+//   //
+//   // \param vector The left-hand side dense vector of the multiplication expression.
+//   // \param scalar The right-hand side scalar of the multiplication expression.
+//   */
+//   explicit inline DVecScalarMultExpr( const MVM& vector, ST scalar )
+//      : vector_( vector )  // Left-hand side dense vector of the multiplication expression
+//      , scalar_( scalar )  // Right-hand side scalar of the multiplication expression
+//   {}
+//   //**********************************************************************************************
+//
+//   //**Subscript operator**************************************************************************
+//   /*!\brief Subscript operator for the direct access to the vector elements.
+//   //
+//   // \param index Access index. The index has to be in the range \f$[0..N-1]\f$.
+//   // \return The resulting value.
+//   */
+//   inline ReturnType operator[]( size_t index ) const {
+//      BLAZE_INTERNAL_ASSERT( index < vector_.size(), "Invalid vector access index" );
+//      return vector_[index] * scalar_;
+//   }
+//   //**********************************************************************************************
+//
+//   //**At function*********************************************************************************
+//   /*!\brief Checked access to the vector elements.
+//   //
+//   // \param index Access index. The index has to be in the range \f$[0..N-1]\f$.
+//   // \return The resulting value.
+//   // \exception std::out_of_range Invalid vector access index.
+//   */
+//   inline ReturnType at( size_t index ) const {
+//      if( index >= vector_.size() ) {
+//         BLAZE_THROW_OUT_OF_RANGE( "Invalid vector access index" );
+//      }
+//      return (*this)[index];
+//   }
+//   //**********************************************************************************************
+//
+//   //**Size function*******************************************************************************
+//   /*!\brief Returns the current size/dimension of the vector.
+//   //
+//   // \return The size of the vector.
+//   */
+//   inline size_t size() const {
+//      return vector_.size();
+//   }
+//   //**********************************************************************************************
+//
+//   //**Left operand access*************************************************************************
+//   /*!\brief Returns the left-hand side dense vector operand.
+//   //
+//   // \return The left-hand side dense vector operand.
+//   */
+//   inline LeftOperand leftOperand() const {
+//      return vector_;
+//   }
+//   //**********************************************************************************************
+//
+//   //**Right operand access************************************************************************
+//   /*!\brief Returns the right-hand side scalar operand.
+//   //
+//   // \return The right-hand side scalar operand.
+//   */
+//   inline RightOperand rightOperand() const {
+//      return scalar_;
+//   }
+//   //**********************************************************************************************
+//
+//   //**********************************************************************************************
+//   /*!\brief Returns whether the expression can alias with the given address \a alias.
+//   //
+//   // \param alias The alias to be checked.
+//   // \return \a true in case the expression can alias, \a false otherwise.
+//   */
+//   template< typename T >
+//   inline bool canAlias( const T* alias ) const {
+//      return vector_.canAlias( alias );
+//   }
+//   //**********************************************************************************************
+//
+//   //**********************************************************************************************
+//   /*!\brief Returns whether the expression is aliased with the given address \a alias.
+//   //
+//   // \param alias The alias to be checked.
+//   // \return \a true in case an alias effect is detected, \a false otherwise.
+//   */
+//   template< typename T >
+//   inline bool isAliased( const T* alias ) const {
+//      return vector_.isAliased( alias );
+//   }
+//   //**********************************************************************************************
+//
+//   //**********************************************************************************************
+//   /*!\brief Returns whether the operands of the expression are properly aligned in memory.
+//   //
+//   // \return \a true in case the operands are aligned, \a false if not.
+//   */
+//   inline bool isAligned() const {
+//      return vector_.isAligned();
+//   }
+//   //**********************************************************************************************
+//
+//   //**********************************************************************************************
+//   /*!\brief Returns whether the expression can be used in SMP assignments.
+//   //
+//   // \return \a true in case the expression can be used in SMP assignments, \a false if not.
+//   */
+//   inline bool canSMPAssign() const noexcept {
+//      LeftOperand_t<MVM> A( vector_.leftOperand() );
+//      return ( !BLAZE_BLAS_MODE ||
+//               !BLAZE_USE_BLAS_MATRIX_VECTOR_MULTIPLICATION ||
+//               !BLAZE_BLAS_IS_PARALLEL ||
+//               ( IsComputation_v<TT> && !evaluateTensor ) ||
+//               ( A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD ) ) &&
+//             ( size() > SMP_DTENSDVECMULT_THRESHOLD );
+//   }
+//   //**********************************************************************************************
+//
+// private:
+//   //**Member variables****************************************************************************
+//   LeftOperand  vector_;  //!< Left-hand side dense vector of the multiplication expression.
+//   RightOperand scalar_;  //!< Right-hand side scalar of the multiplication expression.
+//   //**********************************************************************************************
+//
+//   //**Assignment to dense vectors*****************************************************************
+//   /*!\brief Assignment of a scaled dense tensor-dense vector multiplication to a dense vector
+//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be assigned.
+//   // \return void
+//   //
+//   // This function implements the performance optimized assignment of a scaled dense tensor-
+//   // dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline void assign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      LeftOperand_t<MVM>  left ( rhs.vector_.leftOperand()  );
+//      RightOperand_t<MVM> right( rhs.vector_.rightOperand() );
+//
+//      if( left.rows() == 0UL ) {
+//         return;
+//      }
+//      else if( left.columns() == 0UL ) {
+//         reset( ~lhs );
+//         return;
+//      }
+//
+//      LT A( serial( left  ) );  // Evaluation of the left-hand side dense tensor operand
+//      RT x( serial( right ) );  // Evaluation of the right-hand side dense vector operand
+//
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()   , "Invalid number of rows"    );
+//      BLAZE_INTERNAL_ASSERT( A.columns() == left.columns(), "Invalid number of columns" );
+//      BLAZE_INTERNAL_ASSERT( x.size()    == right.size()  , "Invalid vector size"       );
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).size() , "Invalid vector size"       );
+//
+//      DVecScalarMultExpr::selectAssignKernel( ~lhs, A, x, rhs.scalar_ );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Assignment to dense vectors (kernel selection)**********************************************
+//   /*!\brief Selection of the kernel for an assignment of a scaled dense tensor-dense vector
+//   //        multiplication to a dense vector (\f$ \vec{y}=A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline void selectAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//   {
+//      if( ( IsDiagonal_v<TT1> ) ||
+//          ( IsComputation_v<TT> && !evaluateTensor ) ||
+//          ( A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD ) )
+//         selectSmallAssignKernel( y, A, x, scalar );
+//      else
+//         selectBlasAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Default assignment to dense vectors*********************************************************
+//   /*!\brief Default assignment of a scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function implements the default assignment kernel for the scaled dense tensor-dense
+//   // vector multiplication.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectDefaultAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      y.assign( A * x * scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Default assignment to dense vectors (small tensors)****************************************
+//   /*!\brief Default assignment of a small scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function relays to the default implementation of the assignment of a scaled dense
+//   // tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectSmallAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      selectDefaultAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Vectorized default assignment to dense vectors (small tensors)*****************************
+//   /*!\brief Vectorized default assignment of a small scaled dense tensor-dense vector
+//   //        multiplication (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function implements the vectorized default assignment kernel for the scaled dense
+//   // tensor-dense vector multiplication. This kernel is optimized for small tensors.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectSmallAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
+//
+//      const size_t M( A.rows()    );
+//      const size_t N( A.columns() );
+//
+//      size_t i( 0UL );
+//
+//      for( ; (i+8UL) <= M; i+=8UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//            xmm3 += A.load(i+2UL,j) * x1;
+//            xmm4 += A.load(i+3UL,j) * x1;
+//            xmm5 += A.load(i+4UL,j) * x1;
+//            xmm6 += A.load(i+5UL,j) * x1;
+//            xmm7 += A.load(i+6UL,j) * x1;
+//            xmm8 += A.load(i+7UL,j) * x1;
+//         }
+//
+//         y[i    ] = sum( xmm1 ) * scalar;
+//         y[i+1UL] = sum( xmm2 ) * scalar;
+//         y[i+2UL] = sum( xmm3 ) * scalar;
+//         y[i+3UL] = sum( xmm4 ) * scalar;
+//         y[i+4UL] = sum( xmm5 ) * scalar;
+//         y[i+5UL] = sum( xmm6 ) * scalar;
+//         y[i+6UL] = sum( xmm7 ) * scalar;
+//         y[i+7UL] = sum( xmm8 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
+//            y[i+4UL] += A(i+4UL,j) * x[j] * scalar;
+//            y[i+5UL] += A(i+5UL,j) * x[j] * scalar;
+//            y[i+6UL] += A(i+6UL,j) * x[j] * scalar;
+//            y[i+7UL] += A(i+7UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+4UL) <= M; i+=4UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2, xmm3, xmm4;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//            xmm3 += A.load(i+2UL,j) * x1;
+//            xmm4 += A.load(i+3UL,j) * x1;
+//         }
+//
+//         y[i    ] = sum( xmm1 ) * scalar;
+//         y[i+1UL] = sum( xmm2 ) * scalar;
+//         y[i+2UL] = sum( xmm3 ) * scalar;
+//         y[i+3UL] = sum( xmm4 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+3UL) <= M; i+=3UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2, xmm3;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//            xmm3 += A.load(i+2UL,j) * x1;
+//         }
+//
+//         y[i    ] = sum( xmm1 ) * scalar;
+//         y[i+1UL] = sum( xmm2 ) * scalar;
+//         y[i+2UL] = sum( xmm3 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+2UL) <= M; i+=2UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//         }
+//
+//         y[i    ] = sum( xmm1 ) * scalar;
+//         y[i+1UL] = sum( xmm2 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      if( i < M )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            xmm1 += A.load(i,j) * x.load(j);
+//         }
+//
+//         y[i] = sum( xmm1 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i] += A(i,j) * x[j] * scalar;
+//         }
+//      }
+//   }
+//   //**********************************************************************************************
+//
+//   //**Default assignment to dense vectors (large tensors)****************************************
+//   /*!\brief Default assignment of a large scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function relays to the default implementation of the assignment of a scaled dense
+//   // tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectLargeAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      selectDefaultAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Vectorized default assignment to dense vectors (large tensors)*****************************
+//   /*!\brief Vectorized default assignment of a large scaled dense tensor-dense vector
+//   //        multiplication (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function implements the vectorized default assignment kernel for the scaled dense
+//   // tensor-dense vector multiplication. This kernel is optimized for large tensors.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectLargeAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
+//
+//      const size_t M( A.rows()    );
+//      const size_t N( A.columns() );
+//
+//      reset( y );
+//
+//      size_t i( 0UL );
+//
+//      for( ; (i+8UL) <= M; i+=8UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
+//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 );
+//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 );
+//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 );
+//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 );
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
+//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 );
+//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 );
+//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 );
+//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 );
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 );
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
+//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 );
+//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 );
+//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 );
+//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 );
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j];
+//            y[i+1UL] += A(i+1UL,j) * x[j];
+//            y[i+2UL] += A(i+2UL,j) * x[j];
+//            y[i+3UL] += A(i+3UL,j) * x[j];
+//            y[i+4UL] += A(i+4UL,j) * x[j];
+//            y[i+5UL] += A(i+5UL,j) * x[j];
+//            y[i+6UL] += A(i+6UL,j) * x[j];
+//            y[i+7UL] += A(i+7UL,j) * x[j];
+//         }
+//
+//         y[i    ] *= scalar;
+//         y[i+1UL] *= scalar;
+//         y[i+2UL] *= scalar;
+//         y[i+3UL] *= scalar;
+//         y[i+4UL] *= scalar;
+//         y[i+5UL] *= scalar;
+//         y[i+6UL] *= scalar;
+//         y[i+7UL] *= scalar;
+//      }
+//
+//      for( ; (i+4UL) <= M; i+=4UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 );
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j];
+//            y[i+1UL] += A(i+1UL,j) * x[j];
+//            y[i+2UL] += A(i+2UL,j) * x[j];
+//            y[i+3UL] += A(i+3UL,j) * x[j];
+//         }
+//
+//         y[i    ] *= scalar;
+//         y[i+1UL] *= scalar;
+//         y[i+2UL] *= scalar;
+//         y[i+3UL] *= scalar;
+//      }
+//
+//      for( ; (i+2UL) <= M; i+=2UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 );
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j];
+//            y[i+1UL] += A(i+1UL,j) * x[j];
+//         }
+//
+//         y[i    ] *= scalar;
+//         y[i+1UL] *= scalar;
+//      }
+//
+//      if( i < M )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 );
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 );
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i] += sum( A.load(i,j) * x1 );
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i] += A(i,j) * x[j];
+//         }
+//
+//         y[i] *= scalar;
+//      }
+//   }
+//   //**********************************************************************************************
+//
+//   //**BLAS-based assignment to dense vectors (default)********************************************
+//   /*!\brief Default assignment of a scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function relays to the default implementation of the assignment of a large scaled
+//   // dense tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectBlasAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseBlasKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      selectLargeAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**BLAS-based assignment to dense vectors******************************************************
+//#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_MATRIX_VECTOR_MULTIPLICATION
+//   /*!\brief BLAS-based assignment of a scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function performs the scaled dense tensor-dense vector multiplication based on the
+//   // according BLAS functionality.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectBlasAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> EnableIf_t< UseBlasKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      using ET = ElementType_t<VT1>;
+//
+//      if( IsTriangular_v<TT1> ) {
+//         assign( y, scalar * x );
+//         trmv( y, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
+//      }
+//      else {
+//         gemv( y, A, x, ET(scalar), ET(0) );
+//      }
+//   }
+//#endif
+//   //**********************************************************************************************
+//
+//   //**Assignment to sparse vectors****************************************************************
+//   /*!\brief Assignment of a scaled dense tensor-dense vector multiplication to a sparse vector
+//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side sparse vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be assigned.
+//   // \return void
+//   //
+//   // This function implements the performance optimized assignment of a scaled dense tensor-
+//   // dense vector multiplication expression to a sparse vector.
+//   */
+//   template< typename VT1 >  // Type of the target sparse vector
+//   friend inline void assign( SparseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE  ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      const ResultType tmp( serial( rhs ) );
+//      assign( ~lhs, tmp );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Addition assignment to dense vectors********************************************************
+//   /*!\brief Addition assignment of a scaled dense tensor-dense vector multiplication to a dense
+//   //        vector (\f$ \vec{y}+=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be added.
+//   // \return void
+//   //
+//   // This function implements the performance optimized addition assignment of a scaled dense
+//   // tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline void addAssign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      LeftOperand_t<MVM>  left ( rhs.vector_.leftOperand()  );
+//      RightOperand_t<MVM> right( rhs.vector_.rightOperand() );
+//
+//      if( left.rows() == 0UL || left.columns() == 0UL ) {
+//         return;
+//      }
+//
+//      LT A( serial( left  ) );  // Evaluation of the left-hand side dense tensor operand
+//      RT x( serial( right ) );  // Evaluation of the right-hand side dense vector operand
+//
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()   , "Invalid number of rows"    );
+//      BLAZE_INTERNAL_ASSERT( A.columns() == left.columns(), "Invalid number of columns" );
+//      BLAZE_INTERNAL_ASSERT( x.size()    == right.size()  , "Invalid vector size"       );
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).size() , "Invalid vector size"       );
+//
+//      DVecScalarMultExpr::selectAddAssignKernel( ~lhs, A, x, rhs.scalar_ );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Addition assignment to dense vectors (kernel selection)*************************************
+//   /*!\brief Selection of the kernel for an addition assignment of a scaled dense tensor-dense
+//   //        vector multiplication to a dense vector (\f$ \vec{y}+=A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline void selectAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//   {
+//      if( ( IsDiagonal_v<TT1> ) ||
+//          ( IsComputation_v<TT> && !evaluateTensor ) ||
+//          ( A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD ) )
+//         selectSmallAddAssignKernel( y, A, x, scalar );
+//      else
+//         selectBlasAddAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Default addition assignment to dense vectors************************************************
+//   /*!\brief Default addition assignment of a scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}+=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function implements the default addition assignment kernel for the scaled dense tensor-
+//   // dense vector multiplication.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline void selectDefaultAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//   {
+//      y.addAssign( A * x * scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Default addition assignment to dense vectors (small tensors)*******************************
+//   /*!\brief Default addition assignment of a small scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}+=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function relays to the default implementation of the addition assignment of a scaled
+//   // dense tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectSmallAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      selectDefaultAddAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Vectorized default addition assignment to dense vectors (small tensors)********************
+//   /*!\brief Vectorized default addition assignment of a small scaled dense tensor-dense vector
+//   //        multiplication (\f$ \vec{y}+=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function implements the vectorized default addition assignment kernel for the scaled
+//   // dense tensor-dense vector multiplication. This kernel is optimized for small tensors.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectSmallAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
+//
+//      const size_t M( A.rows()    );
+//      const size_t N( A.columns() );
+//
+//      size_t i( 0UL );
+//
+//      for( ; (i+8UL) <= M; i+=8UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//            xmm3 += A.load(i+2UL,j) * x1;
+//            xmm4 += A.load(i+3UL,j) * x1;
+//            xmm5 += A.load(i+4UL,j) * x1;
+//            xmm6 += A.load(i+5UL,j) * x1;
+//            xmm7 += A.load(i+6UL,j) * x1;
+//            xmm8 += A.load(i+7UL,j) * x1;
+//         }
+//
+//         y[i    ] += sum( xmm1 ) * scalar;
+//         y[i+1UL] += sum( xmm2 ) * scalar;
+//         y[i+2UL] += sum( xmm3 ) * scalar;
+//         y[i+3UL] += sum( xmm4 ) * scalar;
+//         y[i+4UL] += sum( xmm5 ) * scalar;
+//         y[i+5UL] += sum( xmm6 ) * scalar;
+//         y[i+6UL] += sum( xmm7 ) * scalar;
+//         y[i+7UL] += sum( xmm8 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
+//            y[i+4UL] += A(i+4UL,j) * x[j] * scalar;
+//            y[i+5UL] += A(i+5UL,j) * x[j] * scalar;
+//            y[i+6UL] += A(i+6UL,j) * x[j] * scalar;
+//            y[i+7UL] += A(i+7UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+4UL) <= M; i+=4UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2, xmm3, xmm4;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//            xmm3 += A.load(i+2UL,j) * x1;
+//            xmm4 += A.load(i+3UL,j) * x1;
+//         }
+//
+//         y[i    ] += sum( xmm1 ) * scalar;
+//         y[i+1UL] += sum( xmm2 ) * scalar;
+//         y[i+2UL] += sum( xmm3 ) * scalar;
+//         y[i+3UL] += sum( xmm4 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+3UL) <= M; i+=3UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2, xmm3;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//            xmm3 += A.load(i+2UL,j) * x1;
+//         }
+//
+//         y[i    ] += sum( xmm1 ) * scalar;
+//         y[i+1UL] += sum( xmm2 ) * scalar;
+//         y[i+2UL] += sum( xmm3 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+2UL) <= M; i+=2UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//         }
+//
+//         y[i    ] += sum( xmm1 ) * scalar;
+//         y[i+1UL] += sum( xmm2 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      if( i < M )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            xmm1 += A.load(i,j) * x.load(j);
+//         }
+//
+//         y[i] += sum( xmm1 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i] += A(i,j) * x[j] * scalar;
+//         }
+//      }
+//   }
+//   //**********************************************************************************************
+//
+//   //**Default addition assignment to dense vectors (large tensors)*******************************
+//   /*!\brief Default addition assignment of a large scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}+=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function relays to the default implementation of the addition assignment of a scaled
+//   // dense tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectLargeAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      selectDefaultAddAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Vectorized default addition assignment to dense vectors (large tensors)********************
+//   /*!\brief Vectorized default addition assignment of a large scaled dense tensor-dense vector
+//   //        multiplication (\f$ \vec{y}+=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function implements the vectorized default addition assignment kernel for the scaled
+//   // dense tensor-dense vector multiplication. This kernel is optimized for large tensors.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectLargeAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
+//
+//      const size_t M( A.rows()    );
+//      const size_t N( A.columns() );
+//
+//      size_t i( 0UL );
+//
+//      for( ; (i+8UL) <= M; i+=8UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 ) * scalar;
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 ) * scalar;
+//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 ) * scalar;
+//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 ) * scalar;
+//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 ) * scalar;
+//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 ) * scalar;
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 ) * scalar;
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 ) * scalar;
+//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 ) * scalar;
+//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 ) * scalar;
+//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 ) * scalar;
+//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 ) * scalar;
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 ) * scalar;
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 ) * scalar;
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 ) * scalar;
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 ) * scalar;
+//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 ) * scalar;
+//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 ) * scalar;
+//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 ) * scalar;
+//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 ) * scalar;
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
+//            y[i+4UL] += A(i+4UL,j) * x[j] * scalar;
+//            y[i+5UL] += A(i+5UL,j) * x[j] * scalar;
+//            y[i+6UL] += A(i+6UL,j) * x[j] * scalar;
+//            y[i+7UL] += A(i+7UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+4UL) <= M; i+=4UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 ) * scalar;
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 ) * scalar;
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 ) * scalar;
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 ) * scalar;
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 ) * scalar;
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 ) * scalar;
+//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 ) * scalar;
+//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 ) * scalar;
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+2UL) <= M; i+=2UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i    ] += sum( A.load(i    ,j) * x1 ) * scalar;
+//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 ) * scalar;
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] += A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      if( i < M )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 ) * scalar;
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 ) * scalar;
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i] += sum( A.load(i,j) * x1 ) * scalar;
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i] += A(i,j) * x[j] * scalar;
+//         }
+//      }
+//   }
+//   //**********************************************************************************************
+//
+//   //**BLAS-based addition assignment to dense vectors (default)***********************************
+//   /*!\brief Default addition assignment of a scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}+=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function relays to the default implementation of the addition assignment of a large
+//   // scaled dense tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectBlasAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseBlasKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      selectLargeAddAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**BLAS-based addition assignment to dense vectors*********************************************
+//#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_MATRIX_VECTOR_MULTIPLICATION
+//   /*!\brief BLAS-based addition assignment of a scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}+=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function performs the scaled dense tensor-dense vector multiplication based on the
+//   // according BLAS functionality.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectBlasAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> EnableIf_t< UseBlasKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      using ET = ElementType_t<VT1>;
+//
+//      if( IsTriangular_v<TT1> ) {
+//         ResultType_t<VT1> tmp( serial( scalar * x ) );
+//         trmv( tmp, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
+//         addAssign( y, tmp );
+//      }
+//      else {
+//         gemv( y, A, x, ET(scalar), ET(1) );
+//      }
+//   }
+//#endif
+//   //**********************************************************************************************
+//
+//   //**Addition assignment to sparse vectors*******************************************************
+//   // No special implementation for the addition assignment to sparse vectors.
+//   //**********************************************************************************************
+//
+//   //**Subtraction assignment to dense vectors*****************************************************
+//   /*!\brief Subtraction assignment of a scaled dense tensor-dense vector multiplication to a
+//   //        dense vector (\f$ \vec{y}-=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be subtracted.
+//   // \return void
+//   //
+//   // This function implements the performance optimized subtraction assignment of a scaled
+//   // dense tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline void subAssign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      LeftOperand_t<MVM>  left ( rhs.vector_.leftOperand()  );
+//      RightOperand_t<MVM> right( rhs.vector_.rightOperand() );
+//
+//      if( left.rows() == 0UL || left.columns() == 0UL ) {
+//         return;
+//      }
+//
+//      LT A( serial( left  ) );  // Evaluation of the left-hand side dense tensor operand
+//      RT x( serial( right ) );  // Evaluation of the right-hand side dense vector operand
+//
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()   , "Invalid number of rows"    );
+//      BLAZE_INTERNAL_ASSERT( A.columns() == left.columns(), "Invalid number of columns" );
+//      BLAZE_INTERNAL_ASSERT( x.size()    == right.size()  , "Invalid vector size"       );
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).size() , "Invalid vector size"       );
+//
+//      DVecScalarMultExpr::selectSubAssignKernel( ~lhs, A, x, rhs.scalar_ );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Subtraction assignment to dense vectors (kernel selection)**********************************
+//   /*!\brief Selection of the kernel for a subtraction assignment of a scaled dense tensor-dense
+//   //        vector multiplication to a dense vector (\f$ \vec{y}-=A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline void selectSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//   {
+//      if( ( IsDiagonal_v<TT1> ) ||
+//          ( IsComputation_v<TT> && !evaluateTensor ) ||
+//          ( A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD ) )
+//         selectSmallSubAssignKernel( y, A, x, scalar );
+//      else
+//         selectBlasSubAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Default subtraction assignment to dense vectors*********************************************
+//   /*!\brief Default subtraction assignment of a scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}-=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function implements the default subtraction assignment kernel for the scaled dense
+//   // tensor-dense vector multiplication.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline void selectDefaultSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//   {
+//      y.subAssign( A * x * scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Default subtraction assignment to dense vectors (small tensors)****************************
+//   /*!\brief Default subtraction assignment of a small scaled dense tensor-dense vector
+//   //        multiplication (\f$ \vec{y}-=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function relays to the default implementation of the subtraction assignment of a
+//   // scaled dense tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectSmallSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      selectDefaultSubAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Vectorized default subtraction assignment to dense vectors (small tensors)*****************
+//   /*!\brief Vectorized default subtraction assignment of a small scaled dense tensor-dense vector
+//   //        multiplication (\f$ \vec{y}-=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function implements the vectorized default subtraction assignment kernel for the scaled
+//   // dense tensor-dense vector multiplication. This kernel is optimized for small tensors.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectSmallSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
+//
+//      const size_t M( A.rows()    );
+//      const size_t N( A.columns() );
+//
+//      size_t i( 0UL );
+//
+//      for( ; (i+8UL) <= M; i+=8UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//            xmm3 += A.load(i+2UL,j) * x1;
+//            xmm4 += A.load(i+3UL,j) * x1;
+//            xmm5 += A.load(i+4UL,j) * x1;
+//            xmm6 += A.load(i+5UL,j) * x1;
+//            xmm7 += A.load(i+6UL,j) * x1;
+//            xmm8 += A.load(i+7UL,j) * x1;
+//         }
+//
+//         y[i    ] -= sum( xmm1 ) * scalar;
+//         y[i+1UL] -= sum( xmm2 ) * scalar;
+//         y[i+2UL] -= sum( xmm3 ) * scalar;
+//         y[i+3UL] -= sum( xmm4 ) * scalar;
+//         y[i+4UL] -= sum( xmm5 ) * scalar;
+//         y[i+5UL] -= sum( xmm6 ) * scalar;
+//         y[i+6UL] -= sum( xmm7 ) * scalar;
+//         y[i+7UL] -= sum( xmm8 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] -= A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] -= A(i+3UL,j) * x[j] * scalar;
+//            y[i+4UL] -= A(i+4UL,j) * x[j] * scalar;
+//            y[i+5UL] -= A(i+5UL,j) * x[j] * scalar;
+//            y[i+6UL] -= A(i+6UL,j) * x[j] * scalar;
+//            y[i+7UL] -= A(i+7UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+4UL) <= M; i+=4UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2, xmm3, xmm4;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//            xmm3 += A.load(i+2UL,j) * x1;
+//            xmm4 += A.load(i+3UL,j) * x1;
+//         }
+//
+//         y[i    ] -= sum( xmm1 ) * scalar;
+//         y[i+1UL] -= sum( xmm2 ) * scalar;
+//         y[i+2UL] -= sum( xmm3 ) * scalar;
+//         y[i+3UL] -= sum( xmm4 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] -= A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] -= A(i+3UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+3UL) <= M; i+=3UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2, xmm3;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//            xmm3 += A.load(i+2UL,j) * x1;
+//         }
+//
+//         y[i    ] -= sum( xmm1 ) * scalar;
+//         y[i+1UL] -= sum( xmm2 ) * scalar;
+//         y[i+2UL] -= sum( xmm3 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] -= A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+2UL) <= M; i+=2UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1, xmm2;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            xmm1 += A.load(i    ,j) * x1;
+//            xmm2 += A.load(i+1UL,j) * x1;
+//         }
+//
+//         y[i    ] -= sum( xmm1 ) * scalar;
+//         y[i+1UL] -= sum( xmm2 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] -= A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      if( i < M )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         SIMDType xmm1;
+//         size_t j( jbegin );
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            xmm1 += A.load(i,j) * x.load(j);
+//         }
+//
+//         y[i] -= sum( xmm1 ) * scalar;
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i] -= A(i,j) * x[j] * scalar;
+//         }
+//      }
+//   }
+//   //**********************************************************************************************
+//
+//   //**Default subtraction assignment to dense vectors (large tensors)****************************
+//   /*!\brief Default subtraction assignment of a large scaled dense tensor-dense vector
+//   //        multiplication (\f$ \vec{y}-=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function relays to the default implementation of the subtraction assignment of a
+//   // scaled dense tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectLargeSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      selectDefaultSubAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Vectorized default subtraction assignment to dense vectors (large tensors)*****************
+//   /*!\brief Vectorized default subtraction assignment of a large scaled dense tensor-dense vector
+//   //        multiplication (\f$ \vec{y}-=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function implements the vectorized default subtraction assignment kernel for the scaled
+//   // dense tensor-dense vector multiplication. This kernel is optimized for large tensors.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectLargeSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
+//
+//      const size_t M( A.rows()    );
+//      const size_t N( A.columns() );
+//
+//      size_t i( 0UL );
+//
+//      for( ; (i+8UL) <= M; i+=8UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
+//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
+//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 ) * scalar;
+//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 ) * scalar;
+//            y[i+4UL] -= sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 ) * scalar;
+//            y[i+5UL] -= sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 ) * scalar;
+//            y[i+6UL] -= sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 ) * scalar;
+//            y[i+7UL] -= sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 ) * scalar;
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
+//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
+//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 ) * scalar;
+//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 ) * scalar;
+//            y[i+4UL] -= sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 ) * scalar;
+//            y[i+5UL] -= sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 ) * scalar;
+//            y[i+6UL] -= sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 ) * scalar;
+//            y[i+7UL] -= sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 ) * scalar;
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i    ] -= sum( A.load(i    ,j) * x1 ) * scalar;
+//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 ) * scalar;
+//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 ) * scalar;
+//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 ) * scalar;
+//            y[i+4UL] -= sum( A.load(i+4UL,j) * x1 ) * scalar;
+//            y[i+5UL] -= sum( A.load(i+5UL,j) * x1 ) * scalar;
+//            y[i+6UL] -= sum( A.load(i+6UL,j) * x1 ) * scalar;
+//            y[i+7UL] -= sum( A.load(i+7UL,j) * x1 ) * scalar;
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] -= A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] -= A(i+3UL,j) * x[j] * scalar;
+//            y[i+4UL] -= A(i+4UL,j) * x[j] * scalar;
+//            y[i+5UL] -= A(i+5UL,j) * x[j] * scalar;
+//            y[i+6UL] -= A(i+6UL,j) * x[j] * scalar;
+//            y[i+7UL] -= A(i+7UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+4UL) <= M; i+=4UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
+//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
+//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 ) * scalar;
+//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 ) * scalar;
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
+//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
+//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 ) * scalar;
+//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 ) * scalar;
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i    ] -= sum( A.load(i    ,j) * x1 ) * scalar;
+//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 ) * scalar;
+//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 ) * scalar;
+//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 ) * scalar;
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] -= A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
+//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
+//            y[i+3UL] -= A(i+3UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      for( ; (i+2UL) <= M; i+=2UL )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
+//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
+//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i    ] -= sum( A.load(i    ,j) * x1 ) * scalar;
+//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 ) * scalar;
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i    ] -= A(i    ,j) * x[j] * scalar;
+//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
+//         }
+//      }
+//
+//      if( i < M )
+//      {
+//         const size_t jbegin( ( IsUpper_v<TT1> )
+//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+//                              :( 0UL ) );
+//         const size_t jend( ( IsLower_v<TT1> )
+//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+//                            :( N ) );
+//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+//
+//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+//
+//         size_t j( jbegin );
+//
+//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+//            const size_t j1( j+SIMDSIZE     );
+//            const size_t j2( j+SIMDSIZE*2UL );
+//            const size_t j3( j+SIMDSIZE*3UL );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            const SIMDType x3( x.load(j2) );
+//            const SIMDType x4( x.load(j3) );
+//            y[i] -= sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 ) * scalar;
+//         }
+//
+//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+//            const size_t j1( j+SIMDSIZE );
+//            const SIMDType x1( x.load(j ) );
+//            const SIMDType x2( x.load(j1) );
+//            y[i] -= sum( A.load(i,j) * x1 + A.load(i,j1) * x2 ) * scalar;
+//         }
+//
+//         for( ; j<jpos; j+=SIMDSIZE ) {
+//            const SIMDType x1( x.load(j) );
+//            y[i] -= sum( A.load(i,j) * x1 ) * scalar;
+//         }
+//
+//         for( ; remainder && j<jend; ++j ) {
+//            y[i] -= A(i,j) * x[j] * scalar;
+//         }
+//      }
+//   }
+//   //**********************************************************************************************
+//
+//   //**BLAS-based subtraction assignment to dense vectors (default)********************************
+//   /*!\brief Default subtraction assignment of a scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}-=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function relays to the default implementation of the subtraction assignment of a large
+//   // scaled dense tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectBlasSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> DisableIf_t< UseBlasKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      selectLargeSubAssignKernel( y, A, x, scalar );
+//   }
+//   //**********************************************************************************************
+//
+//   //**BLAS-based subtraction assignment to dense vectors******************************************
+//#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_MATRIX_VECTOR_MULTIPLICATION
+//   /*!\brief BLAS-based subtraction assignment of a scaled dense tensor-dense vector multiplication
+//   //        (\f$ \vec{y}-=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param y The target left-hand side dense vector.
+//   // \param A The left-hand side dense tensor operand.
+//   // \param x The right-hand side dense vector operand.
+//   // \param scalar The scaling factor.
+//   // \return void
+//   //
+//   // This function performs the scaled dense tensor-dense vector multiplication based on the
+//   // according BLAS functionality.
+//   */
+//   template< typename VT1    // Type of the left-hand side target vector
+//           , typename TT1    // Type of the left-hand side tensor operand
+//           , typename VT2    // Type of the right-hand side vector operand
+//           , typename ST2 >  // Type of the scalar value
+//   static inline auto selectBlasSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+//      -> EnableIf_t< UseBlasKernel_v<VT1,TT1,VT2,ST2> >
+//   {
+//      using ET = ElementType_t<VT1>;
+//
+//      if( IsTriangular_v<TT1> ) {
+//         ResultType_t<VT1> tmp( serial( scalar * x ) );
+//         trmv( tmp, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
+//         subAssign( y, tmp );
+//      }
+//      else {
+//         gemv( y, A, x, ET(-scalar), ET(1) );
+//      }
+//   }
+//#endif
+//   //**********************************************************************************************
+//
+//   //**Subtraction assignment to sparse vectors****************************************************
+//   // No special implementation for the subtraction assignment to sparse vectors.
+//   //**********************************************************************************************
+//
+//   //**Multiplication assignment to dense vectors**************************************************
+//   /*!\brief Multiplication assignment of a scaled dense tensor-dense vector multiplication to a
+//   //        dense vector (\f$ \vec{y}*=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be multiplied.
+//   // \return void
+//   //
+//   // This function implements the performance optimized multiplication assignment of a scaled
+//   // dense tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline void multAssign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE  ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      const ResultType tmp( serial( rhs ) );
+//      multAssign( ~lhs, tmp );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Multiplication assignment to sparse vectors*************************************************
+//   // No special implementation for the multiplication assignment to sparse vectors.
+//   //**********************************************************************************************
+//
+//   //**Division assignment to dense vectors********************************************************
+//   /*!\brief Division assignment of a scaled dense tensor-dense vector multiplication to a dense
+//   //        vector (\f$ \vec{y}/=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression divisor.
+//   // \return void
+//   //
+//   // This function implements the performance optimized division assignment of a scaled dense
+//   // tensor-dense vector multiplication expression to a dense vector.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline void divAssign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE  ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      const ResultType tmp( serial( rhs ) );
+//      divAssign( ~lhs, tmp );
+//   }
+//   //**********************************************************************************************
+//
+//   //**Division assignment to sparse vectors*******************************************************
+//   // No special implementation for the division assignment to sparse vectors.
+//   //**********************************************************************************************
+//
+//   //**SMP assignment to dense vectors*************************************************************
+//   /*!\brief SMP assignment of a scaled dense tensor-dense vector multiplication to a dense vector
+//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be assigned.
+//   // \return void
+//   //
+//   // This function implements the performance optimized SMP assignment of a scaled dense tensor-
+//   // dense vector multiplication expression to a dense vector. Due to the explicit application
+//   // of the SFINAE principle, this function can only be selected by the compiler in case the
+//   // expression specific parallel evaluation strategy is selected.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline auto smpAssign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//      -> EnableIf_t< UseSMPAssign_v<VT1> >
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      LeftOperand_t<MVM>  left ( rhs.vector_.leftOperand()  );
+//      RightOperand_t<MVM> right( rhs.vector_.rightOperand() );
+//
+//      if( left.rows() == 0UL ) {
+//         return;
+//      }
+//      else if( left.columns() == 0UL ) {
+//         reset( ~lhs );
+//         return;
+//      }
+//
+//      LT A( left  );  // Evaluation of the left-hand side dense tensor operand
+//      RT x( right );  // Evaluation of the right-hand side dense vector operand
+//
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()   , "Invalid number of rows"    );
+//      BLAZE_INTERNAL_ASSERT( A.columns() == left.columns(), "Invalid number of columns" );
+//      BLAZE_INTERNAL_ASSERT( x.size()    == right.size()  , "Invalid vector size"       );
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).size() , "Invalid vector size"       );
+//
+//      smpAssign( ~lhs, A * x * rhs.scalar_ );
+//   }
+//   //**********************************************************************************************
+//
+//   //**SMP assignment to sparse vectors************************************************************
+//   /*!\brief SMP assignment of a scaled dense tensor-dense vector multiplication to a sparse vector
+//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side sparse vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be assigned.
+//   // \return void
+//   //
+//   // This function implements the performance optimized SMP assignment of a scaled dense tensor-
+//   // dense vector multiplication expression to a sparse vector. Due to the explicit application
+//   // of the SFINAE principle, this function can only be selected by the compiler in case the
+//   // expression specific parallel evaluation strategy is selected.
+//   */
+//   template< typename VT1 >  // Type of the target sparse vector
+//   friend inline auto smpAssign( SparseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//      -> EnableIf_t< UseSMPAssign_v<VT1> >
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE  ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      const ResultType tmp( rhs );
+//      smpAssign( ~lhs, tmp );
+//   }
+//   //**********************************************************************************************
+//
+//   //**SMP addition assignment to dense vectors****************************************************
+//   /*!\brief SMP addition assignment of a scaled dense tensor-dense vector multiplication to a
+//   //        dense vector (\f$ \vec{y}+=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be added.
+//   // \return void
+//   //
+//   // This function implements the performance optimized SMP addition assignment of a scaled
+//   // dense tensor-dense vector multiplication expression to a dense vector. Due to the explicit
+//   // application of the SFINAE principle, this function can only be selected by the compiler in
+//   // case the expression specific parallel evaluation strategy is selected.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline auto smpAddAssign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//      -> EnableIf_t< UseSMPAssign_v<VT1> >
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      LeftOperand_t<MVM>  left ( rhs.vector_.leftOperand()  );
+//      RightOperand_t<MVM> right( rhs.vector_.rightOperand() );
+//
+//      if( left.rows() == 0UL || left.columns() == 0UL ) {
+//         return;
+//      }
+//
+//      LT A( left  );  // Evaluation of the left-hand side dense tensor operand
+//      RT x( right );  // Evaluation of the right-hand side dense vector operand
+//
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()   , "Invalid number of rows"    );
+//      BLAZE_INTERNAL_ASSERT( A.columns() == left.columns(), "Invalid number of columns" );
+//      BLAZE_INTERNAL_ASSERT( x.size()    == right.size()  , "Invalid vector size"       );
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).size() , "Invalid vector size"       );
+//
+//      smpAddAssign( ~lhs, A * x * rhs.scalar_ );
+//   }
+//   //**********************************************************************************************
+//
+//   //**SMP addition assignment to sparse vectors***************************************************
+//   // No special implementation for the SMP addition assignment to sparse vectors.
+//   //**********************************************************************************************
+//
+//   //**SMP subtraction assignment to dense vectors*************************************************
+//   /*!\brief SMP subtraction assignment of a scaled dense tensor-dense vector multiplication to a
+//   //        dense vector (\f$ \vec{y}-=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be subtracted.
+//   // \return void
+//   //
+//   // This function implements the performance optimized SMP subtraction assignment of a scaled
+//   // dense tensor-dense vector multiplication expression to a dense vector. Due to the explicit
+//   // application of the SFINAE principle, this function can only be selected by the compiler in
+//   // case the expression specific parallel evaluation strategy is selected.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline auto smpSubAssign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//      -> EnableIf_t< UseSMPAssign_v<VT1> >
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      LeftOperand_t<MVM>  left ( rhs.vector_.leftOperand()  );
+//      RightOperand_t<MVM> right( rhs.vector_.rightOperand() );
+//
+//      if( left.rows() == 0UL || left.columns() == 0UL ) {
+//         return;
+//      }
+//
+//      LT A( left  );  // Evaluation of the left-hand side dense tensor operand
+//      RT x( right );  // Evaluation of the right-hand side dense vector operand
+//
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()   , "Invalid number of rows"    );
+//      BLAZE_INTERNAL_ASSERT( A.columns() == left.columns(), "Invalid number of columns" );
+//      BLAZE_INTERNAL_ASSERT( x.size()    == right.size()  , "Invalid vector size"       );
+//      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).size() , "Invalid vector size"       );
+//
+//      smpSubAssign( ~lhs, A * x * rhs.scalar_ );
+//   }
+//   //**********************************************************************************************
+//
+//   //**SMP subtraction assignment to sparse vectors************************************************
+//   // No special implementation for the SMP subtraction assignment to sparse vectors.
+//   //**********************************************************************************************
+//
+//   //**SMP multiplication assignment to dense vectors**********************************************
+//   /*!\brief SMP multiplication assignment of a scaled dense tensor-dense vector multiplication
+//   //        to a dense vector (\f$ \vec{y}*=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression to be multiplied.
+//   // \return void
+//   //
+//   // This function implements the performance optimized SMP multiplication assignment of a scaled
+//   // dense tensor-dense vector multiplication expression to a dense vector. Due to the explicit
+//   // application of the SFINAE principle, this function can only be selected by the compiler in
+//   // case the expression specific parallel evaluation strategy is selected.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline auto smpMultAssign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//      -> EnableIf_t< UseSMPAssign_v<VT1> >
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE  ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      const ResultType tmp( rhs );
+//      smpMultAssign( ~lhs, tmp );
+//   }
+//   //**********************************************************************************************
+//
+//   //**SMP multiplication assignment to sparse vectors*********************************************
+//   // No special implementation for the SMP multiplication assignment to sparse vectors.
+//   //**********************************************************************************************
+//
+//   //**SMP division assignment to dense vectors****************************************************
+//   /*!\brief SMP division assignment of a scaled dense tensor-dense vector multiplication to a
+//   //        dense vector (\f$ \vec{y}/=s*A*\vec{x} \f$).
+//   // \ingroup dense_vector
+//   //
+//   // \param lhs The target left-hand side dense vector.
+//   // \param rhs The right-hand side scaled multiplication expression division.
+//   // \return void
+//   //
+//   // This function implements the performance optimized SMP division assignment of a scaled
+//   // dense tensor-dense vector multiplication expression to a dense vector. Due to the explicit
+//   // application of the SFINAE principle, this function can only be selected by the compiler in
+//   // case the expression specific parallel evaluation strategy is selected.
+//   */
+//   template< typename VT1 >  // Type of the target dense vector
+//   friend inline auto smpDivAssign( DenseVector<VT1,false>& lhs, const DVecScalarMultExpr& rhs )
+//      -> EnableIf_t< UseSMPAssign_v<VT1> >
+//   {
+//      BLAZE_FUNCTION_TRACE;
+//
+//      BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE  ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE ( ResultType );
+//      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
+//
+//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//
+//      const ResultType tmp( rhs );
+//      smpDivAssign( ~lhs, tmp );
+//   }
+//   //**********************************************************************************************
+//
+//   //**SMP division assignment to sparse vectors***************************************************
+//   // No special implementation for the SMP division assignment to sparse vectors.
+//   //**********************************************************************************************
+//
+//   //**Compile time checks*************************************************************************
+//   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE ( MVM );
+//   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( MVM );
+//   BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE ( TT );
+//   BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( TT );
+//   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE ( VT );
+//   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( VT );
+//   BLAZE_CONSTRAINT_MUST_BE_NUMERIC_TYPE( ST );
+//   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( ST, RightOperand );
+//   //**********************************************************************************************
+//};
+///*! \endcond */
+////*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  GLOBAL BINARY ARITHTETIC OPERATORS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Multiplication operator for the multiplication of a row-major dense tensor and a dense
+//        vector (\f$ \vec{y}=A*\vec{x} \f$).
+// \ingroup dense_vector
+//
+// \param tens The left-hand side row-major dense tensor for the multiplication.
+// \param vec The right-hand side dense vector for the multiplication.
+// \return The resulting vector.
+// \exception std::invalid_argument Tensor and vector sizes do not tensch.
+//
+// This operator represents the multiplication between a row-major dense tensor and a dense vector:
+
+   \code
+   using blaze::rowMajor;
+   using blaze::columnVector;
+
+   blaze::DynamicTensor<double,rowMajor> A;
+   blaze::DynamicVector<double,columnVector> x, y;
+   // ... Resizing and initialization
+   y = A * x;
+   \endcode
+
+// The operator returns an expression representing a dense vector of the higher-order element
+// type of the two involved element types \a TT::ElementType and \a VT::ElementType. Both the
+// dense tensor type \a TT and the dense vector type \a VT as well as the two element types
+// \a TT::ElementType and \a VT::ElementType have to be supported by the MultTrait class
+// template.\n
+// In case the current size of the vector \a vec doesn't tensch the current number of columns
+// of the tensor \a tens, a \a std::invalid_argument is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+inline decltype(auto)
+   operator*( const DenseTensor<TT>& tens, const DenseVector<VT,false>& vec )
+{
+   BLAZE_FUNCTION_TRACE;
+
+   //BLAZE_CONSTRAINT_MUST_NOT_BE_MATMATMULTEXPR_TYPE( TT );
+
+   if( (~tens).columns() != (~vec).size() ) {
+      BLAZE_THROW_INVALID_ARGUMENT( "Tensor and vector sizes do not match" );
+   }
+
+   using ReturnType = const DTensDVecMultExpr<TT,VT>;
+   return ReturnType( ~tens, ~vec );
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  GLOBAL RESTRUCTURING BINARY ARITHTETIC OPERATORS
+//
+//=================================================================================================
+
+////*************************************************************************************************
+///*! \cond BLAZE_INTERNAL */
+///*!\brief Multiplication operator for the multiplication of a tensor-matrix multiplication
+////        expression and a dense vector (\f$ \vec{y}=(A*B)*\vec{x} \f$).
+//// \ingroup dense_vector
+////
+//// \param tens The left-hand side dense tensor-tensor multiplication.
+//// \param vec The right-hand side dense vector for the multiplication.
+//// \return The resulting vector.
+////
+//// This operator implements a performance optimized treatment of the multiplication of a
+//// tensor-tensor multiplication expression and a dense vector. It restructures the expression
+//// \f$ \vec{x}=(A*B)*\vec{x} \f$ to the expression \f$ \vec{y}=A*(B*\vec{x}) \f$.
+//*/
+//template< typename TT    // Tensor base type of the left-hand side expression
+//        , typename VT >  // Type of the right-hand side dense vector
+//inline decltype(auto)
+//   operator*( const TensMatMultExpr<TT>& tens, const DenseVector<VT,false>& vec )
+//{
+//   BLAZE_FUNCTION_TRACE;
+//
+//   return (~tens).leftOperand() * ( (~tens).rightOperand() * vec );
+//}
+///*! \endcond */
+////*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  ISALIGNED SPECIALIZATIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+template< typename TT, typename VT >
+struct IsAligned< DTensDVecMultExpr<TT,VT> >
+   : public BoolConstant< IsAligned_v<TT> && IsAligned_v<VT> >
+{};
+/*! \endcond */
+//*************************************************************************************************
+
+} // namespace blaze
+
+#endif

--- a/blaze_tensor/math/expressions/DTensDVecMultExpr.h
+++ b/blaze_tensor/math/expressions/DTensDVecMultExpr.h
@@ -207,6 +207,7 @@ class DTensDVecMultExpr
    using BaseType      = DenseMatrix<This,false>;       //!< Base type of this DTensDVecMultExpr instance.
    using ResultType    = MultTrait_t<TRT,VRT>;         //!< Result type for expression template evaluations.
    using TransposeType = TransposeType_t<ResultType>;  //!< Transpose type for expression template evaluations.
+   using OppositeType  = OppositeType_t<ResultType>;   //!< Result type with opposite storage order for expression template evaluations.
    using ElementType   = ElementType_t<ResultType>;    //!< Resulting element type.
    using SIMDType      = SIMDTrait_t<ElementType>;     //!< Resulting SIMD element type.
    using ReturnType    = const ElementType;            //!< Return type for expression template evaluations.

--- a/blaze_tensor/math/expressions/Forward.h
+++ b/blaze_tensor/math/expressions/Forward.h
@@ -57,6 +57,7 @@ template< typename, typename > class DTensDTensAddExpr;
 template< typename, typename > class DTensDTensMultExpr;
 template< typename, typename > class DTensDTensSchurExpr;
 template< typename, typename > class DTensDTensSubExpr;
+template< typename, typename > class DTensDVecMultExpr;
 template< typename, typename > class DTensMapExpr;
 //template< typename > class DTensRavelExpr;
 template< typename, typename > class DTensScalarMultExpr;
@@ -77,6 +78,9 @@ decltype(auto) operator-( const DenseTensor<TT1>&, const DenseTensor<TT2>& );
 
 template< typename TT1, typename TT2 >
 decltype(auto) operator*( const DenseTensor<TT1>&, const DenseTensor<TT2>& );
+
+template< typename TT, typename VT >
+decltype(auto) operator*( const DenseTensor<TT>&, const DenseVector<VT,false>& );
 
 template< typename TT1, typename TT2 >
 decltype(auto) operator%( const DenseTensor<TT1>&, const DenseTensor<TT2>& );

--- a/blaze_tensor/math/expressions/TensVecMultExpr.h
+++ b/blaze_tensor/math/expressions/TensVecMultExpr.h
@@ -1,10 +1,11 @@
 //=================================================================================================
 /*!
-//  \file blaze_tensor/math/DenseMatrix.h
-//  \brief Header file for all basic DenseMatrix functionality
+//  \file blaze/math/expressions/MatVecMultExpr.h
+//  \brief Header file for the MatVecMultExpr base class
 //
-//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
-//  Copyright (C) 2018 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
 //  This file is part of the Blaze library. You can redistribute it and/or modify it under
 //  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
@@ -33,33 +34,43 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_DENSETENSOR_H_
-#define _BLAZE_TENSOR_MATH_DENSETENSOR_H_
+#ifndef _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
+#define _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
 
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/DenseMatrix.h>
+#include <blaze/math/expressions/MultExpr.h>
 
-#include <blaze_tensor/math/Tensor.h>
-#include <blaze_tensor/math/dense/DenseTensor.h>
-#include <blaze_tensor/math/expressions/DMatExpandExpr.h>
-#include <blaze_tensor/math/expressions/DMatRavelExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensAddExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensEqualExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensSchurExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensSubExpr.h>
-#include <blaze_tensor/math/expressions/DTensDVecMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensMapExpr.h>
-#include <blaze_tensor/math/expressions/DTensRavelExpr.h>
-#include <blaze_tensor/math/expressions/DTensScalarDivExpr.h>
-#include <blaze_tensor/math/expressions/DTensScalarMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensSerialExpr.h>
-#include <blaze_tensor/math/expressions/DTensTransExpr.h>
-#include <blaze_tensor/math/expressions/DenseTensor.h>
-#include <blaze_tensor/math/smp/DenseTensor.h>
+
+namespace blaze {
+
+//=================================================================================================
+//
+//  CLASS DEFINITION
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Base class for all matrix/vector multiplication expression templates.
+// \ingroup math
+//
+// The MatVecMultExpr class serves as a tag for all expression templates that implement a
+// matrix/vector multiplication. All classes, that represent a matrix/vector multiplication
+// and that are used within the expression template environment of the Blaze library have
+// to derive publicly from this class in order to qualify as matrix/vector multiplication
+// expression template. Only in case a class is derived publicly from the MatVecMultExpr
+// base class, the IsMatVecMultExpr type trait recognizes the class as valid matrix/vector
+// multiplication expression template.
+*/
+template< typename VT >  // Vector base type of the expression
+struct TensVecMultExpr
+   : public MultExpr<VT>
+{};
+//*************************************************************************************************
+
+} // namespace blaze
 
 #endif

--- a/blaze_tensor/math/expressions/Vector.h
+++ b/blaze_tensor/math/expressions/Vector.h
@@ -1,10 +1,11 @@
 //=================================================================================================
 /*!
-//  \file blaze_tensor/math/DenseMatrix.h
-//  \brief Header file for all basic DenseMatrix functionality
+//  \file blaze_tensor/math/expressions/Vector.h
+//  \brief Header file for the Vector CRTP base class
 //
-//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
-//  Copyright (C) 2018 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
 //  This file is part of the Blaze library. You can redistribute it and/or modify it under
 //  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
@@ -33,33 +34,21 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_DENSETENSOR_H_
-#define _BLAZE_TENSOR_MATH_DENSETENSOR_H_
+#ifndef _BLAZE_TENSOR_MATH_EXPRESSIONS_VECTOR_H_
+#define _BLAZE_TENSOR_MATH_EXPRESSIONS_VECTOR_H_
 
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/DenseMatrix.h>
+#include <blaze/math/expressions/Vector.h>
 
-#include <blaze_tensor/math/Tensor.h>
-#include <blaze_tensor/math/dense/DenseTensor.h>
-#include <blaze_tensor/math/expressions/DMatExpandExpr.h>
-#include <blaze_tensor/math/expressions/DMatRavelExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensAddExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensEqualExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensSchurExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensSubExpr.h>
-#include <blaze_tensor/math/expressions/DTensDVecMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensMapExpr.h>
-#include <blaze_tensor/math/expressions/DTensRavelExpr.h>
-#include <blaze_tensor/math/expressions/DTensScalarDivExpr.h>
-#include <blaze_tensor/math/expressions/DTensScalarMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensSerialExpr.h>
-#include <blaze_tensor/math/expressions/DTensTransExpr.h>
-#include <blaze_tensor/math/expressions/DenseTensor.h>
-#include <blaze_tensor/math/smp/DenseTensor.h>
+
+namespace blaze {
+
+
+
+} // namespace blaze
 
 #endif

--- a/blaze_tensor/math/traits/MultTrait.h
+++ b/blaze_tensor/math/traits/MultTrait.h
@@ -1,10 +1,11 @@
 //=================================================================================================
 /*!
-//  \file blaze_tensor/math/DenseMatrix.h
-//  \brief Header file for all basic DenseMatrix functionality
+//  \file blaze_tensor/math/traits/MultTrait.h
+//  \brief Header file for the multiplication trait
 //
-//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
-//  Copyright (C) 2018 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
 //  This file is part of the Blaze library. You can redistribute it and/or modify it under
 //  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
@@ -33,33 +34,17 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_DENSETENSOR_H_
-#define _BLAZE_TENSOR_MATH_DENSETENSOR_H_
+#ifndef _BLAZE_TENSOR_MATH_TRAITS_MULTTRAIT_H_
+#define _BLAZE_TENSOR_MATH_TRAITS_MULTTRAIT_H_
 
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/DenseMatrix.h>
 
-#include <blaze_tensor/math/Tensor.h>
-#include <blaze_tensor/math/dense/DenseTensor.h>
-#include <blaze_tensor/math/expressions/DMatExpandExpr.h>
-#include <blaze_tensor/math/expressions/DMatRavelExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensAddExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensEqualExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensSchurExpr.h>
-#include <blaze_tensor/math/expressions/DTensDTensSubExpr.h>
-#include <blaze_tensor/math/expressions/DTensDVecMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensMapExpr.h>
-#include <blaze_tensor/math/expressions/DTensRavelExpr.h>
-#include <blaze_tensor/math/expressions/DTensScalarDivExpr.h>
-#include <blaze_tensor/math/expressions/DTensScalarMultExpr.h>
-#include <blaze_tensor/math/expressions/DTensSerialExpr.h>
-#include <blaze_tensor/math/expressions/DTensTransExpr.h>
-#include <blaze_tensor/math/expressions/DenseTensor.h>
-#include <blaze_tensor/math/smp/DenseTensor.h>
+#include <blaze_tensor/math/typetraits/HasMult.h>
+#include <blaze/math/traits/MultTrait.h>
+
 
 #endif

--- a/blaze_tensor/math/typetraits/HasMult.h
+++ b/blaze_tensor/math/typetraits/HasMult.h
@@ -1,0 +1,169 @@
+//=================================================================================================
+/*!
+//  \file blaze_tensor/math/typetraits/HasMult.h
+//  \brief Header file for the HasMult type trait
+//
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
+//
+//  This file is part of the Blaze library. You can redistribute it and/or modify it under
+//  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
+//  forms, with or without modification, are permitted provided that the following conditions
+//  are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list
+//     of conditions and the following disclaimer in the documentation and/or other materials
+//     provided with the distribution.
+//  3. Neither the names of the Blaze development group nor the names of its contributors
+//     may be used to endorse or promote products derived from this software without specific
+//     prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+//  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+*/
+//=================================================================================================
+
+#ifndef _BLAZE_TENSOR_MATH_TYPETRAITS_HASMULT_H_
+#define _BLAZE_TENSOR_MATH_TYPETRAITS_HASMULT_H_
+
+
+//*************************************************************************************************
+// Includes
+//*************************************************************************************************
+
+#include <blaze/math/typetraits/HasMult.h>
+
+#include <blaze_tensor/math/typetraits/IsTensor.h>
+
+
+namespace blaze {
+
+//=================================================================================================
+//
+//  CLASS DEFINITION
+//
+//=================================================================================================
+
+////*************************************************************************************************
+///*! \cond BLAZE_INTERNAL */
+///*!\brief Auxiliary helper struct for the IsMultHelper type trait.
+//// \ingroup math_type_traits
+//*/
+//template< typename T1, typename T2, typename = void >
+//struct HasMultHelper
+//   : public FalseType
+//{};
+///*! \endcond */
+////*************************************************************************************************
+//
+//
+////*************************************************************************************************
+///*! \cond BLAZE_INTERNAL */
+///*!\brief Specialization of the HasMultHelper type trait for types providing a multiplication
+////        operator.
+//// \ingroup math_type_traits
+//*/
+//template< typename T1, typename T2 >
+//struct HasMultHelper< T1, T2, Void_t< decltype( std::declval<T1>() * std::declval<T2>() ) > >
+//   : public TrueType
+//{};
+///*! \endcond */
+////*************************************************************************************************
+//
+//
+////*************************************************************************************************
+///*!\brief Availability of a multiplication operator for the given data types.
+//// \ingroup math_type_traits
+////
+//// This type trait provides the information whether a multiplication operator (i.e. operator*)
+//// exists for the two given data types \a T1 and \a T2 (taking the cv-qualifiers into account).
+//// In case the operator is available, the \a value member constant is set to \a true, the nested
+//// type definition \a Type is \a TrueType, and the class derives from \a TrueType. Otherwise
+//// \a value is set to \a false, \a Type is \a FalseType, and the class derives from \a FalseType.
+//
+//   \code
+//   blaze::HasMult< int, int >::value                         // Evaluates to 1
+//   blaze::HasMult< complex<float>, complex<float> >::Type    // Results in TrueType
+//   blaze::HasMult< DynamicVector<int>, DynamicVector<int> >  // Is derived from TrueType
+//   blaze::HasMult< int, complex<float> >::value              // Evaluates to 0
+//   blaze::HasMult< complex<int>, complex<float> >::Type      // Results in FalseType
+//   blaze::HasMult< DynamicMatrix<int>, DynamicVector<int> >  // Is derived from FalseType
+//   \endcode
+//*/
+//template< typename T1, typename T2, typename = void >
+//struct HasMult
+//   : public HasMultHelper<T1,T2>
+//{};
+////*************************************************************************************************
+
+
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+/*!\brief Specialization of the HasMult type trait for tensor/vector multiplications.
+// \ingroup math_type_traits
+*/
+template< typename T1, typename T2 >
+struct HasMult< T1, T2, EnableIf_t< IsTensor_v<T1> && IsVector_v<T2> > >
+   : public HasMult< typename T1::ElementType, typename T2::ElementType >
+{};
+/*! \endcond */
+//*************************************************************************************************
+
+//
+////*************************************************************************************************
+///*! \cond BLAZE_INTERNAL */
+///*!\brief Specialization of the HasMult type trait for vector/matrix multiplications.
+//// \ingroup math_type_traits
+//*/
+//template< typename T1, typename T2 >
+//struct HasMult< T1, T2, EnableIf_t< IsVector_v<T1> && IsMatrix_v<T2> > >
+//   : public HasMult< typename T1::ElementType, typename T2::ElementType >
+//{};
+///*! \endcond */
+////*************************************************************************************************
+//
+//
+////*************************************************************************************************
+///*! \cond BLAZE_INTERNAL */
+///*!\brief Specialization of the HasMult type trait for matrix/matrix multiplications.
+//// \ingroup math_type_traits
+//*/
+//template< typename T1, typename T2 >
+//struct HasMult< T1, T2, EnableIf_t< IsMatrix_v<T1> && IsMatrix_v<T2> > >
+//   : public HasMult< typename T1::ElementType, typename T2::ElementType >
+//{};
+///*! \endcond */
+////*************************************************************************************************
+
+
+////*************************************************************************************************
+///*!\brief Auxiliary variable template for the HasMult type trait.
+//// \ingroup type_traits
+////
+//// The HasMult_v variable template provides a convenient shortcut to access the nested \a value
+//// of the HasMult class template. For instance, given the types \a T1 and \a T2 the following
+//// two statements are identical:
+//
+//   \code
+//   constexpr bool value1 = blaze::HasMult<T1,T2>::value;
+//   constexpr bool value2 = blaze::HasMult_v<T1,T2>;
+//   \endcode
+//*/
+//template< typename T1, typename T2 >
+//constexpr bool HasMult_v = HasMult<T1,T2>::value;
+////*************************************************************************************************
+
+} // namespace blaze
+
+#endif

--- a/blaze_tensor/math/typetraits/IsTensVecMultExpr.h
+++ b/blaze_tensor/math/typetraits/IsTensVecMultExpr.h
@@ -1,9 +1,11 @@
 //=================================================================================================
 /*!
-//  \file blaze/math/typetraits/IsMatVecMultExpr.h
-//  \brief Header file for the IsMatVecMultExpr type trait class
+//  \file blaze_tensor/math/typetraits/IsTensVecMultExpr.h
+//  \brief Header file for the IsTensVecMultExpr type trait class
 //
 //  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
 //  This file is part of the Blaze library. You can redistribute it and/or modify it under
 //  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
@@ -41,6 +43,7 @@
 //*************************************************************************************************
 
 #include <blaze_tensor/math/expressions/TensVecMultExpr.h>
+#include <blaze_tensor/math/expressions/TensTransExpr.h>
 #include <blaze/util/FalseType.h>
 #include <blaze/util/TrueType.h>
 
@@ -68,8 +71,8 @@ struct IsTensVecMultExprHelper
    template< typename VT >
    static TrueType test( const TensVecMultExpr<VT>* );
 
-   //template< typename TT >
-   //static TrueType test( const volatile TensTransExpr<TT>* );
+   template< typename TT >
+   static TrueType test( const volatile TensTransExpr<TT>* );
 
    static FalseType test( ... );
    //**********************************************************************************************

--- a/blaze_tensor/math/views/PageSlice.h
+++ b/blaze_tensor/math/views/PageSlice.h
@@ -59,6 +59,7 @@
 #include <blaze_tensor/math/expressions/TensTensMultExpr.h>
 #include <blaze_tensor/math/expressions/TensTensSubExpr.h>
 #include <blaze_tensor/math/expressions/TensTransExpr.h>
+#include <blaze_tensor/math/expressions/TensVecMultExpr.h>
 #include <blaze_tensor/math/expressions/Tensor.h>
 #include <blaze_tensor/math/views/Forward.h>
 #include <blaze_tensor/math/views/pageslice/BaseTemplate.h>
@@ -743,6 +744,38 @@ inline decltype(auto) pageslice( const MatExpandExpr<MT,CEAs...>& tensor, RSAs..
 /*! \endcond */
 //*************************************************************************************************
 
+
+
+
+//=================================================================================================
+//
+//  GLOBAL RESTRUCTURING FUNCTIONS (ROW)
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+/*!\brief Creating a view on a selection of row of the given tensor/vector multiplication.
+// \ingroup pageslice
+//
+// \param matrix The constant tensor/vector multiplication.
+// \param args The runtime element arguments.
+// \return View on the specified row of the multiplication.
+//
+// This function returns an expression representing the specified elements of the given
+// matrix/vector multiplication.
+*/
+template< size_t... CEAs      // Compile time element arguments
+        , typename MT         // Matrix base type of the expression
+        , typename... REAs >  // Runtime element arguments
+inline decltype(auto) row( const TensVecMultExpr<MT>& matrix, REAs... args )
+{
+   BLAZE_FUNCTION_TRACE;
+
+   return trans(pageslice<CEAs...>( (~matrix).leftOperand(), args... ) * (~matrix).rightOperand());
+}
+/*! \endcond */
+//*************************************************************************************************
 
 
 

--- a/blaze_tensor/math/views/RowSlice.h
+++ b/blaze_tensor/math/views/RowSlice.h
@@ -59,6 +59,7 @@
 #include <blaze_tensor/math/expressions/TensTensMultExpr.h>
 #include <blaze_tensor/math/expressions/TensTensSubExpr.h>
 #include <blaze_tensor/math/expressions/TensTransExpr.h>
+#include <blaze_tensor/math/expressions/TensVecMultExpr.h>
 #include <blaze_tensor/math/expressions/Tensor.h>
 #include <blaze_tensor/math/views/Forward.h>
 #include <blaze_tensor/math/views/rowslice/BaseTemplate.h>
@@ -738,6 +739,38 @@ inline decltype(auto) rowslice( const MatExpandExpr<TT,CEAs...>& tensor, CSAs...
    MAYBE_UNUSED( args... );
 
    return expand( trans( row( (~tensor).operand(), 0UL ) ), (~tensor).expansion() );
+}
+/*! \endcond */
+//*************************************************************************************************
+
+
+
+//=================================================================================================
+//
+//  GLOBAL RESTRUCTURING FUNCTIONS (COLUMN)
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+/*!\brief Creating a view on a selection of column of the given tensor/vector multiplication.
+// \ingroup rowslice
+//
+// \param matrix The constant tensor/vector multiplication.
+// \param args The runtime element arguments.
+// \return View on the specified row of the multiplication.
+//
+// This function returns an expression representing the specified elements of the given
+// matrix/vector multiplication.
+*/
+template< size_t... CEAs      // Compile time element arguments
+        , typename MT         // Matrix base type of the expression
+        , typename... REAs >  // Runtime element arguments
+inline decltype(auto) column( const TensVecMultExpr<MT>& matrix, REAs... args )
+{
+   BLAZE_FUNCTION_TRACE;
+
+   return trans(rowslice<CEAs...>( (~matrix).leftOperand(), args... )) * (~matrix).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/views/Subtensor.h
+++ b/blaze_tensor/math/views/Subtensor.h
@@ -88,6 +88,7 @@
 #include <blaze_tensor/math/expressions/MatExpandExpr.h>
 #include <blaze_tensor/math/expressions/TensEvalExpr.h>
 #include <blaze_tensor/math/expressions/TensMapExpr.h>
+#include <blaze_tensor/math/expressions/Tensor.h>
 #include <blaze_tensor/math/expressions/TensReduceExpr.h>
 #include <blaze_tensor/math/expressions/TensScalarDivExpr.h>
 #include <blaze_tensor/math/expressions/TensScalarMultExpr.h>
@@ -96,6 +97,8 @@
 #include <blaze_tensor/math/expressions/TensTensMultExpr.h>
 #include <blaze_tensor/math/expressions/TensTensSubExpr.h>
 #include <blaze_tensor/math/expressions/TensTransExpr.h>
+#include <blaze_tensor/math/expressions/TensVecMultExpr.h>
+//#include <blaze_tensor/math/expressions/TVecTensMultExpr.h>
 #include <blaze_tensor/math/views/columnslice/ColumnSliceData.h>
 #include <blaze_tensor/math/views/pageslice/PageSliceData.h>
 #include <blaze_tensor/math/views/rowslice/RowSliceData.h>
@@ -1696,13 +1699,13 @@ inline decltype(auto)
 
 //=================================================================================================
 //
-//  GLOBAL RESTRUCTURING FUNCTIONS (SUBVECTOR)
+//  GLOBAL RESTRUCTURING FUNCTIONS (SUBVECTOR/SUBMATRIX)
 //
 //=================================================================================================
 
 //*************************************************************************************************
 /*! \cond BLAZE_INTERNAL */
-/*!\brief Creating a view on a specific subvector of the given tensor/vector multiplication.
+/*!\brief Creating a view on a specific submatrix of the given tensor/vector multiplication.
 // \ingroup subtensor
 //
 // \param vector The constant tensor/vector multiplication.
@@ -1712,34 +1715,26 @@ inline decltype(auto)
 // This function returns an expression representing the specified subvector of the given
 // tensor/vector multiplication.
 */
-// template< AlignmentFlag AF    // Alignment flag
-//         , size_t... CSAs      // Compile time subvector arguments
-//         , typename VT         // Vector base type of the expression
-//         , typename... RSAs >  // Runtime subvector arguments
-// inline decltype(auto) subvector( const MatVecMultExpr<VT>& vector, RSAs... args )
-// {
-//    BLAZE_FUNCTION_TRACE;
-//
-//    using TT = RemoveReference_t< LeftOperand_t< VectorType_t<VT> > >;
-//
-//    const SubvectorData<CSAs...> sd( args... );
-//
-//    BLAZE_DECLTYPE_AUTO( left , (~vector).leftOperand()  );
-//    BLAZE_DECLTYPE_AUTO( right, (~vector).rightOperand() );
-//
-//    const size_t column( ( IsUpper_v<TT> )
-//                         ?( ( !AF && IsStrictlyUpper_v<TT> )?( sd.offset() + 1UL ):( sd.offset() ) )
-//                         :( 0UL ) );
-//    const size_t n( ( IsLower_v<TT> )
-//                    ?( ( IsUpper_v<TT> )?( sd.size() )
-//                                        :( ( IsStrictlyLower_v<TT> && sd.size() > 0UL )
-//                                           ?( sd.offset() + sd.size() - 1UL )
-//                                           :( sd.offset() + sd.size() ) ) )
-//                    :( ( IsUpper_v<TT> )?( left.columns() - column )
-//                                        :( left.columns() ) ) );
-//
-//    return subtensor<AF>( left, sd.offset(), column, sd.size(), n ) * subvector<AF>( right, column, n );
-// }
+ template< AlignmentFlag AF    // Alignment flag
+         , size_t... CSAs      // Compile time submatrix arguments
+         , typename MT         // Vector base type of the expression
+         , typename... RSAs >  // Runtime submatrix arguments
+ inline decltype(auto) submatrix( const TensVecMultExpr<MT>& matrix, RSAs... args )
+ {
+    BLAZE_FUNCTION_TRACE;
+
+    using TT = RemoveReference_t< LeftOperand_t< MatrixType_t<MT> > >;
+
+    const SubmatrixData<CSAs...> sm( args... );
+
+    BLAZE_DECLTYPE_AUTO( left , (~matrix).leftOperand()  );
+    BLAZE_DECLTYPE_AUTO( right, (~matrix).rightOperand() );
+
+    const size_t column( 0UL );
+    const size_t n( left.columns() );
+
+    return subtensor<AF>( left, sm.row(), sm.column(), column, sm.rows(), sm.columns(), n ) * subvector<AF>( right, column, n );
+ }
 /*! \endcond */
 //*************************************************************************************************
 

--- a/blaze_tensor/system/Thresholds.h
+++ b/blaze_tensor/system/Thresholds.h
@@ -1,7 +1,7 @@
 //=================================================================================================
 /*!
-//  \file blaze_tensor/math/dense/DynamicMatrix.h
-//  \brief Header file for the implementation of a dynamic MxN matrix
+//  \file blaze/system/Thresholds.h
+//  \brief Header file for the thresholds for matrix/vector and matrix/matrix multiplications
 //
 //  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
 //  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
@@ -34,120 +34,111 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_DENSE_DYNAMICMATRIX_H_
-#define _BLAZE_TENSOR_MATH_DENSE_DYNAMICMATRIX_H_
+#ifndef _BLAZE_TENSOR_SYSTEM_THRESHOLDS_H_
+#define _BLAZE_TENSOR_SYSTEM_THRESHOLDS_H_
 
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/dense/DynamicMatrix.h>
-#include <blaze/math/traits/ExpandTrait.h>
+#include <blaze/system/Debugging.h>
+#include <blaze/util/StaticAssert.h>
+#include <blaze/util/Types.h>
 
-#include <blaze_tensor/math/dense/Forward.h>
-#include <blaze_tensor/math/traits/DilatedSubmatrixTrait.h>
-#include <blaze_tensor/math/traits/MultTrait.h>
-#include <blaze_tensor/math/traits/RavelTrait.h>
+
+
+
+//=================================================================================================
+//
+//  THRESHOLDS
+//
+//=================================================================================================
+
+#include <blaze/config/Thresholds.h>
+#include <blaze_tensor/config/Thresholds.h>
+
+
 
 namespace blaze {
 
 //=================================================================================================
 //
-//  EXPANDTRAIT SPECIALIZATIONS
+//  BLAS THRESHOLDS
 //
 //=================================================================================================
 
 //*************************************************************************************************
-/*! \cond BLAZE_INTERNAL */
-template< typename T  // Type to be expanded
-        , size_t E >  // Compile time expansion
-struct ExpandTraitEval2< T, E
-                       , EnableIf_t< IsDenseMatrix_v<T> &&
-                                     ( ( E == inf ) ||
-                                       ( ( Size_v<T,0UL> == DefaultSize_v ) &&
-                                         ( MaxSize_v<T,0UL> == DefaultMaxSize_v ) &&
-                                         ( Size_v<T,1UL> == DefaultSize_v ) &&
-                                         ( MaxSize_v<T,1UL> == DefaultMaxSize_v ) ) ) > >
-{
-   using Type = DynamicTensor< ElementType_t<T> >;
-};
-/*! \endcond */
+/*!\brief Row-major dense matrix/dense vector multiplication threshold.
+// \ingroup config
+//
+// This debug value is used instead of the BLAZE_DTENSDVECMULT_THRESHOLD while the Blaze debug
+// mode is active. It specifies the threshold between the application of the custom Blaze kernels
+// and the BLAS kernels for the row-major dense matrix/dense vector multiplication. In case the
+// number of elements in the dense matrix is equal or higher than this value, the BLAS kernels
+// are preferred over the custom Blaze kernels. In case the number of elements in the dense
+// matrix is smaller, the Blaze kernels are used.
+*/
+constexpr size_t DTENSDVECMULT_DEBUG_THRESHOLD = 256UL;
 //*************************************************************************************************
-
-
 
 
 //*************************************************************************************************
 /*! \cond BLAZE_INTERNAL */
-template< typename T > // Type to be expanded
-struct RavelTraitEval2< T
-                       , EnableIf_t< IsDenseMatrix_v<T> &&
-                                     ( ( ( Size_v<T,0UL> == DefaultSize_v ) &&
-                                         ( MaxSize_v<T,0UL> == DefaultMaxSize_v ) &&
-                                         ( Size_v<T,1UL> == DefaultSize_v ) &&
-                                         ( MaxSize_v<T,1UL> == DefaultMaxSize_v ) ) ) > >
-{
-   using Type = DynamicVector< ElementType_t<T>, rowVector >;
-};
+constexpr size_t DTENSDVECMULT_THRESHOLD  = ( BLAZE_DEBUG_MODE ? DTENSDVECMULT_DEBUG_THRESHOLD  : BLAZE_DTENSDVECMULT_THRESHOLD  );
+
 /*! \endcond */
 //*************************************************************************************************
 
 
 //=================================================================================================
 //
-//  DILATEDSUBMATRIXTRAIT SPECIALIZATIONS
+//  SMP THRESHOLDS
 //
 //=================================================================================================
+
+
+//*************************************************************************************************
+/*!\brief SMP row-major dense matrix/dense vector multiplication threshold.
+// \ingroup config
+//
+// This debug value is used instead of the BLAZE_SMP_DTENSDVECMULT_THRESHOLD while the Blaze
+// debug mode is active. It specifies when a row-major dense matrix/dense vector multiplication
+// can be executed in parallel. In case the number of elements of the target vector is larger or
+// equal to this threshold, the operation is executed in parallel. If the number of elements is
+// below this threshold the operation is executed single-threaded.
+*/
+constexpr size_t SMP_DTENSDVECMULT_DEBUG_THRESHOLD = 16UL;
+//*************************************************************************************************
+
 
 //*************************************************************************************************
 /*! \cond BLAZE_INTERNAL */
-template< typename MT >
-struct DilatedSubmatrixTraitEval2< MT, inf, inf, inf, inf, inf, inf
-                          , EnableIf_t< IsDenseMatrix_v<MT> &&
-                                        ( Size_v<MT,0UL> == DefaultSize_v ||
-                                          Size_v<MT,1UL> == DefaultSize_v ) &&
-                                        ( MaxSize_v<MT,0UL> == DefaultMaxSize_v ||
-                                          MaxSize_v<MT,1UL> == DefaultMaxSize_v ) > >
-{
-   using Type = DynamicMatrix< RemoveConst_t< ElementType_t<MT> >, StorageOrder_v<MT> >;
-};
+constexpr size_t SMP_DTENSDVECMULT_THRESHOLD  = ( BLAZE_DEBUG_MODE ? SMP_DTENSDVECMULT_DEBUG_THRESHOLD  : BLAZE_SMP_DTENSDVECMULT_THRESHOLD  );
 /*! \endcond */
 //*************************************************************************************************
-
-
-
-
-//=================================================================================================
-//
-//  MULTTRAIT SPECIALIZATIONS
-//
-//=================================================================================================
-
-//*************************************************************************************************
-/*! \cond BLAZE_INTERNAL */
-template< typename T1, typename T2 >
-struct MultTraitEval2< T1, T2
-                     , EnableIf_t< IsTensor_v<T1> &&
-                                   IsColumnVector_v<T2> &&
-                                   ( IsDenseTensor_v<T1> || IsDenseVector_v<T2> ) &&
-                                   ( Size_v<T1,0UL> == DefaultSize_v &&
-                                     Size_v<T2,0UL> == DefaultSize_v ) &&
-                                   ( MaxSize_v<T1,0UL> == DefaultMaxSize_v &&
-                                     MaxSize_v<T2,0UL> == DefaultMaxSize_v ) /*&&
-                                   ( Size_v<T1,1UL> == DefaultSize_v ) &&
-                                   ( MaxSize_v<T1,1UL> == DefaultMaxSize_v )*/> >
-{
-   using ET1 = ElementType_t<T1>;
-   using ET2 = ElementType_t<T2>;
-
-   using Type = DynamicMatrix< MultTrait_t<ET1,ET2>, true >;
-};
-
-/*! \endcond */
-//*************************************************************************************************
-
 
 } // namespace blaze
+
+
+
+
+//=================================================================================================
+//
+//  COMPILE TIME CONSTRAINT
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+namespace {
+
+BLAZE_STATIC_ASSERT( blaze::DTENSDVECMULT_THRESHOLD  > 0UL );
+
+BLAZE_STATIC_ASSERT( blaze::SMP_DTENSDVECMULT_THRESHOLD  >= 0UL );
+
+}
+/*! \endcond */
+//*************************************************************************************************
 
 #endif

--- a/blazetest/blazetest/mathtest/dtensdvecmult/AliasingTest.h
+++ b/blazetest/blazetest/mathtest/dtensdvecmult/AliasingTest.h
@@ -1,0 +1,216 @@
+//=================================================================================================
+/*!
+//  \file blazetest/mathtest/dtensdvecmult/AliasingTest.h
+//  \brief Header file for the dense matrix/dense vector multiplication aliasing test
+//
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
+//
+//  This file is part of the Blaze library. You can redistribute it and/or modify it under
+//  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
+//  forms, with or without modification, are permitted provided that the following conditions
+//  are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list
+//     of conditions and the following disclaimer in the documentation and/or other materials
+//     provided with the distribution.
+//  3. Neither the names of the Blaze development group nor the names of its contributors
+//     may be used to endorse or promote products derived from this software without specific
+//     prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+//  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+*/
+//=================================================================================================
+
+#ifndef _BLAZETEST_MATHTEST_DTENSDVECMULT_ALIASINGTEST_H_
+#define _BLAZETEST_MATHTEST_DTENSDVECMULT_ALIASINGTEST_H_
+
+
+//*************************************************************************************************
+// Includes
+//*************************************************************************************************
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <blaze/math/CompressedVector.h>
+#include <blaze/math/DynamicMatrix.h>
+#include <blaze/math/DynamicVector.h>
+#include <blaze/math/StaticMatrix.h>
+#include <blaze/math/StaticVector.h>
+
+#include <blaze_tensor/math/DynamicTensor.h>
+
+
+namespace blazetest {
+
+namespace mathtest {
+
+namespace dtensdvecmult {
+
+//=================================================================================================
+//
+//  CLASS DEFINITION
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Auxiliary class template for the dense matrix/dense vector multiplication aliasing test.
+//
+// This class represents a test suite for all dense matrix/dense vector multiplication aliasing
+// tests. It performs a series of runtime tests to assure that all mathematical operations work
+// correctly even in the presence of aliasing.
+*/
+class AliasingTest
+{
+ private:
+   //**Type definitions****************************************************************************
+   using DVec  = blaze::DynamicVector<int,blaze::columnVector>;      //!< Dense column vector type.
+   using DTens = blaze::DynamicTensor<int>;                          //!< Dense tensor type.
+   using RMat  = blaze::StaticMatrix<int,2UL,3UL,blaze::columnMajor>;//!< Result column major matrix type.
+   //**********************************************************************************************
+
+ public:
+   //**Constructors********************************************************************************
+   /*!\name Constructors */
+   //@{
+   explicit AliasingTest();
+   // No explicitly declared copy constructor.
+   //@}
+   //**********************************************************************************************
+
+   //**Destructor**********************************************************************************
+   // No explicitly declared destructor.
+   //**********************************************************************************************
+
+ private:
+   //**Test functions******************************************************************************
+   /*!\name Test functions */
+   //@{
+   void testDTensDVecMult ();
+
+   template< typename T1, typename T2 >
+   void checkResult( const T1& computedResult, const T2& expectedResult );
+   //@}
+   //**********************************************************************************************
+
+   //**Utility functions***************************************************************************
+   /*!\name Utility functions */
+   //@{
+   void initialize();
+   //@}
+   //**********************************************************************************************
+
+   //**Member variables****************************************************************************
+   /*!\name Member variables */
+   //@{
+   DTens dA2x3x4_;
+   DTens dB2x4x3_;
+   DVec da4_;
+   DVec db4_;
+   DVec dc3_;
+   DVec dd3_;
+   DVec de3_;
+   RMat result_;
+
+   std::string test_;  //!< Label of the currently performed test.
+   //@}
+   //**********************************************************************************************
+};
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  TEST FUNCTIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Checking and comparing the computed result.
+//
+// \param computedResult The computed result.
+// \param expectedResult The expected result.
+// \return void
+// \exception std::runtime_error Incorrect result detected.
+//
+// This function is called after each test case to check and compare the computed result.
+// In case the computed and the expected result differ in any way, a \a std::runtime_error
+// exception is thrown.
+*/
+template< typename T1    // Matrix type of the computed result
+        , typename T2 >  // Matrix type of the expected result
+void AliasingTest::checkResult( const T1& computedResult, const T2& expectedResult )
+{
+   if( computedResult != expectedResult ) {
+      std::ostringstream oss;
+      oss.precision( 20 );
+      oss << " Test : " << test_ << "\n"
+          << " Error: Incorrect result detected\n"
+          << " Details:\n"
+          << "   Computed result:\n" << computedResult << "\n"
+          << "   Expected result:\n" << expectedResult << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  GLOBAL TEST FUNCTIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Testing the dense matrix/dense vector multiplication in the presence of aliasing.
+//
+// \return void
+*/
+void runTest()
+{
+   AliasingTest();
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  MACRO DEFINITIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+/*!\brief Macro for the execution of the dense matrix/dense vector multiplication aliasing test.
+*/
+#define RUN_DTENSDVECMULT_ALIASING_TEST \
+   blazetest::mathtest::dtensdvecmult::runTest()
+/*! \endcond */
+//*************************************************************************************************
+
+} // namespace dtensdvecmult
+
+} // namespace mathtest
+
+} // namespace blazetest
+
+#endif

--- a/blazetest/blazetest/mathtest/dtensdvecmult/AliasingTest.h
+++ b/blazetest/blazetest/mathtest/dtensdvecmult/AliasingTest.h
@@ -79,7 +79,7 @@ class AliasingTest
    //**Type definitions****************************************************************************
    using DVec  = blaze::DynamicVector<int,blaze::columnVector>;      //!< Dense column vector type.
    using DTens = blaze::DynamicTensor<int>;                          //!< Dense tensor type.
-   using RMat  = blaze::StaticMatrix<int,2UL,3UL,blaze::columnMajor>;//!< Result column major matrix type.
+   using RVec  = blaze::StaticVector<int,3UL,blaze::columnVector>;   //!< Result column vector type.
    //**********************************************************************************************
 
  public:
@@ -116,14 +116,10 @@ class AliasingTest
    //**Member variables****************************************************************************
    /*!\name Member variables */
    //@{
-   DTens dA2x3x4_;
-   DTens dB2x4x3_;
-   DVec da4_;
-   DVec db4_;
+   DTens dB3x3x3_;
    DVec dc3_;
    DVec dd3_;
-   DVec de3_;
-   RMat result_;
+   RVec res_;
 
    std::string test_;  //!< Label of the currently performed test.
    //@}

--- a/blazetest/blazetest/mathtest/dtensdvecmult/OperationTest.h
+++ b/blazetest/blazetest/mathtest/dtensdvecmult/OperationTest.h
@@ -1,0 +1,5088 @@
+//=================================================================================================
+/*!
+//  \file blazetest/mathtest/dtensdvecmult/OperationTest.h
+//  \brief Header file for the dense tensor/dense vector multiplication operation test
+//
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
+//
+//  This file is part of the Blaze library. You can redistribute it and/or modify it under
+//  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
+//  forms, with or without modification, are permitted provided that the following conditions
+//  are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list
+//     of conditions and the following disclaimer in the documentation and/or other tenserials
+//     provided with the distribution.
+//  3. Neither the names of the Blaze development group nor the names of its contributors
+//     may be used to endorse or promote products derived from this software without specific
+//     prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+//  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+*/
+//=================================================================================================
+
+#ifndef _BLAZETEST_MATHTEST_DTENSDVECMULT_OPERATIONTEST_H_
+#define _BLAZETEST_MATHTEST_DTENSDVECMULT_OPERATIONTEST_H_
+
+
+//*************************************************************************************************
+// Includes
+//*************************************************************************************************
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <typeinfo>
+#include <vector>
+#include <blaze/math/Aliases.h>
+#include <blaze/math/CompressedTensor.h>
+#include <blaze/math/constraints/ColumnMajorTensor.h>
+#include <blaze/math/constraints/ColumnVector.h>
+#include <blaze/math/constraints/DenseTensor.h>
+#include <blaze/math/constraints/DenseVector.h>
+#include <blaze/math/constraints/RowMajorTensor.h>
+#include <blaze/math/constraints/RowVector.h>
+#include <blaze/math/constraints/SparseTensor.h>
+#include <blaze/math/constraints/SparseVector.h>
+#include <blaze/math/constraints/TransposeFlag.h>
+#include <blaze/math/DynamicTensor.h>
+#include <blaze/math/Functors.h>
+#include <blaze/math/shims/Equal.h>
+#include <blaze/math/shims/IsDivisor.h>
+#include <blaze/math/StaticTensor.h>
+#include <blaze/math/traits/MultTrait.h>
+#include <blaze/math/typetraits/IsRowMajorTensor.h>
+#include <blaze/math/typetraits/IsUniform.h>
+#include <blaze/math/typetraits/UnderlyingBuiltin.h>
+#include <blaze/math/typetraits/UnderlyingNumeric.h>
+#include <blaze/math/Views.h>
+#include <blaze/util/constraints/Numeric.h>
+#include <blaze/util/constraints/SameType.h>
+#include <blaze/util/FalseType.h>
+#include <blaze/util/mpl/Not.h>
+#include <blaze/util/Random.h>
+#include <blaze/util/TrueType.h>
+#include <blaze/util/typetraits/Decay.h>
+#include <blazetest/system/MathTest.h>
+#include <blazetest/mathtest/Creator.h>
+#include <blazetest/mathtest/IsEqual.h>
+#include <blazetest/mathtest/RandomMaximum.h>
+#include <blazetest/mathtest/RandomMinimum.h>
+
+
+namespace blazetest {
+
+namespace mathtest {
+
+namespace dtensdvecmult {
+
+//=================================================================================================
+//
+//  CLASS DEFINITION
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Auxiliary class template for the dense tensor/dense vector multiplication operation test.
+//
+// This class template represents one particular tensor/vector multiplication test between a
+// tensor and a vector of particular types. The two template arguments \a TT and \a VT represent
+// the types of the left-hand side tensor and right-hand side vector, respectively.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+class OperationTest
+{
+ private:
+   //**Type definitions****************************************************************************
+   using TET = blaze::ElementType_t<TT>;  //!< Element type of the tensor type
+   using VET = blaze::ElementType_t<VT>;  //!< Element type of the vector type
+
+   using OTT  = blaze::OppositeType_t<TT>;    //!< Tensor type with opposite storage order
+   using TTT  = blaze::TransposeType_t<TT>;   //!< Transpose tensor type
+   using TOTT = blaze::TransposeType_t<OTT>;  //!< Transpose tensor type with opposite storage order
+   using TVT  = blaze::TransposeType_t<VT>;   //!< Transpose vector type
+
+   //! Dense result type
+   using DRE = blaze::MultTrait_t<TT,VT>;
+
+   using DET  = blaze::ElementType_t<DRE>;    //!< Element type of the dense result
+   using TDRE = blaze::TransposeType_t<DRE>;  //!< Transpose dense result type
+
+   //! Sparse result type
+   using SRE = blaze::CompressedVector<DET,false>;
+
+   using SET  = blaze::ElementType_t<SRE>;    //!< Element type of the sparse result
+   using TSRE = blaze::TransposeType_t<SRE>;  //!< Transpose sparse result type
+
+   using TRT  = blaze::DynamicTensor<TET,false>;     //!< Tensor reference type
+   using VRT  = blaze::CompressedVector<VET,false>;  //!< Vector reference type
+   using RRE  = blaze::MultTrait_t<TRT,VRT>;         //!< Reference result type
+   using TRRE = blaze::TransposeType_t<RRE>;         //!< Transpose reference result type
+
+   //! Type of the tensor/vector multiplication expression
+   using MatVecMultExprType = blaze::Decay_t< decltype( std::declval<TT>() * std::declval<VT>() ) >;
+
+   //! Type of the transpose tensor/vector multiplication expression
+   using TMatVecMultExprType = blaze::Decay_t< decltype( std::declval<OTT>() * std::declval<VT>() ) >;
+   //**********************************************************************************************
+
+ public:
+   //**Constructors********************************************************************************
+   /*!\name Constructors */
+   //@{
+   explicit OperationTest( const Creator<TT>& creator1, const Creator<VT>& creator2 );
+   // No explicitly declared copy constructor.
+   //@}
+   //**********************************************************************************************
+
+   //**Destructor**********************************************************************************
+   // No explicitly declared destructor.
+   //**********************************************************************************************
+
+ private:
+   //**Test functions******************************************************************************
+   /*!\name Test functions */
+   //@{
+                          void testInitialStatus     ();
+                          void testAssignment        ();
+                          void testEvaluation        ();
+                          void testElementAccess     ();
+                          void testBasicOperation    ();
+                          void testNegatedOperation  ();
+   template< typename T > void testScaledOperation   ( T scalar );
+                          void testTransOperation    ();
+                          void testCTransOperation   ();
+                          void testAbsOperation      ();
+                          void testConjOperation     ();
+                          void testRealOperation     ();
+                          void testImagOperation     ();
+                          void testEvalOperation     ();
+                          void testSerialOperation   ();
+                          void testSubvectorOperation( blaze::TrueType  );
+                          void testSubvectorOperation( blaze::FalseType );
+                          void testElementsOperation ( blaze::TrueType  );
+                          void testElementsOperation ( blaze::FalseType );
+
+   template< typename OP > void testCustomOperation( OP op, const std::string& name );
+   //@}
+   //**********************************************************************************************
+
+   //**Error detection functions*******************************************************************
+   /*!\name Error detection functions */
+   //@{
+   template< typename LT > void checkResults();
+   template< typename LT > void checkTransposeResults();
+   //@}
+   //**********************************************************************************************
+
+   //**Utility functions***************************************************************************
+   /*!\name Utility functions */
+   //@{
+   void initResults();
+   void initTransposeResults();
+   template< typename LT > void convertException( const std::exception& ex );
+   //@}
+   //**********************************************************************************************
+
+   //**Member variables****************************************************************************
+   /*!\name Member variables */
+   //@{
+   TT   lhs_;      //!< The left-hand side dense tensor.
+   VT   rhs_;      //!< The right-hand side dense vector.
+   DRE  dres_;     //!< The dense result vector.
+   SRE  sres_;     //!< The sparse result vector.
+   TRT  reflhs_;   //!< The reference left-hand side tensor.
+   VRT  refrhs_;   //!< The reference right-hand side vector.
+   RRE  refres_;   //!< The reference result.
+   OTT  olhs_;     //!< The left-hand side dense tensor with opposite storage order.
+   TDRE tdres_;    //!< The transpose dense result vector.
+   TSRE tsres_;    //!< The transpose sparse result vector.
+   TRRE trefres_;  //!< The transpose reference result.
+
+   std::string test_;   //!< Label of the currently performed test.
+   std::string error_;  //!< Description of the current error type.
+   //@}
+   //**********************************************************************************************
+
+   //**Compile time checks*************************************************************************
+   /*! \cond BLAZE_INTERNAL */
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE ( TT   );
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE ( TTT  );
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE ( TOTT );
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE ( VT   );
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE ( TVT  );
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE ( TRT  );
+   BLAZE_CONSTRAINT_MUST_BE_SPARSE_VECTOR_TYPE( VRT  );
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE ( RRE  );
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE ( DRE  );
+   BLAZE_CONSTRAINT_MUST_BE_SPARSE_VECTOR_TYPE( SRE  );
+   BLAZE_CONSTRAINT_MUST_BE_DENSE_VECTOR_TYPE ( TDRE );
+   BLAZE_CONSTRAINT_MUST_BE_SPARSE_VECTOR_TYPE( TSRE );
+
+   BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE   ( TT   );
+   BLAZE_CONSTRAINT_MUST_BE_COLUMN_MAJOR_MATRIX_TYPE( TTT  );
+   BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE   ( TOTT );
+   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE      ( VT   );
+   BLAZE_CONSTRAINT_MUST_BE_ROW_VECTOR_TYPE         ( TVT  );
+   BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE   ( TRT  );
+   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE      ( VRT  );
+   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE      ( DRE  );
+   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE      ( SRE  );
+   BLAZE_CONSTRAINT_MUST_BE_ROW_VECTOR_TYPE         ( TDRE );
+   BLAZE_CONSTRAINT_MUST_BE_ROW_VECTOR_TYPE         ( TSRE );
+
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( TET, blaze::ElementType_t<OTT>    );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( TET, blaze::ElementType_t<TTT>    );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( TET, blaze::ElementType_t<TOTT>   );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( VET, blaze::ElementType_t<TVT>    );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( DET, blaze::ElementType_t<DRE>    );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( DET, blaze::ElementType_t<TDRE>   );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( DET, blaze::ElementType_t<SRE>    );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( SET, blaze::ElementType_t<SRE>    );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( SET, blaze::ElementType_t<TSRE>   );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( SET, blaze::ElementType_t<DRE>    );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( TT , blaze::OppositeType_t<OTT>   );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( TT , blaze::TransposeType_t<TTT>  );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( VT , blaze::TransposeType_t<TVT>  );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( DRE, blaze::TransposeType_t<TDRE> );
+   BLAZE_CONSTRAINT_MUST_BE_SAME_TYPE( SRE, blaze::TransposeType_t<TSRE> );
+
+   BLAZE_CONSTRAINT_VECTORS_MUST_HAVE_SAME_TRANSPOSE_FLAG     ( MatVecMultExprType, blaze::ResultType_t<MatVecMultExprType>    );
+   BLAZE_CONSTRAINT_VECTORS_MUST_HAVE_DIFFERENT_TRANSPOSE_FLAG( MatVecMultExprType, blaze::TransposeType_t<MatVecMultExprType> );
+
+   BLAZE_CONSTRAINT_VECTORS_MUST_HAVE_SAME_TRANSPOSE_FLAG     ( TMatVecMultExprType, blaze::ResultType_t<TMatVecMultExprType>    );
+   BLAZE_CONSTRAINT_VECTORS_MUST_HAVE_DIFFERENT_TRANSPOSE_FLAG( TMatVecMultExprType, blaze::TransposeType_t<TMatVecMultExprType> );
+   /*! \endcond */
+   //**********************************************************************************************
+};
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  CONSTRUCTORS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Constructor for the dense tensor/dense vector multiplication operation test.
+//
+// \param creator1 The creator for the left-hand side dense tensor of the multiplication.
+// \param creator2 The creator for the right-hand side dense vector of the multiplication.
+// \exception std::runtime_error Operation error detected.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+OperationTest<TT,VT>::OperationTest( const Creator<TT>& creator1, const Creator<VT>& creator2 )
+   : lhs_ ( creator1() )  // The left-hand side dense tensor
+   , rhs_ ( creator2() )  // The right-hand side dense vector
+   , dres_()              // The dense result vector
+   , sres_()              // The sparse result vector
+   , reflhs_( lhs_ )      // The reference left-hand side tensor
+   , refrhs_( rhs_ )      // The reference right-hand side vector
+   , refres_()            // The reference result
+   , olhs_( lhs_ )        // The left-hand side dense tensor with opposite storage order.
+   , tdres_()             // The transpose dense result vector.
+   , tsres_()             // The transpose sparse result vector.
+   , trefres_()           // The transpose reference result.
+   , test_()              // Label of the currently performed test
+   , error_()             // Description of the current error type
+{
+   using namespace blaze;
+
+   using Scalar = UnderlyingNumeric_t<DET>;
+
+   testInitialStatus();
+   testAssignment();
+   testEvaluation();
+   testElementAccess();
+   testBasicOperation();
+   testNegatedOperation();
+   testScaledOperation( 2 );
+   testScaledOperation( 2UL );
+   testScaledOperation( 2.0F );
+   testScaledOperation( 2.0 );
+   testScaledOperation( Scalar( 2 ) );
+   testTransOperation();
+   testCTransOperation();
+   testAbsOperation();
+   testConjOperation();
+   testRealOperation();
+   testImagOperation();
+   testEvalOperation();
+   testSerialOperation();
+   testSubvectorOperation( Not< IsUniform<DRE> >() );
+   testElementsOperation( Not< IsUniform<DRE> >() );
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  TEST FUNCTIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Tests on the initial status of the operands.
+//
+// \return void
+// \exception std::runtime_error Initialization error detected.
+//
+// This function runs tests on the initial status of the operands. In case any initialization
+// error is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testInitialStatus()
+{
+   //=====================================================================================
+   // Performing initial tests with the given types
+   //=====================================================================================
+
+   // Checking the number of rows of the left-hand side operand
+   if( lhs_.rows() != reflhs_.rows() ) {
+      std::ostringstream oss;
+      oss << " Test: Initial size comparison of left-hand side dense operand\n"
+          << " Error: Invalid number of rows\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Dense tensor type:\n"
+          << "     " << typeid( TT ).name() << "\n"
+          << "   Detected number of rows = " << lhs_.rows() << "\n"
+          << "   Expected number of rows = " << reflhs_.rows() << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   // Checking the number of columns of the left-hand side operand
+   if( lhs_.columns() != reflhs_.columns() ) {
+      std::ostringstream oss;
+      oss << " Test: Initial size comparison of left-hand side dense operand\n"
+          << " Error: Invalid number of columns\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Dense tensor type:\n"
+          << "     " << typeid( TT ).name() << "\n"
+          << "   Detected number of columns = " << lhs_.columns() << "\n"
+          << "   Expected number of columns = " << reflhs_.columns() << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   // Checking the size of the right-hand side operand
+   if( rhs_.size() != refrhs_.size() ) {
+      std::ostringstream oss;
+      oss << " Test: Initial size comparison of right-hand side dense operand\n"
+          << " Error: Invalid vector size\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n"
+          << "   Detected size = " << rhs_.size() << "\n"
+          << "   Expected size = " << refrhs_.size() << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   // Checking the initialization of the left-hand side operand
+   if( !isEqual( lhs_, reflhs_ ) ) {
+      std::ostringstream oss;
+      oss << " Test: Initial test of initialization of left-hand side dense operand\n"
+          << " Error: Invalid tensor initialization\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Dense tensor type:\n"
+          << "     " << typeid( TT ).name() << "\n"
+          << "   Current initialization:\n" << lhs_ << "\n"
+          << "   Expected initialization:\n" << reflhs_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   // Checking the initialization of the right-hand side operand
+   if( !isEqual( rhs_, refrhs_ ) ) {
+      std::ostringstream oss;
+      oss << " Test: Initial test of initialization of right-hand side dense operand\n"
+          << " Error: Invalid vector initialization\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n"
+          << "   Current initialization:\n" << rhs_ << "\n"
+          << "   Expected initialization:\n" << refrhs_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+
+   //=====================================================================================
+   // Performing initial tests with the transpose types
+   //=====================================================================================
+
+   // Checking the number of rows of the transpose left-hand side operand
+   if( olhs_.rows() != reflhs_.rows() ) {
+      std::ostringstream oss;
+      oss << " Test: Initial size comparison of transpose left-hand side dense operand\n"
+          << " Error: Invalid number of rows\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Transpose dense tensor type:\n"
+          << "     " << typeid( TTT ).name() << "\n"
+          << "   Detected number of rows = " << olhs_.rows() << "\n"
+          << "   Expected number of rows = " << reflhs_.rows() << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   // Checking the number of columns of the transpose left-hand side operand
+   if( olhs_.columns() != reflhs_.columns() ) {
+      std::ostringstream oss;
+      oss << " Test: Initial size comparison of transpose left-hand side dense operand\n"
+          << " Error: Invalid number of columns\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Transpose dense tensor type:\n"
+          << "     " << typeid( TTT ).name() << "\n"
+          << "   Detected number of columns = " << olhs_.columns() << "\n"
+          << "   Expected number of columns = " << reflhs_.columns() << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   // Checking the initialization of the transpose left-hand side operand
+   if( !isEqual( olhs_, reflhs_ ) ) {
+      std::ostringstream oss;
+      oss << " Test: Initial test of initialization of transpose left-hand side dense operand\n"
+          << " Error: Invalid tensor initialization\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Transpose dense tensor type:\n"
+          << "     " << typeid( TTT ).name() << "\n"
+          << "   Current initialization:\n" << olhs_ << "\n"
+          << "   Expected initialization:\n" << reflhs_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the vector assignment.
+//
+// \return void
+// \exception std::runtime_error Assignment error detected.
+//
+// This function tests the vector assignment. In case any error is detected, a
+// \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testAssignment()
+{
+   //=====================================================================================
+   // Performing an assignment with the given types
+   //=====================================================================================
+
+   try {
+      lhs_ = reflhs_;
+      rhs_ = refrhs_;
+   }
+   catch( std::exception& ex ) {
+      std::ostringstream oss;
+      oss << " Test: Assignment with the given types\n"
+          << " Error: Failed assignment\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Left-hand side dense tensor type:\n"
+          << "     " << typeid( TT ).name() << "\n"
+          << "   Right-hand side dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n"
+          << "   Error message: " << ex.what() << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   if( !isEqual( lhs_, reflhs_ ) ) {
+      std::ostringstream oss;
+      oss << " Test: Checking the assignment result of left-hand side dense operand\n"
+          << " Error: Invalid tensor initialization\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Dense tensor type:\n"
+          << "     " << typeid( TT ).name() << "\n"
+          << "   Current initialization:\n" << lhs_ << "\n"
+          << "   Expected initialization:\n" << reflhs_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   if( !isEqual( rhs_, refrhs_ ) ) {
+      std::ostringstream oss;
+      oss << " Test: Checking the assignment result of right-hand side dense operand\n"
+          << " Error: Invalid vector initialization\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n"
+          << "   Current initialization:\n" << rhs_ << "\n"
+          << "   Expected initialization:\n" << refrhs_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+
+   //=====================================================================================
+   // Performing an assignment with the transpose types
+   //=====================================================================================
+
+   try {
+      olhs_ = reflhs_;
+   }
+   catch( std::exception& ex ) {
+      std::ostringstream oss;
+      oss << " Test: Assignment with the transpose types\n"
+          << " Error: Failed assignment\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Transpose left-hand side dense tensor type:\n"
+          << "     " << typeid( TTT ).name() << "\n"
+          << "   Error message: " << ex.what() << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   if( !isEqual( olhs_, reflhs_ ) ) {
+      std::ostringstream oss;
+      oss << " Test: Checking the assignment result of transpose left-hand side dense operand\n"
+          << " Error: Invalid tensor initialization\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Transpose dense tensor type:\n"
+          << "     " << typeid( TTT ).name() << "\n"
+          << "   Current initialization:\n" << olhs_ << "\n"
+          << "   Expected initialization:\n" << reflhs_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the explicit evaluation.
+//
+// \return void
+// \exception std::runtime_error Evaluation error detected.
+//
+// This function tests the explicit evaluation. In case any error is detected, a
+// \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testEvaluation()
+{
+   using blaze::IsRowMajorTensor;
+
+
+   //=====================================================================================
+   // Testing the evaluation with the given types
+   //=====================================================================================
+
+   {
+      const auto res   ( evaluate( lhs_    * rhs_    ) );
+      const auto refres( evaluate( reflhs_ * refrhs_ ) );
+
+      if( !isEqual( res, refres ) ) {
+         std::ostringstream oss;
+         oss << " Test: Evaluation with the given tensor/vector\n"
+             << " Error: Failed evaluation\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side " << ( IsRowMajorTensor<TT>::value ? ( "row-major" ) : ( "column-major" ) ) << " dense tensor type:\n"
+             << "     " << typeid( lhs_ ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( rhs_ ).name() << "\n"
+             << "   Deduced result type:\n"
+             << "     " << typeid( res ).name() << "\n"
+             << "   Deduced reference result type:\n"
+             << "     " << typeid( refres ).name() << "\n"
+             << "   Result:\n" << res << "\n"
+             << "   Expected result:\n" << refres << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+   }
+
+   {
+      const auto res   ( evaluate( eval( lhs_ )    * eval( rhs_ )    ) );
+      const auto refres( evaluate( eval( reflhs_ ) * eval( refrhs_ ) ) );
+
+      if( !isEqual( res, refres ) ) {
+         std::ostringstream oss;
+         oss << " Test: Evaluation with evaluated tensor/vector\n"
+             << " Error: Failed evaluation\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side " << ( IsRowMajorTensor<TT>::value ? ( "row-major" ) : ( "column-major" ) ) << " dense tensor type:\n"
+             << "     " << typeid( lhs_ ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( rhs_ ).name() << "\n"
+             << "   Deduced result type:\n"
+             << "     " << typeid( res ).name() << "\n"
+             << "   Deduced reference result type:\n"
+             << "     " << typeid( refres ).name() << "\n"
+             << "   Result:\n" << res << "\n"
+             << "   Expected result:\n" << refres << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+   }
+
+
+   //=====================================================================================
+   // Testing the evaluation with the transpose types
+   //=====================================================================================
+
+   {
+      const auto res   ( evaluate( olhs_   * rhs_    ) );
+      const auto refres( evaluate( reflhs_ * refrhs_ ) );
+
+      if( !isEqual( res, refres ) ) {
+         std::ostringstream oss;
+         oss << " Test: Evaluation with the transpose tensor/vector\n"
+             << " Error: Failed evaluation\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side " << ( IsRowMajorTensor<OTT>::value ? ( "row-major" ) : ( "column-major" ) ) << " dense tensor type:\n"
+             << "     " << typeid( olhs_ ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( rhs_ ).name() << "\n"
+             << "   Deduced result type:\n"
+             << "     " << typeid( res ).name() << "\n"
+             << "   Deduced reference result type:\n"
+             << "     " << typeid( refres ).name() << "\n"
+             << "   Result:\n" << res << "\n"
+             << "   Expected result:\n" << refres << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+   }
+
+   {
+      const auto res   ( evaluate( eval( olhs_ )   * eval( rhs_ )    ) );
+      const auto refres( evaluate( eval( reflhs_ ) * eval( refrhs_ ) ) );
+
+      if( !isEqual( res, refres ) ) {
+         std::ostringstream oss;
+         oss << " Test: Evaluation with evaluated transpose tensor/vector\n"
+             << " Error: Failed evaluation\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side " << ( IsRowMajorTensor<OTT>::value ? ( "row-major" ) : ( "column-major" ) ) << " dense tensor type:\n"
+             << "     " << typeid( olhs_ ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( rhs_ ).name() << "\n"
+             << "   Deduced result type:\n"
+             << "     " << typeid( res ).name() << "\n"
+             << "   Deduced reference result type:\n"
+             << "     " << typeid( refres ).name() << "\n"
+             << "   Result:\n" << res << "\n"
+             << "   Expected result:\n" << refres << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+   }
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the vector element access.
+//
+// \return void
+// \exception std::runtime_error Element access error detected.
+//
+// This function tests the element access via the subscript operator. In case any
+// error is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testElementAccess()
+{
+   using blaze::equal;
+
+
+   //=====================================================================================
+   // Testing the element access with the given types
+   //=====================================================================================
+
+   if( lhs_.rows() > 0UL )
+   {
+      const size_t n( lhs_.rows() - 1UL );
+
+      if( !equal( ( lhs_ * rhs_ )[n], ( reflhs_ * refrhs_ )[n] ) ||
+          !equal( ( lhs_ * rhs_ ).at(n), ( reflhs_ * refrhs_ ).at(n) ) ) {
+         std::ostringstream oss;
+         oss << " Test : Element access of multiplication expression\n"
+             << " Error: Unequal resulting elements at index " << n << " detected\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side row-major dense tensor type:\n"
+             << "     " << typeid( TT ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( VT ).name() << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+
+      if( !equal( ( lhs_ * eval( rhs_ ) )[n], ( reflhs_ * eval( refrhs_ ) )[n] ) ||
+          !equal( ( lhs_ * eval( rhs_ ) ).at(n), ( reflhs_ * eval( refrhs_ ) ).at(n) ) ) {
+         std::ostringstream oss;
+         oss << " Test : Element access of right evaluated multiplication expression\n"
+             << " Error: Unequal resulting elements at index " << n << " detected\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side row-major dense tensor type:\n"
+             << "     " << typeid( TT ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( VT ).name() << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+
+      if( !equal( ( eval( lhs_ ) * rhs_ )[n], ( eval( reflhs_ ) * refrhs_ )[n] ) ||
+          !equal( ( eval( lhs_ ) * rhs_ ).at(n), ( eval( reflhs_ ) * refrhs_ ).at(n) ) ) {
+         std::ostringstream oss;
+         oss << " Test : Element access of left evaluated multiplication expression\n"
+             << " Error: Unequal resulting elements at index " << n << " detected\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side row-major dense tensor type:\n"
+             << "     " << typeid( TT ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( VT ).name() << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+
+      if( !equal( ( eval( lhs_ ) * eval( rhs_ ) )[n], ( eval( reflhs_ ) * eval( refrhs_ ) )[n] ) ||
+          !equal( ( eval( lhs_ ) * eval( rhs_ ) ).at(n), ( eval( reflhs_ ) * eval( refrhs_ ) ).at(n) ) ) {
+         std::ostringstream oss;
+         oss << " Test : Element access of fully evaluated multiplication expression\n"
+             << " Error: Unequal resulting elements at index " << n << " detected\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side row-major dense tensor type:\n"
+             << "     " << typeid( TT ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( VT ).name() << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+   }
+
+   try {
+      ( lhs_ * rhs_ ).at( lhs_.rows() );
+
+      std::ostringstream oss;
+      oss << " Test : Checked element access of multiplication expression\n"
+          << " Error: Out-of-bound access succeeded\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Left-hand side row-major dense tensor type:\n"
+          << "     " << typeid( TT ).name() << "\n"
+          << "   Right-hand side dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+   catch( std::out_of_range& ) {}
+
+
+   //=====================================================================================
+   // Testing the element access with the transpose types
+   //=====================================================================================
+
+   if( olhs_.rows() > 0UL )
+   {
+      const size_t n( olhs_.rows() - 1UL );
+
+      if( !equal( ( olhs_ * rhs_ )[n], ( reflhs_ * refrhs_ )[n] ) ||
+          !equal( ( olhs_ * rhs_ ).at(n), ( reflhs_ * refrhs_ ).at(n) ) ) {
+         std::ostringstream oss;
+         oss << " Test : Element access of transpose multiplication expression\n"
+             << " Error: Unequal resulting elements at index " << n << " detected\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side column-major dense tensor type:\n"
+             << "     " << typeid( TTT ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( VT ).name() << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+
+      if( !equal( ( olhs_ * eval( rhs_ ) )[n], ( reflhs_ * eval( refrhs_ ) )[n] ) ||
+          !equal( ( olhs_ * eval( rhs_ ) ).at(n), ( reflhs_ * eval( refrhs_ ) ).at(n) ) ) {
+         std::ostringstream oss;
+         oss << " Test : Element access of right evaluated transpose multiplication expression\n"
+             << " Error: Unequal resulting elements at index " << n << " detected\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side column-major dense tensor type:\n"
+             << "     " << typeid( TTT ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( VT ).name() << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+
+      if( !equal( ( eval( olhs_ ) * rhs_ )[n], ( eval( reflhs_ ) * refrhs_ )[n] ) ||
+          !equal( ( eval( olhs_ ) * rhs_ ).at(n), ( eval( reflhs_ ) * refrhs_ ).at(n) ) ) {
+         std::ostringstream oss;
+         oss << " Test : Element access of left evaluated transpose multiplication expression\n"
+             << " Error: Unequal resulting elements at index " << n << " detected\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side column-major dense tensor type:\n"
+             << "     " << typeid( TTT ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( VT ).name() << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+
+      if( !equal( ( eval( olhs_ ) * eval( rhs_ ) )[n], ( eval( reflhs_ ) * eval( refrhs_ ) )[n] ) ||
+          !equal( ( eval( olhs_ ) * eval( rhs_ ) ).at(n), ( eval( reflhs_ ) * eval( refrhs_ ) ).at(n) ) ) {
+         std::ostringstream oss;
+         oss << " Test : Element access of fully evaluated transpose multiplication expression\n"
+             << " Error: Unequal resulting elements at index " << n << " detected\n"
+             << " Details:\n"
+             << "   Random seed = " << blaze::getSeed() << "\n"
+             << "   Left-hand side column-major dense tensor type:\n"
+             << "     " << typeid( TTT ).name() << "\n"
+             << "   Right-hand side dense vector type:\n"
+             << "     " << typeid( VT ).name() << "\n";
+         throw std::runtime_error( oss.str() );
+      }
+   }
+
+   try {
+      ( olhs_ * rhs_ ).at( olhs_.rows() );
+
+      std::ostringstream oss;
+      oss << " Test : Checked element access of transpose multiplication expression\n"
+          << " Error: Out-of-bound access succeeded\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Left-hand side column-major dense tensor type:\n"
+          << "     " << typeid( TTT ).name() << "\n"
+          << "   Right-hand side dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+   catch( std::out_of_range& ) {}
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the plain dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the plain tensor/vector multiplication with plain assignment, addition
+// assignment, subtraction assignment, multiplication assignment, and division assignment. In
+// case any error resulting from the multiplication or the subsequent assignment is detected,
+// a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testBasicOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_BASIC_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_BASIC_OPERATION > 1 )
+   {
+      //=====================================================================================
+      // Multiplication
+      //=====================================================================================
+
+      // Multiplication with the given tensor/vector
+      {
+         test_  = "Multiplication with the given tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = lhs_ * rhs_;
+            sres_   = lhs_ * rhs_;
+            refres_ = reflhs_ * refrhs_;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   = olhs_ * rhs_;
+            sres_   = olhs_ * rhs_;
+            refres_ = reflhs_ * refrhs_;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Multiplication with evaluated tensor/vector
+      {
+         test_  = "Multiplication with evaluated tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = eval( lhs_ ) * eval( rhs_ );
+            sres_   = eval( lhs_ ) * eval( rhs_ );
+            refres_ = eval( reflhs_ ) * eval( refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   = eval( olhs_ ) * eval( rhs_ );
+            sres_   = eval( olhs_ ) * eval( rhs_ );
+            refres_ = eval( reflhs_ ) * eval( refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Multiplication with addition assignment
+      //=====================================================================================
+
+      // Multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Multiplication with addition assignment with the given tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += lhs_ * rhs_;
+            sres_   += lhs_ * rhs_;
+            refres_ += reflhs_ * refrhs_;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += olhs_ * rhs_;
+            sres_   += olhs_ * rhs_;
+            refres_ += reflhs_ * refrhs_;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Multiplication with addition assignment with evaluated tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += eval( lhs_ ) * eval( rhs_ );
+            sres_   += eval( lhs_ ) * eval( rhs_ );
+            refres_ += eval( reflhs_ ) * eval( refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += eval( olhs_ ) * eval( rhs_ );
+            sres_   += eval( olhs_ ) * eval( rhs_ );
+            refres_ += eval( reflhs_ ) * eval( refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Multiplication with subtraction assignment
+      //=====================================================================================
+
+      // Multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Multiplication with subtraction assignment with the given tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= lhs_ * rhs_;
+            sres_   -= lhs_ * rhs_;
+            refres_ -= reflhs_ * refrhs_;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= olhs_ * rhs_;
+            sres_   -= olhs_ * rhs_;
+            refres_ -= reflhs_ * refrhs_;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Multiplication with subtraction assignment with evaluated tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= eval( lhs_ ) * eval( rhs_ );
+            sres_   -= eval( lhs_ ) * eval( rhs_ );
+            refres_ -= eval( reflhs_ ) * eval( refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= eval( olhs_ ) * eval( rhs_ );
+            sres_   -= eval( olhs_ ) * eval( rhs_ );
+            refres_ -= eval( reflhs_ ) * eval( refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Multiplication with multiplication assignment
+      //=====================================================================================
+
+      // Multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Multiplication with multiplication assignment with the given tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= lhs_ * rhs_;
+            sres_   *= lhs_ * rhs_;
+            refres_ *= reflhs_ * refrhs_;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= olhs_ * rhs_;
+            sres_   *= olhs_ * rhs_;
+            refres_ *= reflhs_ * refrhs_;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Multiplication with multiplication assignment with evaluated tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= eval( lhs_ ) * eval( rhs_ );
+            sres_   *= eval( lhs_ ) * eval( rhs_ );
+            refres_ *= eval( reflhs_ ) * eval( refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= eval( olhs_ ) * eval( rhs_ );
+            sres_   *= eval( olhs_ ) * eval( rhs_ );
+            refres_ *= eval( reflhs_ ) * eval( refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Multiplication with division assignment
+      //=====================================================================================
+
+      if( !blaze::IsUniform_v<TT> && !blaze::IsUniform_v<VT> && blaze::isDivisor( lhs_ * rhs_ ) )
+      {
+         // Multiplication with division assignment with the given tensor/vector
+         {
+            test_  = "Multiplication with division assignment with the given tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= lhs_ * rhs_;
+               sres_   /= lhs_ * rhs_;
+               refres_ /= reflhs_ * refrhs_;
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= olhs_ * rhs_;
+               sres_   /= olhs_ * rhs_;
+               refres_ /= reflhs_ * refrhs_;
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+
+         // Multiplication with division assignment with evaluated tensor/vector
+         {
+            test_  = "Multiplication with division assignment with evaluated tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= eval( lhs_ ) * eval( rhs_ );
+               sres_   /= eval( lhs_ ) * eval( rhs_ );
+               refres_ /= eval( reflhs_ ) * eval( refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= eval( olhs_ ) * eval( rhs_ );
+               sres_   /= eval( olhs_ ) * eval( rhs_ );
+               refres_ /= eval( reflhs_ ) * eval( refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+      }
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the negated dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the negated tensor/vector multiplication with plain assignment, addition
+// assignment, subtraction assignment, multiplication assignment, and division assignment. In
+// case any error resulting from the multiplication or the subsequent assignment is detected,
+// a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testNegatedOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_NEGATED_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_NEGATED_OPERATION > 1 )
+   {
+      //=====================================================================================
+      // Negated multiplication
+      //=====================================================================================
+
+      // Negated multiplication with the given tensor/vector
+      {
+         test_  = "Negated multiplication with the given tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = -( lhs_ * rhs_ );
+            sres_   = -( lhs_ * rhs_ );
+            refres_ = -( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   = -( olhs_ * rhs_ );
+            sres_   = -( olhs_ * rhs_ );
+            refres_ = -( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Negated multiplication with evaluated tensor/vector
+      {
+         test_  = "Negated multiplication with evaluated tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = -( eval( lhs_ ) * eval( rhs_ ) );
+            sres_   = -( eval( lhs_ ) * eval( rhs_ ) );
+            refres_ = -( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   = -( eval( olhs_ ) * eval( rhs_ ) );
+            sres_   = -( eval( olhs_ ) * eval( rhs_ ) );
+            refres_ = -( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Negated multiplication with addition assignment
+      //=====================================================================================
+
+      // Negated multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Negated multiplication with addition assignment with the given tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += -( lhs_ * rhs_ );
+            sres_   += -( lhs_ * rhs_ );
+            refres_ += -( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += -( olhs_ * rhs_ );
+            sres_   += -( olhs_ * rhs_ );
+            refres_ += -( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Negated multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Negated multiplication with addition assignment with evaluated tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += -( eval( lhs_ ) * eval( rhs_ ) );
+            sres_   += -( eval( lhs_ ) * eval( rhs_ ) );
+            refres_ += -( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += -( eval( olhs_ ) * eval( rhs_ ) );
+            sres_   += -( eval( olhs_ ) * eval( rhs_ ) );
+            refres_ += -( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Negated multiplication with subtraction assignment
+      //=====================================================================================
+
+      // Negated multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Negated multiplication with subtraction assignment with the given tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= -( lhs_ * rhs_ );
+            sres_   -= -( lhs_ * rhs_ );
+            refres_ -= -( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= -( olhs_ * rhs_ );
+            sres_   -= -( olhs_ * rhs_ );
+            refres_ -= -( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Negated multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Negated multiplication with subtraction assignment with evaluated tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= -( eval( lhs_ ) * eval( rhs_ ) );
+            sres_   -= -( eval( lhs_ ) * eval( rhs_ ) );
+            refres_ -= -( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= -( eval( olhs_ ) * eval( rhs_ ) );
+            sres_   -= -( eval( olhs_ ) * eval( rhs_ ) );
+            refres_ -= -( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Negated multiplication with multiplication assignment
+      //=====================================================================================
+
+      // Negated multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Negated multiplication with multiplication assignment with the given tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= -( lhs_ * rhs_ );
+            sres_   *= -( lhs_ * rhs_ );
+            refres_ *= -( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= -( olhs_ * rhs_ );
+            sres_   *= -( olhs_ * rhs_ );
+            refres_ *= -( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Negated multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Negated multiplication with multiplication assignment with evaluated tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= -( eval( lhs_ ) * eval( rhs_ ) );
+            sres_   *= -( eval( lhs_ ) * eval( rhs_ ) );
+            refres_ *= -( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= -( eval( olhs_ ) * eval( rhs_ ) );
+            sres_   *= -( eval( olhs_ ) * eval( rhs_ ) );
+            refres_ *= -( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Negated multiplication with division assignment
+      //=====================================================================================
+
+      if( !blaze::IsUniform_v<TT> && !blaze::IsUniform_v<VT> && blaze::isDivisor( lhs_ * rhs_ ) )
+      {
+         // Negated multiplication with division assignment with the given tensor/vector
+         {
+            test_  = "Negated multiplication with division assignment with the given tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= -( lhs_ * rhs_ );
+               sres_   /= -( lhs_ * rhs_ );
+               refres_ /= -( reflhs_ * refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= -( olhs_ * rhs_ );
+               sres_   /= -( olhs_ * rhs_ );
+               refres_ /= -( reflhs_ * refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+
+         // Negated multiplication with division assignment with evaluated tensor/vector
+         {
+            test_  = "Negated multiplication with division assignment with evaluated tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= -( eval( lhs_ ) * eval( rhs_ ) );
+               sres_   /= -( eval( lhs_ ) * eval( rhs_ ) );
+               refres_ /= -( eval( reflhs_ ) * eval( refrhs_ ) );
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= -( eval( olhs_ ) * eval( rhs_ ) );
+               sres_   /= -( eval( olhs_ ) * eval( rhs_ ) );
+               refres_ /= -( eval( reflhs_ ) * eval( refrhs_ ) );
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+      }
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the scaled dense tensor/dense vector multiplication.
+//
+// \param scalar The scalar value.
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the scaled tensor/vector multiplication with plain assignment, addition
+// assignment, subtraction assignment, multiplication assignment, and division assignment. In
+// case any error resulting from the multiplication or the subsequent assignment is detected,
+// a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+template< typename T >   // Type of the scalar
+void OperationTest<TT,VT>::testScaledOperation( T scalar )
+{
+   BLAZE_CONSTRAINT_MUST_BE_NUMERIC_TYPE( T );
+
+   if( scalar == T(0) )
+      throw std::invalid_argument( "Invalid scalar parameter" );
+
+
+#if BLAZETEST_MATHTEST_TEST_SCALED_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_SCALED_OPERATION > 1 )
+   {
+      //=====================================================================================
+      // Self-scaling (v*=s)
+      //=====================================================================================
+
+      // Self-scaling (v*=s)
+      {
+         test_ = "Self-scaling (v*=s)";
+
+         try {
+            dres_   = lhs_ * rhs_;
+            sres_   = dres_;
+            refres_ = dres_;
+
+            dres_   *= scalar;
+            sres_   *= scalar;
+            refres_ *= scalar;
+         }
+         catch( std::exception& ex ) {
+            std::ostringstream oss;
+            oss << " Test : " << test_ << "\n"
+                << " Error: Failed self-scaling operation\n"
+                << " Details:\n"
+                << "   Random seed = " << blaze::getSeed() << "\n"
+                << "   Scalar = " << scalar << "\n"
+                << "   Error message: " << ex.what() << "\n";
+            throw std::runtime_error( oss.str() );
+         }
+
+         checkResults<TT>();
+      }
+
+
+      //=====================================================================================
+      // Self-scaling (v=v*s)
+      //=====================================================================================
+
+      // Self-scaling (v=v*s)
+      {
+         test_ = "Self-scaling (v=v*s)";
+
+         try {
+            dres_   = lhs_ * rhs_;
+            sres_   = dres_;
+            refres_ = dres_;
+
+            dres_   = dres_   * scalar;
+            sres_   = sres_   * scalar;
+            refres_ = refres_ * scalar;
+         }
+         catch( std::exception& ex ) {
+            std::ostringstream oss;
+            oss << " Test : " << test_ << "\n"
+                << " Error: Failed self-scaling operation\n"
+                << " Details:\n"
+                << "   Random seed = " << blaze::getSeed() << "\n"
+                << "   Scalar = " << scalar << "\n"
+                << "   Error message: " << ex.what() << "\n";
+            throw std::runtime_error( oss.str() );
+         }
+
+         checkResults<TT>();
+      }
+
+
+      //=====================================================================================
+      // Self-scaling (v=s*v)
+      //=====================================================================================
+
+      // Self-scaling (v=s*v)
+      {
+         test_ = "Self-scaling (v=s*v)";
+
+         try {
+            dres_   = lhs_ * rhs_;
+            sres_   = dres_;
+            refres_ = dres_;
+
+            dres_   = scalar * dres_;
+            sres_   = scalar * sres_;
+            refres_ = scalar * refres_;
+         }
+         catch( std::exception& ex ) {
+            std::ostringstream oss;
+            oss << " Test : " << test_ << "\n"
+                << " Error: Failed self-scaling operation\n"
+                << " Details:\n"
+                << "   Random seed = " << blaze::getSeed() << "\n"
+                << "   Scalar = " << scalar << "\n"
+                << "   Error message: " << ex.what() << "\n";
+            throw std::runtime_error( oss.str() );
+         }
+
+         checkResults<TT>();
+      }
+
+
+      //=====================================================================================
+      // Self-scaling (v/=s)
+      //=====================================================================================
+
+      // Self-scaling (v/=s)
+      {
+         test_ = "Self-scaling (v/=s)";
+
+         try {
+            dres_   = lhs_ * rhs_;
+            sres_   = dres_;
+            refres_ = dres_;
+
+            dres_   /= scalar;
+            sres_   /= scalar;
+            refres_ /= scalar;
+         }
+         catch( std::exception& ex ) {
+            std::ostringstream oss;
+            oss << " Test : " << test_ << "\n"
+                << " Error: Failed self-scaling operation\n"
+                << " Details:\n"
+                << "   Random seed = " << blaze::getSeed() << "\n"
+                << "   Scalar = " << scalar << "\n"
+                << "   Error message: " << ex.what() << "\n";
+            throw std::runtime_error( oss.str() );
+         }
+
+         checkResults<TT>();
+      }
+
+
+      //=====================================================================================
+      // Self-scaling (v=v/s)
+      //=====================================================================================
+
+      // Self-scaling (v=v/s)
+      {
+         test_ = "Self-scaling (v=v/s)";
+
+         try {
+            dres_   = lhs_ * rhs_;
+            sres_   = dres_;
+            refres_ = dres_;
+
+            dres_   = dres_   / scalar;
+            sres_   = sres_   / scalar;
+            refres_ = refres_ / scalar;
+         }
+         catch( std::exception& ex ) {
+            std::ostringstream oss;
+            oss << " Test : " << test_ << "\n"
+                << " Error: Failed self-scaling operation\n"
+                << " Details:\n"
+                << "   Random seed = " << blaze::getSeed() << "\n"
+                << "   Scalar = " << scalar << "\n"
+                << "   Error message: " << ex.what() << "\n";
+            throw std::runtime_error( oss.str() );
+         }
+
+         checkResults<TT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication (s*OP)
+      //=====================================================================================
+
+      // Scaled multiplication with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with the given tensor/vector (s*OP)";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = scalar * ( lhs_ * rhs_ );
+            sres_   = scalar * ( lhs_ * rhs_ );
+            refres_ = scalar * ( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   = scalar * ( olhs_ * rhs_ );
+            sres_   = scalar * ( olhs_ * rhs_ );
+            refres_ = scalar * ( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with evaluated tensor/vector (s*OP)";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+            sres_   = scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+            refres_ = scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   = scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+            sres_   = scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+            refres_ = scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication (OP*s)
+      //=====================================================================================
+
+      // Scaled multiplication with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with the given tensor/vector (OP*s)";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = ( lhs_ * rhs_ ) * scalar;
+            sres_   = ( lhs_ * rhs_ ) * scalar;
+            refres_ = ( reflhs_ * refrhs_ ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   = ( olhs_ * rhs_ ) * scalar;
+            sres_   = ( olhs_ * rhs_ ) * scalar;
+            refres_ = ( reflhs_ * refrhs_ ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with evaluated tensor/vector (OP*s)";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+            sres_   = ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+            refres_ = ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_ = ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+            sres_ = ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+            refres_ = ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication (OP/s)
+      //=====================================================================================
+
+      // Scaled multiplication with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with the given tensor/vector (OP/s)";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = ( lhs_ * rhs_ ) / scalar;
+            sres_   = ( lhs_ * rhs_ ) / scalar;
+            refres_ = ( reflhs_ * refrhs_ ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   = ( olhs_ * rhs_ ) / scalar;
+            sres_   = ( olhs_ * rhs_ ) / scalar;
+            refres_ = ( reflhs_ * refrhs_ ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with evaluated tensor/vector (OP/s)";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            dres_   = ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+            sres_   = ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+            refres_ = ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_ = ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+            sres_ = ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+            refres_ = ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with addition assignment (s*OP)
+      //=====================================================================================
+
+      // Scaled multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with addition assignment with the given tensor/vector (s*OP)";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += scalar * ( lhs_ * rhs_ );
+            sres_   += scalar * ( lhs_ * rhs_ );
+            refres_ += scalar * ( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += scalar * ( olhs_ * rhs_ );
+            sres_   += scalar * ( olhs_ * rhs_ );
+            refres_ += scalar * ( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with addition assignment with evaluated tensor/vector (s*OP)";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+            sres_   += scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+            refres_ += scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+            sres_   += scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+            refres_ += scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with addition assignment (OP*s)
+      //=====================================================================================
+
+      // Scaled multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with addition assignment with the given tensor/vector (OP*s)";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += ( lhs_ * rhs_ ) * scalar;
+            sres_   += ( lhs_ * rhs_ ) * scalar;
+            refres_ += ( reflhs_ * refrhs_ ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += ( olhs_ * rhs_ ) * scalar;
+            sres_   += ( olhs_ * rhs_ ) * scalar;
+            refres_ += ( reflhs_ * refrhs_ ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with addition assignment with evaluated tensor/vector (OP*s)";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+            sres_   += ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+            refres_ += ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+            sres_   += ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+            refres_ += ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with addition assignment (OP/s)
+      //=====================================================================================
+
+      // Scaled multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with addition assignment with the given tensor/vector (OP/s)";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += ( lhs_ * rhs_ ) / scalar;
+            sres_   += ( lhs_ * rhs_ ) / scalar;
+            refres_ += ( reflhs_ * refrhs_ ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += ( olhs_ * rhs_ ) / scalar;
+            sres_   += ( olhs_ * rhs_ ) / scalar;
+            refres_ += ( reflhs_ * refrhs_ ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with addition assignment with evaluated tensor/vector (OP/s)";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            dres_   += ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+            sres_   += ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+            refres_ += ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   += ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+            sres_   += ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+            refres_ += ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with subtraction assignment (s*OP)
+      //=====================================================================================
+
+      // Scaled multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with subtraction assignment with the given tensor/vector (s*OP)";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= scalar * ( lhs_ * rhs_ );
+            sres_   -= scalar * ( lhs_ * rhs_ );
+            refres_ -= scalar * ( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= scalar * ( olhs_ * rhs_ );
+            sres_   -= scalar * ( olhs_ * rhs_ );
+            refres_ -= scalar * ( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with subtraction assignment with evaluated tensor/vector (s*OP)";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+            sres_   -= scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+            refres_ -= scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+            sres_   -= scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+            refres_ -= scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with subtraction assignment (OP*s)
+      //=====================================================================================
+
+      // Scaled multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with subtraction assignment with the given tensor/vector (OP*s)";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= ( lhs_ * rhs_ ) * scalar;
+            sres_   -= ( lhs_ * rhs_ ) * scalar;
+            refres_ -= ( reflhs_ * refrhs_ ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= ( olhs_ * rhs_ ) * scalar;
+            sres_   -= ( olhs_ * rhs_ ) * scalar;
+            refres_ -= ( reflhs_ * refrhs_ ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with subtraction assignment with evaluated tensor/vector (OP*s)";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+            sres_   -= ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+            refres_ -= ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+            sres_   -= ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+            refres_ -= ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with subtraction assignment (OP/s)
+      //=====================================================================================
+
+      // Scaled multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with subtraction assignment with the given tensor/vector (OP/s)";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= ( lhs_ * rhs_ ) / scalar;
+            sres_   -= ( lhs_ * rhs_ ) / scalar;
+            refres_ -= ( reflhs_ * refrhs_ ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= ( olhs_ * rhs_ ) / scalar;
+            sres_   -= ( olhs_ * rhs_ ) / scalar;
+            refres_ -= ( reflhs_ * refrhs_ ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with subtraction assignment with evaluated tensor/vector (OP/s)";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            dres_   -= ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+            sres_   -= ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+            refres_ -= ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   -= ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+            sres_   -= ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+            refres_ -= ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with multiplication assignment (s*OP)
+      //=====================================================================================
+
+      // Scaled multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with multiplication assignment with the given tensor/vector (s*OP)";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= scalar * ( lhs_ * rhs_ );
+            sres_   *= scalar * ( lhs_ * rhs_ );
+            refres_ *= scalar * ( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= scalar * ( olhs_ * rhs_ );
+            sres_   *= scalar * ( olhs_ * rhs_ );
+            refres_ *= scalar * ( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with multiplication assignment with evaluated tensor/vector (s*OP)";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+            sres_   *= scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+            refres_ *= scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+            sres_   *= scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+            refres_ *= scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with multiplication assignment (OP*s)
+      //=====================================================================================
+
+      // Scaled multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with multiplication assignment with the given tensor/vector (OP*s)";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= ( lhs_ * rhs_ ) * scalar;
+            sres_   *= ( lhs_ * rhs_ ) * scalar;
+            refres_ *= ( reflhs_ * refrhs_ ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= ( olhs_ * rhs_ ) * scalar;
+            sres_   *= ( olhs_ * rhs_ ) * scalar;
+            refres_ *= ( reflhs_ * refrhs_ ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with multiplication assignment with evaluated tensor/vector (OP*s)";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+            sres_   *= ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+            refres_ *= ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+            sres_   *= ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+            refres_ *= ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with multiplication assignment (OP/s)
+      //=====================================================================================
+
+      // Scaled multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Scaled multiplication with multiplication assignment with the given tensor/vector (OP/s)";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= ( lhs_ * rhs_ ) / scalar;
+            sres_   *= ( lhs_ * rhs_ ) / scalar;
+            refres_ *= ( reflhs_ * refrhs_ ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= ( olhs_ * rhs_ ) / scalar;
+            sres_   *= ( olhs_ * rhs_ ) / scalar;
+            refres_ *= ( reflhs_ * refrhs_ ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Scaled multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Scaled multiplication with multiplication assignment with evaluated tensor/vector (OP/s)";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            dres_   *= ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+            sres_   *= ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+            refres_ *= ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   *= ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+            sres_   *= ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+            refres_ *= ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with division assignment (s*OP)
+      //=====================================================================================
+
+      if( !blaze::IsUniform_v<TT> && !blaze::IsUniform_v<VT> && blaze::isDivisor( lhs_ * rhs_ ) )
+      {
+         // Scaled multiplication with division assignment with the given tensor/vector
+         {
+            test_  = "Scaled multiplication with division assignment with the given tensor/vector (s*OP)";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= scalar * ( lhs_ * rhs_ );
+               sres_   /= scalar * ( lhs_ * rhs_ );
+               refres_ /= scalar * ( reflhs_ * refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= scalar * ( olhs_ * rhs_ );
+               sres_   /= scalar * ( olhs_ * rhs_ );
+               refres_ /= scalar * ( reflhs_ * refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+
+         // Scaled multiplication with division assignment with evaluated tensor/vector
+         {
+            test_  = "Scaled multiplication with division assignment with evaluated tensor/vector (s*OP)";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+               sres_   /= scalar * ( eval( lhs_ ) * eval( rhs_ ) );
+               refres_ /= scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+               sres_   /= scalar * ( eval( olhs_ ) * eval( rhs_ ) );
+               refres_ /= scalar * ( eval( reflhs_ ) * eval( refrhs_ ) );
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with division assignment (OP*s)
+      //=====================================================================================
+
+      if( !blaze::IsUniform_v<TT> && !blaze::IsUniform_v<VT> && blaze::isDivisor( lhs_ * rhs_ ) )
+      {
+         // Scaled multiplication with division assignment with the given tensor/vector
+         {
+            test_  = "Scaled multiplication with division assignment with the given tensor/vector (OP*s)";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= ( lhs_ * rhs_ ) * scalar;
+               sres_   /= ( lhs_ * rhs_ ) * scalar;
+               refres_ /= ( reflhs_ * refrhs_ ) * scalar;
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= ( olhs_ * rhs_ ) * scalar;
+               sres_   /= ( olhs_ * rhs_ ) * scalar;
+               refres_ /= ( reflhs_ * refrhs_ ) * scalar;
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+
+         // Scaled multiplication with division assignment with evaluated tensor/vector
+         {
+            test_  = "Scaled multiplication with division assignment with evaluated tensor/vector (OP*s)";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+               sres_   /= ( eval( lhs_ ) * eval( rhs_ ) ) * scalar;
+               refres_ /= ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+               sres_   /= ( eval( olhs_ ) * eval( rhs_ ) ) * scalar;
+               refres_ /= ( eval( reflhs_ ) * eval( refrhs_ ) ) * scalar;
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+      }
+
+
+      //=====================================================================================
+      // Scaled multiplication with division assignment (OP/s)
+      //=====================================================================================
+
+      if( !blaze::IsUniform_v<TT> && !blaze::IsUniform_v<VT> && blaze::isDivisor( ( lhs_ * rhs_ ) / scalar ) )
+      {
+         // Scaled multiplication with division assignment with the given tensor/vector
+         {
+            test_  = "Scaled multiplication with division assignment with the given tensor/vector (OP/s)";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= ( lhs_ * rhs_ ) / scalar;
+               sres_   /= ( lhs_ * rhs_ ) / scalar;
+               refres_ /= ( reflhs_ * refrhs_ ) / scalar;
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= ( olhs_ * rhs_ ) / scalar;
+               sres_   /= ( olhs_ * rhs_ ) / scalar;
+               refres_ /= ( reflhs_ * refrhs_ ) / scalar;
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+
+         // Scaled multiplication with division assignment with evaluated tensor/vector
+         {
+            test_  = "Scaled multiplication with division assignment with evaluated tensor/vector (OP/s)";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               dres_   /= ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+               sres_   /= ( eval( lhs_ ) * eval( rhs_ ) ) / scalar;
+               refres_ /= ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               dres_   /= ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+               sres_   /= ( eval( olhs_ ) * eval( rhs_ ) ) / scalar;
+               refres_ /= ( eval( reflhs_ ) * eval( refrhs_ ) ) / scalar;
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+      }
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the transpose dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the transpose tensor/vector multiplication with plain assignment,
+// addition assignment, subtraction assignment, multiplication assignment, and division
+// assignment. In case any error resulting from the multiplication or the subsequent
+// assignment is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testTransOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_TRANS_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_TRANS_OPERATION > 1 )
+   {
+      //=====================================================================================
+      // Transpose multiplication
+      //=====================================================================================
+
+      // Transpose multiplication with the given tensor/vector
+      {
+         test_  = "Transpose multiplication with the given tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initTransposeResults();
+            tdres_   = trans( lhs_ * rhs_ );
+            tsres_   = trans( lhs_ * rhs_ );
+            trefres_ = trans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   = trans( olhs_ * rhs_ );
+            tsres_   = trans( olhs_ * rhs_ );
+            trefres_ = trans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+      // Transpose multiplication with evaluated tensor/vector
+      {
+         test_  = "Transpose multiplication with evaluated tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initTransposeResults();
+            tdres_   = trans( eval( lhs_ ) * eval( rhs_ ) );
+            tsres_   = trans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ = trans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   = trans( eval( olhs_ ) * eval( rhs_ ) );
+            tsres_   = trans( eval( olhs_ ) * eval( rhs_ ) );
+            trefres_ = trans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Transpose multiplication with addition assignment
+      //=====================================================================================
+
+      // Transpose multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Transpose multiplication with addition assignment with the given tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   += trans( lhs_ * rhs_ );
+            tsres_   += trans( lhs_ * rhs_ );
+            trefres_ += trans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   += trans( olhs_ * rhs_ );
+            tsres_   += trans( olhs_ * rhs_ );
+            trefres_ += trans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+      // Transpose multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Transpose multiplication with addition assignment with evaluated tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   += trans( eval( lhs_ ) * eval( rhs_ ) );
+            tsres_   += trans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ += trans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   += trans( eval( olhs_ ) * eval( rhs_ ) );
+            tsres_   += trans( eval( olhs_ ) * eval( rhs_ ) );
+            trefres_ += trans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Transpose multiplication with subtraction assignment
+      //=====================================================================================
+
+      // Transpose multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Transpose multiplication with subtraction assignment with the given tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   -= trans( lhs_ * rhs_ );
+            tsres_   -= trans( lhs_ * rhs_ );
+            trefres_ -= trans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   -= trans( olhs_ * rhs_ );
+            tsres_   -= trans( olhs_ * rhs_ );
+            trefres_ -= trans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+      // Transpose multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Transpose multiplication with subtraction assignment with evaluated tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   -= trans( eval( lhs_ ) * eval( rhs_ ) );
+            tsres_   -= trans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ -= trans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   -= trans( eval( olhs_ ) * eval( rhs_ ) );
+            tsres_   -= trans( eval( olhs_ ) * eval( rhs_ ) );
+            trefres_ -= trans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Transpose multiplication with multiplication assignment
+      //=====================================================================================
+
+      // Transpose multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Transpose multiplication with multiplication assignment with the given tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   *= trans( lhs_ * rhs_ );
+            tsres_   *= trans( lhs_ * rhs_ );
+            trefres_ *= trans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   *= trans( olhs_ * rhs_ );
+            tsres_   *= trans( olhs_ * rhs_ );
+            trefres_ *= trans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+      // Transpose multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Transpose multiplication with multiplication assignment with evaluated tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   *= trans( eval( lhs_ ) * eval( rhs_ ) );
+            tsres_   *= trans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ *= trans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   *= trans( eval( olhs_ ) * eval( rhs_ ) );
+            tsres_   *= trans( eval( olhs_ ) * eval( rhs_ ) );
+            trefres_ *= trans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Transpose multiplication with division assignment
+      //=====================================================================================
+
+      if( !blaze::IsUniform_v<TT> && !blaze::IsUniform_v<VT> && blaze::isDivisor( lhs_ * rhs_ ) )
+      {
+         // Transpose multiplication with division assignment with the given tensor/vector
+         {
+            test_  = "Transpose multiplication with division assignment with the given tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initTransposeResults();
+               tdres_   /= trans( lhs_ * rhs_ );
+               tsres_   /= trans( lhs_ * rhs_ );
+               trefres_ /= trans( reflhs_ * refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkTransposeResults<TT>();
+
+            try {
+               initTransposeResults();
+               tdres_   /= trans( olhs_ * rhs_ );
+               tsres_   /= trans( olhs_ * rhs_ );
+               trefres_ /= trans( reflhs_ * refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkTransposeResults<TTT>();
+         }
+
+         // Transpose multiplication with division assignment with evaluated tensor/vector
+         {
+            test_  = "Transpose multiplication with division assignment with evaluated tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initTransposeResults();
+               tdres_   /= trans( eval( lhs_ ) * eval( rhs_ ) );
+               tsres_   /= trans( eval( lhs_ ) * eval( rhs_ ) );
+               trefres_ /= trans( eval( reflhs_ ) * eval( refrhs_ ) );
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkTransposeResults<TT>();
+
+            try {
+               initTransposeResults();
+               tdres_   /= trans( eval( olhs_ ) * eval( rhs_ ) );
+               tsres_   /= trans( eval( olhs_ ) * eval( rhs_ ) );
+               trefres_ /= trans( eval( reflhs_ ) * eval( refrhs_ ) );
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkTransposeResults<TTT>();
+         }
+      }
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the conjugate transpose dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the conjugate transpose tensor/vector multiplication with plain
+// assignment, addition assignment, subtraction assignment, multiplication assignment,
+// and division assignment. In case any error resulting from the multiplication or the
+// subsequent assignment is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testCTransOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_CTRANS_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_CTRANS_OPERATION > 1 )
+   {
+      //=====================================================================================
+      // Conjugate transpose multiplication
+      //=====================================================================================
+
+      // Conjugate transpose multiplication with the given tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with the given tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initTransposeResults();
+            tdres_   = ctrans( lhs_ * rhs_ );
+            tsres_   = ctrans( lhs_ * rhs_ );
+            trefres_ = ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   = ctrans( olhs_ * rhs_ );
+            tsres_   = ctrans( olhs_ * rhs_ );
+            trefres_ = ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+      // Conjugate transpose multiplication with evaluated tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with evaluated tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initTransposeResults();
+            tdres_   = ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            tsres_   = ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ = ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   = ctrans( eval( olhs_ ) * eval( rhs_ ) );
+            tsres_   = ctrans( eval( olhs_ ) * eval( rhs_ ) );
+            trefres_ = ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Conjugate transpose multiplication with addition assignment
+      //=====================================================================================
+
+      // Conjugate transpose multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with addition assignment with the given tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   += ctrans( lhs_ * rhs_ );
+            tsres_   += ctrans( lhs_ * rhs_ );
+            trefres_ += ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   += ctrans( olhs_ * rhs_ );
+            tsres_   += ctrans( olhs_ * rhs_ );
+            trefres_ += ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+      // Conjugate transpose multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with addition assignment with evaluated tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   += ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            tsres_   += ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ += ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   += ctrans( eval( olhs_ ) * eval( rhs_ ) );
+            tsres_   += ctrans( eval( olhs_ ) * eval( rhs_ ) );
+            trefres_ += ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Conjugate transpose multiplication with subtraction assignment
+      //=====================================================================================
+
+      // Conjugate transpose multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with subtraction assignment with the given tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   -= ctrans( lhs_ * rhs_ );
+            tsres_   -= ctrans( lhs_ * rhs_ );
+            trefres_ -= ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   -= ctrans( olhs_ * rhs_ );
+            tsres_   -= ctrans( olhs_ * rhs_ );
+            trefres_ -= ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+      // Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   -= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            tsres_   -= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ -= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   -= ctrans( eval( olhs_ ) * eval( rhs_ ) );
+            tsres_   -= ctrans( eval( olhs_ ) * eval( rhs_ ) );
+            trefres_ -= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Conjugate transpose multiplication with multiplication assignment
+      //=====================================================================================
+
+      // Conjugate transpose multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with multiplication assignment with the given tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   *= ctrans( lhs_ * rhs_ );
+            tsres_   *= ctrans( lhs_ * rhs_ );
+            trefres_ *= ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   *= ctrans( olhs_ * rhs_ );
+            tsres_   *= ctrans( olhs_ * rhs_ );
+            trefres_ *= ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+      // Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   *= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            tsres_   *= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ *= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+
+         try {
+            initTransposeResults();
+            tdres_   *= ctrans( eval( olhs_ ) * eval( rhs_ ) );
+            tsres_   *= ctrans( eval( olhs_ ) * eval( rhs_ ) );
+            trefres_ *= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkTransposeResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Conjugate transpose multiplication with division assignment
+      //=====================================================================================
+
+      if( !blaze::IsUniform_v<TT> && !blaze::IsUniform_v<VT> && blaze::isDivisor( lhs_ * rhs_ ) )
+      {
+         // Conjugate transpose multiplication with division assignment with the given tensor/vector
+         {
+            test_  = "Conjugate transpose multiplication with division assignment with the given tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initTransposeResults();
+               tdres_   /= ctrans( lhs_ * rhs_ );
+               tsres_   /= ctrans( lhs_ * rhs_ );
+               trefres_ /= ctrans( reflhs_ * refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkTransposeResults<TT>();
+
+            try {
+               initTransposeResults();
+               tdres_   /= ctrans( olhs_ * rhs_ );
+               tsres_   /= ctrans( olhs_ * rhs_ );
+               trefres_ /= ctrans( reflhs_ * refrhs_ );
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkTransposeResults<TTT>();
+         }
+
+         // Conjugate transpose multiplication with division assignment with evaluated tensor/vector
+         {
+            test_  = "Conjugate transpose multiplication with division assignment with evaluated tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initTransposeResults();
+               tdres_   /= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+               tsres_   /= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+               trefres_ /= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkTransposeResults<TT>();
+
+            try {
+               initTransposeResults();
+               tdres_   /= ctrans( eval( olhs_ ) * eval( rhs_ ) );
+               tsres_   /= ctrans( eval( olhs_ ) * eval( rhs_ ) );
+               trefres_ /= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkTransposeResults<TTT>();
+         }
+      }
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the abs dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the abs tensor/vector multiplication with plain assignment, addition
+// assignment, subtraction assignment, multiplication assignment, and division assignment. In
+// case any error resulting from the multiplication or the subsequent assignment is detected,
+// a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testAbsOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_ABS_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_ABS_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Abs(), "abs" );
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the conjugate dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the conjugate tensor/vector multiplication with plain assignment,
+// addition assignment, subtraction assignment, multiplication assignment, and division
+// assignment. In case any error resulting from the multiplication or the subsequent
+// assignment is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testConjOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_CONJ_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_CONJ_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Conj(), "conj" );
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the \a real dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the \a real tensor/vector multiplication with plain assignment, addition
+// assignment, subtraction assignment, multiplication assignment, and division assignment. In
+// case any error resulting from the multiplication or the subsequent assignment is detected,
+// a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testRealOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_REAL_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_REAL_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Real(), "real" );
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the \a imag dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the \a imag tensor/vector multiplication with plain assignment, addition
+// assignment, subtraction assignment, multiplication assignment, and division assignment. In
+// case any error resulting from the multiplication or the subsequent assignment is detected,
+// a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testImagOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_IMAG_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_IMAG_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Imag(), "imag" );
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the evaluated dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the evaluated tensor/vector multiplication with plain assignment,
+// addition assignment, subtraction assignment, multiplication assignment, and division
+// assignment. In case any error resulting from the multiplication or the subsequent
+// assignment is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testEvalOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_EVAL_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_EVAL_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Eval(), "eval" );
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the serialized dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the serialized tensor/vector multiplication with plain assignment,
+// addition assignment, subtraction assignment, multiplication assignment, and division
+// assignment. In case any error resulting from the multiplication or the subsequent
+// assignment is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testSerialOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_SERIAL_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_SERIAL_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Serial(), "serial" );
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the subvector-wise dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the subvector-wise tensor/vector multiplication with plain assignment,
+// addition assignment, subtraction assignment, multiplication assignment, and division
+// assignment. In case any error resulting from the multiplication or the subsequent
+// assignment is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testSubvectorOperation( blaze::TrueType )
+{
+#if BLAZETEST_MATHTEST_TEST_SUBVECTOR_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_SUBVECTOR_OPERATION > 1 )
+   {
+      if( lhs_.rows() == 0UL )
+         return;
+
+
+      //=====================================================================================
+      // Subvector-wise multiplication
+      //=====================================================================================
+
+      // Subvector-wise multiplication with the given tensor/vector
+      {
+         test_  = "Subvector-wise multiplication with the given tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+               subvector( dres_  , index, size ) = subvector( lhs_ * rhs_      , index, size );
+               subvector( sres_  , index, size ) = subvector( lhs_ * rhs_      , index, size );
+               subvector( refres_, index, size ) = subvector( reflhs_ * refrhs_, index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+               subvector( dres_  , index, size ) = subvector( olhs_ * rhs_     , index, size );
+               subvector( sres_  , index, size ) = subvector( olhs_ * rhs_     , index, size );
+               subvector( refres_, index, size ) = subvector( reflhs_ * refrhs_, index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Subvector-wise multiplication with evaluated tensor/vector
+      {
+         test_  = "Subvector-wise multiplication with evaluated tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+               subvector( dres_  , index, size ) = subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+               subvector( sres_  , index, size ) = subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+               subvector( refres_, index, size ) = subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+               subvector( dres_  , index, size ) = subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+               subvector( sres_  , index, size ) = subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+               subvector( refres_, index, size ) = subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Subvector-wise multiplication with addition assignment
+      //=====================================================================================
+
+      // Subvector-wise multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Subvector-wise multiplication with addition assignment the given tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+               subvector( dres_  , index, size ) += subvector( lhs_ * rhs_      , index, size );
+               subvector( sres_  , index, size ) += subvector( lhs_ * rhs_      , index, size );
+               subvector( refres_, index, size ) += subvector( reflhs_ * refrhs_, index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+               subvector( dres_  , index, size ) += subvector( olhs_ * rhs_     , index, size );
+               subvector( sres_  , index, size ) += subvector( olhs_ * rhs_     , index, size );
+               subvector( refres_, index, size ) += subvector( reflhs_ * refrhs_, index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Subvector-wise multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Subvector-wise multiplication with addition assignment with evaluated tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+               subvector( dres_  , index, size ) += subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+               subvector( sres_  , index, size ) += subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+               subvector( refres_, index, size ) += subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+               subvector( dres_  , index, size ) += subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+               subvector( sres_  , index, size ) += subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+               subvector( refres_, index, size ) += subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Subvector-wise multiplication with subtraction assignment
+      //=====================================================================================
+
+      // Subvector-wise multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Subvector-wise multiplication with subtraction assignment the given tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+               subvector( dres_  , index, size ) -= subvector( lhs_ * rhs_      , index, size );
+               subvector( sres_  , index, size ) -= subvector( lhs_ * rhs_      , index, size );
+               subvector( refres_, index, size ) -= subvector( reflhs_ * refrhs_, index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+               subvector( dres_  , index, size ) -= subvector( olhs_ * rhs_     , index, size );
+               subvector( sres_  , index, size ) -= subvector( olhs_ * rhs_     , index, size );
+               subvector( refres_, index, size ) -= subvector( reflhs_ * refrhs_, index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Subvector-wise multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Subvector-wise multiplication with subtraction assignment with evaluated tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+               subvector( dres_  , index, size ) -= subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+               subvector( sres_  , index, size ) -= subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+               subvector( refres_, index, size ) -= subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+               subvector( dres_  , index, size ) -= subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+               subvector( sres_  , index, size ) -= subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+               subvector( refres_, index, size ) -= subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Subvector-wise multiplication with multiplication assignment
+      //=====================================================================================
+
+      // Subvector-wise multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Subvector-wise multiplication with multiplication assignment the given tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+               subvector( dres_  , index, size ) *= subvector( lhs_ * rhs_      , index, size );
+               subvector( sres_  , index, size ) *= subvector( lhs_ * rhs_      , index, size );
+               subvector( refres_, index, size ) *= subvector( reflhs_ * refrhs_, index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+               subvector( dres_  , index, size ) *= subvector( olhs_ * rhs_     , index, size );
+               subvector( sres_  , index, size ) *= subvector( olhs_ * rhs_     , index, size );
+               subvector( refres_, index, size ) *= subvector( reflhs_ * refrhs_, index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Subvector-wise multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Subvector-wise multiplication with multiplication assignment with evaluated tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+               subvector( dres_  , index, size ) *= subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+               subvector( sres_  , index, size ) *= subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+               subvector( refres_, index, size ) *= subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+               size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+               subvector( dres_  , index, size ) *= subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+               subvector( sres_  , index, size ) *= subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+               subvector( refres_, index, size ) *= subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Subvector-wise multiplication with division assignment
+      //=====================================================================================
+
+      if( !blaze::IsUniform_v<TT> && !blaze::IsUniform_v<VT> )
+      {
+         // Subvector-wise multiplication with division assignment with the given tensor/vector
+         {
+            test_  = "Subvector-wise multiplication with division assignment the given tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+                  size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+                  if( !blaze::isDivisor( subvector( lhs_ * rhs_, index, size ) ) ) continue;
+                  subvector( dres_  , index, size ) /= subvector( lhs_ * rhs_      , index, size );
+                  subvector( sres_  , index, size ) /= subvector( lhs_ * rhs_      , index, size );
+                  subvector( refres_, index, size ) /= subvector( reflhs_ * refrhs_, index, size );
+               }
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+                  size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+                  if( !blaze::isDivisor( subvector( olhs_ * rhs_, index, size ) ) ) continue;
+                  subvector( dres_  , index, size ) /= subvector( olhs_ * rhs_     , index, size );
+                  subvector( sres_  , index, size ) /= subvector( olhs_ * rhs_     , index, size );
+                  subvector( refres_, index, size ) /= subvector( reflhs_ * refrhs_, index, size );
+               }
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+
+         // Subvector-wise multiplication with division assignment with evaluated tensor/vector
+         {
+            test_  = "Subvector-wise multiplication with division assignment with evaluated tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               for( size_t index=0UL, size=0UL; index<lhs_.rows(); index+=size ) {
+                  size = blaze::rand<size_t>( 1UL, lhs_.rows() - index );
+                  if( !blaze::isDivisor( subvector( lhs_ * rhs_, index, size ) ) ) continue;
+                  subvector( dres_  , index, size ) /= subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+                  subvector( sres_  , index, size ) /= subvector( eval( lhs_ ) * eval( rhs_ )      , index, size );
+                  subvector( refres_, index, size ) /= subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+               }
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               for( size_t index=0UL, size=0UL; index<olhs_.rows(); index+=size ) {
+                  size = blaze::rand<size_t>( 1UL, olhs_.rows() - index );
+                  if( !blaze::isDivisor( subvector( olhs_ * rhs_, index, size ) ) ) continue;
+                  subvector( dres_  , index, size ) /= subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+                  subvector( sres_  , index, size ) /= subvector( eval( olhs_ ) * eval( rhs_ )     , index, size );
+                  subvector( refres_, index, size ) /= subvector( eval( reflhs_ ) * eval( refrhs_ ), index, size );
+               }
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+      }
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Skipping the subvector-wise dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Addition error detected.
+//
+// This function is called in case the subvector-wise tensor/vector multiplication operation is
+// not available for the given types \a TT and \a VT.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testSubvectorOperation( blaze::FalseType )
+{}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the elements-wise dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the elements-wise tensor/vector multiplication with plain assignment,
+// addition assignment, subtraction assignment, multiplication assignment, and division
+// assignment. In case any error resulting from the multiplication or the subsequent
+// assignment is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testElementsOperation( blaze::TrueType )
+{
+#if BLAZETEST_MATHTEST_TEST_ELEMENTS_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_ELEMENTS_OPERATION > 1 )
+   {
+      if( lhs_.rows() == 0UL )
+         return;
+
+
+      std::vector<size_t> indices( lhs_.rows() );
+      std::iota( indices.begin(), indices.end(), 0UL );
+      std::random_shuffle( indices.begin(), indices.end() );
+
+
+      //=====================================================================================
+      // Elements-wise multiplication
+      //=====================================================================================
+
+      // Elements-wise multiplication with the given tensor/vector
+      {
+         test_  = "Elements-wise multiplication with the given tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) = elements( lhs_ * rhs_      , &indices[index], n );
+               elements( sres_  , &indices[index], n ) = elements( lhs_ * rhs_      , &indices[index], n );
+               elements( refres_, &indices[index], n ) = elements( reflhs_ * refrhs_, &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) = elements( olhs_ * rhs_     , &indices[index], n );
+               elements( sres_  , &indices[index], n ) = elements( olhs_ * rhs_     , &indices[index], n );
+               elements( refres_, &indices[index], n ) = elements( reflhs_ * refrhs_, &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Elements-wise multiplication with evaluated tensor/vector
+      {
+         test_  = "Elements-wise multiplication with evaluated tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) = elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+               elements( sres_  , &indices[index], n ) = elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+               elements( refres_, &indices[index], n ) = elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) = elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+               elements( sres_  , &indices[index], n ) = elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+               elements( refres_, &indices[index], n ) = elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Elements-wise multiplication with addition assignment
+      //=====================================================================================
+
+      // Elements-wise multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Elements-wise multiplication with addition assignment the given tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) += elements( lhs_ * rhs_      , &indices[index], n );
+               elements( sres_  , &indices[index], n ) += elements( lhs_ * rhs_      , &indices[index], n );
+               elements( refres_, &indices[index], n ) += elements( reflhs_ * refrhs_, &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) += elements( olhs_ * rhs_     , &indices[index], n );
+               elements( sres_  , &indices[index], n ) += elements( olhs_ * rhs_     , &indices[index], n );
+               elements( refres_, &indices[index], n ) += elements( reflhs_ * refrhs_, &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Elements-wise multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Elements-wise multiplication with addition assignment with evaluated tensor/vector";
+         error_ = "Failed addition assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) += elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+               elements( sres_  , &indices[index], n ) += elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+               elements( refres_, &indices[index], n ) += elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) += elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+               elements( sres_  , &indices[index], n ) += elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+               elements( refres_, &indices[index], n ) += elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Elements-wise multiplication with subtraction assignment
+      //=====================================================================================
+
+      // Elements-wise multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Elements-wise multiplication with subtraction assignment the given tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) -= elements( lhs_ * rhs_      , &indices[index], n );
+               elements( sres_  , &indices[index], n ) -= elements( lhs_ * rhs_      , &indices[index], n );
+               elements( refres_, &indices[index], n ) -= elements( reflhs_ * refrhs_, &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) -= elements( olhs_ * rhs_     , &indices[index], n );
+               elements( sres_  , &indices[index], n ) -= elements( olhs_ * rhs_     , &indices[index], n );
+               elements( refres_, &indices[index], n ) -= elements( reflhs_ * refrhs_, &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Elements-wise multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Elements-wise multiplication with subtraction assignment with evaluated tensor/vector";
+         error_ = "Failed subtraction assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) -= elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+               elements( sres_  , &indices[index], n ) -= elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+               elements( refres_, &indices[index], n ) -= elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) -= elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+               elements( sres_  , &indices[index], n ) -= elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+               elements( refres_, &indices[index], n ) -= elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Elements-wise multiplication with multiplication assignment
+      //=====================================================================================
+
+      // Elements-wise multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Elements-wise multiplication with multiplication assignment the given tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) *= elements( lhs_ * rhs_      , &indices[index], n );
+               elements( sres_  , &indices[index], n ) *= elements( lhs_ * rhs_      , &indices[index], n );
+               elements( refres_, &indices[index], n ) *= elements( reflhs_ * refrhs_, &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) *= elements( olhs_ * rhs_     , &indices[index], n );
+               elements( sres_  , &indices[index], n ) *= elements( olhs_ * rhs_     , &indices[index], n );
+               elements( refres_, &indices[index], n ) *= elements( reflhs_ * refrhs_, &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Elements-wise multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Elements-wise multiplication with multiplication assignment with evaluated tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) *= elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+               elements( sres_  , &indices[index], n ) *= elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+               elements( refres_, &indices[index], n ) *= elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+               n = blaze::rand<size_t>( 1UL, indices.size() - index );
+               elements( dres_  , &indices[index], n ) *= elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+               elements( sres_  , &indices[index], n ) *= elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+               elements( refres_, &indices[index], n ) *= elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+            }
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+
+      //=====================================================================================
+      // Elements-wise multiplication with division assignment
+      //=====================================================================================
+
+      if( !blaze::IsUniform_v<VT> && !blaze::IsUniform_v<TT> )
+      {
+         // Elements-wise multiplication with division assignment with the given tensor/vector
+         {
+            test_  = "Elements-wise multiplication with division assignment the given tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+                  n = blaze::rand<size_t>( 1UL, indices.size() - index );
+                  if( !blaze::isDivisor( elements( lhs_ * rhs_, &indices[index], n ) ) ) continue;
+                  elements( dres_  , &indices[index], n ) /= elements( lhs_ * rhs_      , &indices[index], n );
+                  elements( sres_  , &indices[index], n ) /= elements( lhs_ * rhs_      , &indices[index], n );
+                  elements( refres_, &indices[index], n ) /= elements( reflhs_ * refrhs_, &indices[index], n );
+               }
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+                  n = blaze::rand<size_t>( 1UL, indices.size() - index );
+                  if( !blaze::isDivisor( elements( olhs_ * rhs_, &indices[index], n ) ) ) continue;
+                  elements( dres_  , &indices[index], n ) /= elements( olhs_ * rhs_     , &indices[index], n );
+                  elements( sres_  , &indices[index], n ) /= elements( olhs_ * rhs_     , &indices[index], n );
+                  elements( refres_, &indices[index], n ) /= elements( reflhs_ * refrhs_, &indices[index], n );
+               }
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+
+         // Elements-wise multiplication with division assignment with evaluated tensor/vector
+         {
+            test_  = "Elements-wise multiplication with division assignment with evaluated tensor/vector";
+            error_ = "Failed division assignment operation";
+
+            try {
+               initResults();
+               for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+                  n = blaze::rand<size_t>( 1UL, indices.size() - index );
+                  if( !blaze::isDivisor( elements( lhs_ * rhs_, &indices[index], n ) ) ) continue;
+                  elements( dres_  , &indices[index], n ) /= elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+                  elements( sres_  , &indices[index], n ) /= elements( eval( lhs_ ) * eval( rhs_ )      , &indices[index], n );
+                  elements( refres_, &indices[index], n ) /= elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+               }
+            }
+            catch( std::exception& ex ) {
+               convertException<TT>( ex );
+            }
+
+            checkResults<TT>();
+
+            try {
+               initResults();
+               for( size_t index=0UL, n=0UL; index<indices.size(); index+=n ) {
+                  n = blaze::rand<size_t>( 1UL, indices.size() - index );
+                  if( !blaze::isDivisor( elements( olhs_ * rhs_, &indices[index], n ) ) ) continue;
+                  elements( dres_  , &indices[index], n ) /= elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+                  elements( sres_  , &indices[index], n ) /= elements( eval( olhs_ ) * eval( rhs_ )     , &indices[index], n );
+                  elements( refres_, &indices[index], n ) /= elements( eval( reflhs_ ) * eval( refrhs_ ), &indices[index], n );
+               }
+            }
+            catch( std::exception& ex ) {
+               convertException<TTT>( ex );
+            }
+
+            checkResults<TTT>();
+         }
+      }
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Skipping the elements-wise dense tensor/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Addition error detected.
+//
+// This function is called in case the elements-wise tensor/vector multiplication operation is
+// not available for the given types \a TT and \a VT.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testElementsOperation( blaze::FalseType )
+{}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Testing the customized dense tensor/dense vector multiplication.
+//
+// \param op The custom operation to be tested.
+// \param name The human-readable name of the operation.
+// \return void
+// \exception std::runtime_error Multiplication error detected.
+//
+// This function tests the tensor/vector multiplication with plain assignment, addition
+// assignment, subtraction assignment, multiplication assignment, and division assignment
+// in combination with a custom operation. In case any error resulting from the multiplication
+// or the subsequent assignment is detected, a \a std::runtime_error exception is thrown.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+template< typename OP >  // Type of the custom operation
+void OperationTest<TT,VT>::testCustomOperation( OP op, const std::string& name )
+{
+   //=====================================================================================
+   // Customized multiplication
+   //=====================================================================================
+
+   // Customized multiplication with the given tensor/vector
+   {
+      test_  = "Customized multiplication with the given tensor/vector (" + name + ")";
+      error_ = "Failed multiplication operation";
+
+      try {
+         initResults();
+         dres_   = op( lhs_ * rhs_ );
+         sres_   = op( lhs_ * rhs_ );
+         refres_ = op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+
+      try {
+         initResults();
+         dres_   = op( olhs_ * rhs_ );
+         sres_   = op( olhs_ * rhs_ );
+         refres_ = op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TTT>( ex );
+      }
+
+      checkResults<TTT>();
+   }
+
+   // Customized multiplication with evaluated tensor/vector
+   {
+      test_  = "Customized multiplication with evaluated tensor/vector (" + name + ")";
+      error_ = "Failed multiplication operation";
+
+      try {
+         initResults();
+         dres_   = op( eval( lhs_ ) * eval( rhs_ ) );
+         sres_   = op( eval( lhs_ ) * eval( rhs_ ) );
+         refres_ = op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+
+      try {
+         initResults();
+         dres_   = op( eval( olhs_ ) * eval( rhs_ ) );
+         sres_   = op( eval( olhs_ ) * eval( rhs_ ) );
+         refres_ = op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TTT>( ex );
+      }
+
+      checkResults<TTT>();
+   }
+
+
+   //=====================================================================================
+   // Customized multiplication with addition assignment
+   //=====================================================================================
+
+   // Customized multiplication with addition assignment with the given tensor/vector
+   {
+      test_  = "Customized multiplication with addition assignment with the given tensor/vector (" + name + ")";
+      error_ = "Failed addition assignment operation";
+
+      try {
+         initResults();
+         dres_   += op( lhs_ * rhs_ );
+         sres_   += op( lhs_ * rhs_ );
+         refres_ += op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+
+      try {
+         initResults();
+         dres_   += op( olhs_ * rhs_ );
+         sres_   += op( olhs_ * rhs_ );
+         refres_ += op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TTT>( ex );
+      }
+
+      checkResults<TTT>();
+   }
+
+   // Customized multiplication with addition assignment with evaluated tensor/vector
+   {
+      test_  = "Customized multiplication with addition assignment with evaluated tensor/vector (" + name + ")";
+      error_ = "Failed addition assignment operation";
+
+      try {
+         initResults();
+         dres_   += op( eval( lhs_ ) * eval( rhs_ ) );
+         sres_   += op( eval( lhs_ ) * eval( rhs_ ) );
+         refres_ += op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+
+      try {
+         initResults();
+         dres_   += op( eval( olhs_ ) * eval( rhs_ ) );
+         sres_   += op( eval( olhs_ ) * eval( rhs_ ) );
+         refres_ += op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TTT>( ex );
+      }
+
+      checkResults<TTT>();
+   }
+
+
+   //=====================================================================================
+   // Customized multiplication with subtraction assignment
+   //=====================================================================================
+
+   // Customized multiplication with subtraction assignment with the given tensor/vector
+   {
+      test_  = "Customized multiplication with subtraction assignment with the given tensor/vector (" + name + ")";
+      error_ = "Failed subtraction assignment operation";
+
+      try {
+         initResults();
+         dres_   -= op( lhs_ * rhs_ );
+         sres_   -= op( lhs_ * rhs_ );
+         refres_ -= op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+
+      try {
+         initResults();
+         dres_   -= op( olhs_ * rhs_ );
+         sres_   -= op( olhs_ * rhs_ );
+         refres_ -= op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TTT>( ex );
+      }
+
+      checkResults<TTT>();
+   }
+
+   // Customized multiplication with subtraction assignment with evaluated tensor/vector
+   {
+      test_  = "Customized multiplication with subtraction assignment with evaluated tensor/vector (" + name + ")";
+      error_ = "Failed subtraction assignment operation";
+
+      try {
+         initResults();
+         dres_   -= op( eval( lhs_ ) * eval( rhs_ ) );
+         sres_   -= op( eval( lhs_ ) * eval( rhs_ ) );
+         refres_ -= op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+
+      try {
+         initResults();
+         dres_   -= op( eval( olhs_ ) * eval( rhs_ ) );
+         sres_   -= op( eval( olhs_ ) * eval( rhs_ ) );
+         refres_ -= op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TTT>( ex );
+      }
+
+      checkResults<TTT>();
+   }
+
+
+   //=====================================================================================
+   // Customized multiplication with multiplication assignment
+   //=====================================================================================
+
+   // Customized multiplication with multiplication assignment with the given tensor/vector
+   {
+      test_  = "Customized multiplication with multiplication assignment with the given tensor/vector (" + name + ")";
+      error_ = "Failed multiplication assignment operation";
+
+      try {
+         initResults();
+         dres_   *= op( lhs_ * rhs_ );
+         sres_   *= op( lhs_ * rhs_ );
+         refres_ *= op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+
+      try {
+         initResults();
+         dres_   *= op( olhs_ * rhs_ );
+         sres_   *= op( olhs_ * rhs_ );
+         refres_ *= op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TTT>( ex );
+      }
+
+      checkResults<TTT>();
+   }
+
+   // Customized multiplication with multiplication assignment with evaluated tensor/vector
+   {
+      test_  = "Customized multiplication with multiplication assignment with evaluated tensor/vector (" + name + ")";
+      error_ = "Failed multiplication assignment operation";
+
+      try {
+         initResults();
+         dres_   *= op( eval( lhs_ ) * eval( rhs_ ) );
+         sres_   *= op( eval( lhs_ ) * eval( rhs_ ) );
+         refres_ *= op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+
+      try {
+         initResults();
+         dres_   *= op( eval( olhs_ ) * eval( rhs_ ) );
+         sres_   *= op( eval( olhs_ ) * eval( rhs_ ) );
+         refres_ *= op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TTT>( ex );
+      }
+
+      checkResults<TTT>();
+   }
+
+
+   //=====================================================================================
+   // Customized multiplication with division assignment
+   //=====================================================================================
+
+   if( !blaze::IsUniform_v<VT> && !blaze::IsUniform_v<TT> && blaze::isDivisor( op( lhs_ * rhs_ ) ) )
+   {
+      // Customized multiplication with division assignment with the given tensor/vector
+      {
+         test_  = "Customized multiplication with division assignment with the given tensor/vector (" + name + ")";
+         error_ = "Failed division assignment operation";
+
+         try {
+            initResults();
+            dres_   /= op( lhs_ * rhs_ );
+            sres_   /= op( lhs_ * rhs_ );
+            refres_ /= op( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   /= op( olhs_ * rhs_ );
+            sres_   /= op( olhs_ * rhs_ );
+            refres_ /= op( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+
+      // Customized multiplication with division assignment with evaluated tensor/vector
+      {
+         test_  = "Customized multiplication with division assignment with evaluated tensor/vector (" + name + ")";
+         error_ = "Failed division assignment operation";
+
+         try {
+            initResults();
+            dres_   /= op( eval( lhs_ ) * eval( rhs_ ) );
+            sres_   /= op( eval( lhs_ ) * eval( rhs_ ) );
+            refres_ /= op( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkResults<TT>();
+
+         try {
+            initResults();
+            dres_   /= op( eval( olhs_ ) * eval( rhs_ ) );
+            sres_   /= op( eval( olhs_ ) * eval( rhs_ ) );
+            refres_ /= op( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TTT>( ex );
+         }
+
+         checkResults<TTT>();
+      }
+   }
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  ERROR DETECTION FUNCTIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Checking and comparing the computed results.
+//
+// \return void
+// \exception std::runtime_error Incorrect dense result detected.
+// \exception std::runtime_error Incorrect sparse result detected.
+//
+// This function is called after each test case to check and compare the computed results.
+// The template argument \a LT indicates the types of the left-hand side operand used for
+// the computations.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+template< typename LT >  // Type of the left-hand side operand
+void OperationTest<TT,VT>::checkResults()
+{
+   using blaze::IsRowMajorTensor;
+
+   if( !isEqual( dres_, refres_ ) ) {
+      std::ostringstream oss;
+      oss.precision( 20 );
+      oss << " Test : " << test_ << "\n"
+          << " Error: Incorrect dense result detected\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Left-hand side " << ( IsRowMajorTensor<LT>::value ? ( "row-major" ) : ( "column-major" ) ) << " dense tensor type:\n"
+          << "     " << typeid( LT ).name() << "\n"
+          << "   Right-hand side dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n"
+          << "   Result:\n" << dres_ << "\n"
+          << "   Expected result:\n" << refres_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   if( !isEqual( sres_, refres_ ) ) {
+      std::ostringstream oss;
+      oss.precision( 20 );
+      oss << " Test : " << test_ << "\n"
+          << " Error: Incorrect sparse result detected\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Left-hand side " << ( IsRowMajorTensor<LT>::value ? ( "row-major" ) : ( "column-major" ) ) << " dense tensor type:\n"
+          << "     " << typeid( LT ).name() << "\n"
+          << "   Right-hand side dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n"
+          << "   Result:\n" << sres_ << "\n"
+          << "   Expected result:\n" << refres_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Checking and comparing the computed transpose results.
+//
+// \return void
+// \exception std::runtime_error Incorrect dense result detected.
+// \exception std::runtime_error Incorrect sparse result detected.
+//
+// This function is called after each test case to check and compare the computed transpose
+// results. The template argument \a LT indicates the types of the left-hand side operand
+// used for the computations.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+template< typename LT >  // Type of the left-hand side operand
+void OperationTest<TT,VT>::checkTransposeResults()
+{
+   using blaze::IsRowMajorTensor;
+
+   if( !isEqual( tdres_, trefres_ ) ) {
+      std::ostringstream oss;
+      oss.precision( 20 );
+      oss << " Test : " << test_ << "\n"
+          << " Error: Incorrect dense result detected\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Left-hand side " << ( IsRowMajorTensor<LT>::value ? ( "row-major" ) : ( "column-major" ) ) << " dense tensor type:\n"
+          << "     " << typeid( LT ).name() << "\n"
+          << "   Right-hand side dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n"
+          << "   Transpose result:\n" << tdres_ << "\n"
+          << "   Expected transpose result:\n" << trefres_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+
+   if( !isEqual( tsres_, trefres_ ) ) {
+      std::ostringstream oss;
+      oss.precision( 20 );
+      oss << " Test : " << test_ << "\n"
+          << " Error: Incorrect sparse result detected\n"
+          << " Details:\n"
+          << "   Random seed = " << blaze::getSeed() << "\n"
+          << "   Left-hand side " << ( IsRowMajorTensor<LT>::value ? ( "row-major" ) : ( "column-major" ) ) << " dense tensor type:\n"
+          << "     " << typeid( LT ).name() << "\n"
+          << "   Right-hand side dense vector type:\n"
+          << "     " << typeid( VT ).name() << "\n"
+          << "   Transpose result:\n" << tsres_ << "\n"
+          << "   Expected transpose result:\n" << trefres_ << "\n";
+      throw std::runtime_error( oss.str() );
+   }
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  UTILITY FUNCTIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Initializing the non-transpose result vectors.
+//
+// \return void
+//
+// This function is called before each non-transpose test case to initialize the according result
+// vectors to random values.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::initResults()
+{
+   const blaze::UnderlyingBuiltin_t<DRE> min( randmin );
+   const blaze::UnderlyingBuiltin_t<DRE> max( randmax );
+
+   resize( dres_, rows( lhs_ ) );
+   randomize( dres_, min, max );
+
+   sres_   = dres_;
+   refres_ = dres_;
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Initializing the transpose result vectors.
+//
+// \return void
+//
+// This function is called before each transpose test case to initialize the according result
+// vectors to random values.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::initTransposeResults()
+{
+   const blaze::UnderlyingBuiltin_t<TDRE> min( randmin );
+   const blaze::UnderlyingBuiltin_t<TDRE> max( randmax );
+
+   resize( tdres_, rows( lhs_ ) );
+   randomize( tdres_, min, max );
+
+   tsres_   = tdres_;
+   trefres_ = tdres_;
+}
+//*************************************************************************************************
+
+
+//*************************************************************************************************
+/*!\brief Convert the given exception into a \a std::runtime_error exception.
+//
+// \param ex The \a std::exception to be extended.
+// \return void
+// \exception std::runtime_error The converted exception.
+//
+// This function converts the given exception to a \a std::runtime_error exception. Additionally,
+// the function extends the given exception message by all available infortension for the failed
+// test. The template argument \a LT indicates the types of the left-hand side operand used for
+// used for the computations.
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+template< typename LT >  // Type of the left-hand side operand
+void OperationTest<TT,VT>::convertException( const std::exception& ex )
+{
+   using blaze::IsRowMajorTensor;
+
+   std::ostringstream oss;
+   oss << " Test : " << test_ << "\n"
+       << " Error: " << error_ << "\n"
+       << " Details:\n"
+       << "   Random seed = " << blaze::getSeed() << "\n"
+       << "   Left-hand side " << ( IsRowMajorTensor<LT>::value ? ( "row-major" ) : ( "column-major" ) ) << " dense tensor type:\n"
+       << "     " << typeid( LT ).name() << "\n"
+       << "   Right-hand side dense vector type:\n"
+       << "     " << typeid( VT ).name() << "\n"
+       << "   Error message: " << ex.what() << "\n";
+   throw std::runtime_error( oss.str() );
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  GLOBAL TEST FUNCTIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Testing the tensor/vector multiplication between two specific types.
+//
+// \param creator1 The creator for the left-hand side tensor.
+// \param creator2 The creator for the right-hand side vector.
+// \return void
+*/
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void runTest( const Creator<TT>& creator1, const Creator<VT>& creator2 )
+{
+#if BLAZETEST_MATHTEST_TEST_MULTIPLICATION
+   if( BLAZETEST_MATHTEST_TEST_MULTIPLICATION > 1 )
+   {
+      for( size_t rep=0UL; rep<repetitions; ++rep ) {
+         OperationTest<TT,VT>( creator1, creator2 );
+      }
+   }
+#endif
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  MACROS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*! \cond BLAZE_INTERNAL */
+/*!\brief Macro for the execution of a dense tensor/dense vector multiplication test case.
+*/
+#define RUN_DTENSDVECMULT_OPERATION_TEST( C1, C2 ) \
+   blazetest::mathtest::dtensdvecmult::runTest( C1, C2 )
+/*! \endcond */
+//*************************************************************************************************
+
+} // namespace dtensdvecmult
+
+} // namespace mathtest
+
+} // namespace blazetest
+
+#endif

--- a/blazetest/blazetest/mathtest/dtensdvecmult/OperationTest.h
+++ b/blazetest/blazetest/mathtest/dtensdvecmult/OperationTest.h
@@ -295,6 +295,8 @@ OperationTest<TT,VT>::OperationTest( const Creator<TT>& creator1, const Creator<
    testSubmatrixOperation( Not< IsUniform<DRE> >() );
    testRowOperation      ( Not< IsUniform<DRE> >() );
    testColumnOperation   ( Not< IsUniform<DRE> >() );
+   //testRowsOperation      ( Not< IsUniform<DRE> >() ); // needs pageslices
+   //testColumnsOperation   ( Not< IsUniform<DRE> >() ); // needs rowslices
 }
 //*************************************************************************************************
 
@@ -1025,8 +1027,8 @@ void OperationTest<TT,VT>::testScaledOperation( T scalar )
       throw std::invalid_argument( "Invalid scalar parameter" );
 
 
-#if BLAZETEST_MATHTEST_TEST_SCALED_OPERATION
-   if( BLAZETEST_MATHTEST_TEST_SCALED_OPERATION > 1 )
+//#if BLAZETEST_MATHTEST_TEST_SCALED_OPERATION
+//   if( BLAZETEST_MATHTEST_TEST_SCALED_OPERATION > 1 )
    {
       //=====================================================================================
       // Self-scaling (v*=s)
@@ -1606,7 +1608,7 @@ void OperationTest<TT,VT>::testScaledOperation( T scalar )
          checkResults<TT>();
       }
    }
-#endif
+//#endif
 }
 //*************************************************************************************************
 
@@ -1799,170 +1801,170 @@ void OperationTest<TT,VT>::testTransOperation()
 // and division assignment. In case any error resulting from the multiplication or the
 // subsequent assignment is detected, a \a std::runtime_error exception is thrown.
 */
-//template< typename TT    // Type of the left-hand side dense tensor
-//        , typename VT >  // Type of the right-hand side dense vector
-//void OperationTest<TT,VT>::testCTransOperation()
-//{
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testCTransOperation()
+{
 //#if BLAZETEST_MATHTEST_TEST_CTRANS_OPERATION
-//   if( BLAZETEST_MATHTEST_TEST_CTRANS_OPERATION > 1 )
-//   {
-//      //=====================================================================================
-//      // Conjugate transpose multiplication
-//      //=====================================================================================
-//
-//      // Conjugate transpose multiplication with the given tensor/vector
-//      {
-//         test_  = "Conjugate transpose multiplication with the given tensor/vector";
-//         error_ = "Failed multiplication operation";
-//
-//         try {
-//            initTransposeResults();
-//            tdres_   = ctrans( lhs_ * rhs_ );
-//            trefres_ = ctrans( reflhs_ * refrhs_ );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkTransposeResults<TT>();
-//      }
-//
-//      // Conjugate transpose multiplication with evaluated tensor/vector
-//      {
-//         test_  = "Conjugate transpose multiplication with evaluated tensor/vector";
-//         error_ = "Failed multiplication operation";
-//
-//         try {
-//            initTransposeResults();
-//            tdres_   = ctrans( eval( lhs_ ) * eval( rhs_ ) );
-//            trefres_ = ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkTransposeResults<TT>();
-//      }
-//
-//
-//      //=====================================================================================
-//      // Conjugate transpose multiplication with addition assignment
-//      //=====================================================================================
-//
-//      // Conjugate transpose multiplication with addition assignment with the given tensor/vector
-//      {
-//         test_  = "Conjugate transpose multiplication with addition assignment with the given tensor/vector";
-//         error_ = "Failed addition assignment operation";
-//
-//         try {
-//            initTransposeResults();
-//            tdres_   += ctrans( lhs_ * rhs_ );
-//            trefres_ += ctrans( reflhs_ * refrhs_ );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkTransposeResults<TT>();
-//      }
-//
-//      // Conjugate transpose multiplication with addition assignment with evaluated tensor/vector
-//      {
-//         test_  = "Conjugate transpose multiplication with addition assignment with evaluated tensor/vector";
-//         error_ = "Failed addition assignment operation";
-//
-//         try {
-//            initTransposeResults();
-//            tdres_   += ctrans( eval( lhs_ ) * eval( rhs_ ) );
-//            trefres_ += ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkTransposeResults<TT>();
-//      }
-//
-//
-//      //=====================================================================================
-//      // Conjugate transpose multiplication with subtraction assignment
-//      //=====================================================================================
-//
-//      // Conjugate transpose multiplication with subtraction assignment with the given tensor/vector
-//      {
-//         test_  = "Conjugate transpose multiplication with subtraction assignment with the given tensor/vector";
-//         error_ = "Failed subtraction assignment operation";
-//
-//         try {
-//            initTransposeResults();
-//            tdres_   -= ctrans( lhs_ * rhs_ );
-//            trefres_ -= ctrans( reflhs_ * refrhs_ );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkTransposeResults<TT>();
-//      }
-//
-//      // Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector
-//      {
-//         test_  = "Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector";
-//         error_ = "Failed subtraction assignment operation";
-//
-//         try {
-//            initTransposeResults();
-//            tdres_   -= ctrans( eval( lhs_ ) * eval( rhs_ ) );
-//            trefres_ -= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkTransposeResults<TT>();
-//      }
-//
-//
-//      //=====================================================================================
-//      // Conjugate transpose multiplication with multiplication assignment
-//      //=====================================================================================
-//
-//      // Conjugate transpose multiplication with multiplication assignment with the given tensor/vector
-//      {
-//         test_  = "Conjugate transpose multiplication with multiplication assignment with the given tensor/vector";
-//         error_ = "Failed multiplication assignment operation";
-//
-//         try {
-//            initTransposeResults();
-//            tdres_   %= ctrans( lhs_ * rhs_ );
-//            trefres_ %= ctrans( reflhs_ * refrhs_ );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkTransposeResults<TT>();
-//      }
-//
-//      // Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector
-//      {
-//         test_  = "Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector";
-//         error_ = "Failed multiplication assignment operation";
-//
-//         try {
-//            initTransposeResults();
-//            tdres_   %= ctrans( eval( lhs_ ) * eval( rhs_ ) );
-//            trefres_ %= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkTransposeResults<TT>();
-//      }
-//   }
-////#endif
-//}
+   //if( BLAZETEST_MATHTEST_TEST_CTRANS_OPERATION > 1 )
+   {
+      //=====================================================================================
+      // Conjugate transpose multiplication
+      //=====================================================================================
+
+      // Conjugate transpose multiplication with the given tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with the given tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initTransposeResults();
+            tdres_   = ctrans( lhs_ * rhs_ );
+            //trefres_ = ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         //checkTransposeResults<TT>();
+      }
+
+      // Conjugate transpose multiplication with evaluated tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with evaluated tensor/vector";
+         error_ = "Failed multiplication operation";
+
+         try {
+            initTransposeResults();
+            tdres_   = ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ = ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+      }
+
+
+   //   //=====================================================================================
+   //   // Conjugate transpose multiplication with addition assignment
+   //   //=====================================================================================
+
+   //   // Conjugate transpose multiplication with addition assignment with the given tensor/vector
+   //   {
+   //      test_  = "Conjugate transpose multiplication with addition assignment with the given tensor/vector";
+   //      error_ = "Failed addition assignment operation";
+
+   //      try {
+   //         initTransposeResults();
+   //         tdres_   += ctrans( lhs_ * rhs_ );
+   //         trefres_ += ctrans( reflhs_ * refrhs_ );
+   //      }
+   //      catch( std::exception& ex ) {
+   //         convertException<TT>( ex );
+   //      }
+
+   //      checkTransposeResults<TT>();
+   //   }
+
+   //   // Conjugate transpose multiplication with addition assignment with evaluated tensor/vector
+   //   {
+   //      test_  = "Conjugate transpose multiplication with addition assignment with evaluated tensor/vector";
+   //      error_ = "Failed addition assignment operation";
+
+   //      try {
+   //         initTransposeResults();
+   //         tdres_   += ctrans( eval( lhs_ ) * eval( rhs_ ) );
+   //         trefres_ += ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+   //      }
+   //      catch( std::exception& ex ) {
+   //         convertException<TT>( ex );
+   //      }
+
+   //      checkTransposeResults<TT>();
+   //   }
+
+
+   //   //=====================================================================================
+   //   // Conjugate transpose multiplication with subtraction assignment
+   //   //=====================================================================================
+
+   //   // Conjugate transpose multiplication with subtraction assignment with the given tensor/vector
+   //   {
+   //      test_  = "Conjugate transpose multiplication with subtraction assignment with the given tensor/vector";
+   //      error_ = "Failed subtraction assignment operation";
+
+   //      try {
+   //         initTransposeResults();
+   //         tdres_   -= ctrans( lhs_ * rhs_ );
+   //         trefres_ -= ctrans( reflhs_ * refrhs_ );
+   //      }
+   //      catch( std::exception& ex ) {
+   //         convertException<TT>( ex );
+   //      }
+
+   //      checkTransposeResults<TT>();
+   //   }
+
+   //   // Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector
+   //   {
+   //      test_  = "Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector";
+   //      error_ = "Failed subtraction assignment operation";
+
+   //      try {
+   //         initTransposeResults();
+   //         tdres_   -= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+   //         trefres_ -= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+   //      }
+   //      catch( std::exception& ex ) {
+   //         convertException<TT>( ex );
+   //      }
+
+   //      checkTransposeResults<TT>();
+   //   }
+
+
+   //   //=====================================================================================
+   //   // Conjugate transpose multiplication with multiplication assignment
+   //   //=====================================================================================
+
+   //   // Conjugate transpose multiplication with multiplication assignment with the given tensor/vector
+   //   {
+   //      test_  = "Conjugate transpose multiplication with multiplication assignment with the given tensor/vector";
+   //      error_ = "Failed multiplication assignment operation";
+
+   //      try {
+   //         initTransposeResults();
+   //         tdres_   %= ctrans( lhs_ * rhs_ );
+   //         trefres_ %= ctrans( reflhs_ * refrhs_ );
+   //      }
+   //      catch( std::exception& ex ) {
+   //         convertException<TT>( ex );
+   //      }
+
+   //      checkTransposeResults<TT>();
+   //   }
+
+   //   // Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector
+   //   {
+   //      test_  = "Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector";
+   //      error_ = "Failed multiplication assignment operation";
+
+   //      try {
+   //         initTransposeResults();
+   //         tdres_   %= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+   //         trefres_ %= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+   //      }
+   //      catch( std::exception& ex ) {
+   //         convertException<TT>( ex );
+   //      }
+
+   //      checkTransposeResults<TT>();
+   //   }
+   }
+//#endif
+}
 //*************************************************************************************************
 
 

--- a/blazetest/blazetest/mathtest/dtensdvecmult/OperationTest.h
+++ b/blazetest/blazetest/mathtest/dtensdvecmult/OperationTest.h
@@ -285,13 +285,13 @@ OperationTest<TT,VT>::OperationTest( const Creator<TT>& creator1, const Creator<
    testScaledOperation( 2.0 );
    testScaledOperation( Scalar( 2 ) );
    testTransOperation();
-   //testCTransOperation();
-   //testAbsOperation();
-   //testConjOperation();
-   //testRealOperation();
-   //testImagOperation();
-   //testEvalOperation();
-   //testSerialOperation();
+   testCTransOperation();
+   testAbsOperation();
+   testConjOperation();
+   testRealOperation();
+   testImagOperation();
+   testEvalOperation();
+   testSerialOperation();
    testSubmatrixOperation( Not< IsUniform<DRE> >() );
    testRowOperation      ( Not< IsUniform<DRE> >() );
    testColumnOperation   ( Not< IsUniform<DRE> >() );
@@ -1805,8 +1805,8 @@ template< typename TT    // Type of the left-hand side dense tensor
         , typename VT >  // Type of the right-hand side dense vector
 void OperationTest<TT,VT>::testCTransOperation()
 {
-//#if BLAZETEST_MATHTEST_TEST_CTRANS_OPERATION
-   //if( BLAZETEST_MATHTEST_TEST_CTRANS_OPERATION > 1 )
+#if BLAZETEST_MATHTEST_TEST_CTRANS_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_CTRANS_OPERATION > 1 )
    {
       //=====================================================================================
       // Conjugate transpose multiplication
@@ -1820,13 +1820,13 @@ void OperationTest<TT,VT>::testCTransOperation()
          try {
             initTransposeResults();
             tdres_   = ctrans( lhs_ * rhs_ );
-            //trefres_ = ctrans( reflhs_ * refrhs_ );
+            trefres_ = ctrans( reflhs_ * refrhs_ );
          }
          catch( std::exception& ex ) {
             convertException<TT>( ex );
          }
 
-         //checkTransposeResults<TT>();
+         checkTransposeResults<TT>();
       }
 
       // Conjugate transpose multiplication with evaluated tensor/vector
@@ -1847,123 +1847,123 @@ void OperationTest<TT,VT>::testCTransOperation()
       }
 
 
-   //   //=====================================================================================
-   //   // Conjugate transpose multiplication with addition assignment
-   //   //=====================================================================================
+      //=====================================================================================
+      // Conjugate transpose multiplication with addition assignment
+      //=====================================================================================
 
-   //   // Conjugate transpose multiplication with addition assignment with the given tensor/vector
-   //   {
-   //      test_  = "Conjugate transpose multiplication with addition assignment with the given tensor/vector";
-   //      error_ = "Failed addition assignment operation";
+      // Conjugate transpose multiplication with addition assignment with the given tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with addition assignment with the given tensor/vector";
+         error_ = "Failed addition assignment operation";
 
-   //      try {
-   //         initTransposeResults();
-   //         tdres_   += ctrans( lhs_ * rhs_ );
-   //         trefres_ += ctrans( reflhs_ * refrhs_ );
-   //      }
-   //      catch( std::exception& ex ) {
-   //         convertException<TT>( ex );
-   //      }
+         try {
+            initTransposeResults();
+            tdres_   += ctrans( lhs_ * rhs_ );
+            trefres_ += ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
 
-   //      checkTransposeResults<TT>();
-   //   }
+         checkTransposeResults<TT>();
+      }
 
-   //   // Conjugate transpose multiplication with addition assignment with evaluated tensor/vector
-   //   {
-   //      test_  = "Conjugate transpose multiplication with addition assignment with evaluated tensor/vector";
-   //      error_ = "Failed addition assignment operation";
+      // Conjugate transpose multiplication with addition assignment with evaluated tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with addition assignment with evaluated tensor/vector";
+         error_ = "Failed addition assignment operation";
 
-   //      try {
-   //         initTransposeResults();
-   //         tdres_   += ctrans( eval( lhs_ ) * eval( rhs_ ) );
-   //         trefres_ += ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
-   //      }
-   //      catch( std::exception& ex ) {
-   //         convertException<TT>( ex );
-   //      }
+         try {
+            initTransposeResults();
+            tdres_   += ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ += ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
 
-   //      checkTransposeResults<TT>();
-   //   }
-
-
-   //   //=====================================================================================
-   //   // Conjugate transpose multiplication with subtraction assignment
-   //   //=====================================================================================
-
-   //   // Conjugate transpose multiplication with subtraction assignment with the given tensor/vector
-   //   {
-   //      test_  = "Conjugate transpose multiplication with subtraction assignment with the given tensor/vector";
-   //      error_ = "Failed subtraction assignment operation";
-
-   //      try {
-   //         initTransposeResults();
-   //         tdres_   -= ctrans( lhs_ * rhs_ );
-   //         trefres_ -= ctrans( reflhs_ * refrhs_ );
-   //      }
-   //      catch( std::exception& ex ) {
-   //         convertException<TT>( ex );
-   //      }
-
-   //      checkTransposeResults<TT>();
-   //   }
-
-   //   // Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector
-   //   {
-   //      test_  = "Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector";
-   //      error_ = "Failed subtraction assignment operation";
-
-   //      try {
-   //         initTransposeResults();
-   //         tdres_   -= ctrans( eval( lhs_ ) * eval( rhs_ ) );
-   //         trefres_ -= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
-   //      }
-   //      catch( std::exception& ex ) {
-   //         convertException<TT>( ex );
-   //      }
-
-   //      checkTransposeResults<TT>();
-   //   }
+         checkTransposeResults<TT>();
+      }
 
 
-   //   //=====================================================================================
-   //   // Conjugate transpose multiplication with multiplication assignment
-   //   //=====================================================================================
+      //=====================================================================================
+      // Conjugate transpose multiplication with subtraction assignment
+      //=====================================================================================
 
-   //   // Conjugate transpose multiplication with multiplication assignment with the given tensor/vector
-   //   {
-   //      test_  = "Conjugate transpose multiplication with multiplication assignment with the given tensor/vector";
-   //      error_ = "Failed multiplication assignment operation";
+      // Conjugate transpose multiplication with subtraction assignment with the given tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with subtraction assignment with the given tensor/vector";
+         error_ = "Failed subtraction assignment operation";
 
-   //      try {
-   //         initTransposeResults();
-   //         tdres_   %= ctrans( lhs_ * rhs_ );
-   //         trefres_ %= ctrans( reflhs_ * refrhs_ );
-   //      }
-   //      catch( std::exception& ex ) {
-   //         convertException<TT>( ex );
-   //      }
+         try {
+            initTransposeResults();
+            tdres_   -= ctrans( lhs_ * rhs_ );
+            trefres_ -= ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
 
-   //      checkTransposeResults<TT>();
-   //   }
+         checkTransposeResults<TT>();
+      }
 
-   //   // Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector
-   //   {
-   //      test_  = "Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector";
-   //      error_ = "Failed multiplication assignment operation";
+      // Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with subtraction assignment with evaluated tensor/vector";
+         error_ = "Failed subtraction assignment operation";
 
-   //      try {
-   //         initTransposeResults();
-   //         tdres_   %= ctrans( eval( lhs_ ) * eval( rhs_ ) );
-   //         trefres_ %= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
-   //      }
-   //      catch( std::exception& ex ) {
-   //         convertException<TT>( ex );
-   //      }
+         try {
+            initTransposeResults();
+            tdres_   -= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ -= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
 
-   //      checkTransposeResults<TT>();
-   //   }
+         checkTransposeResults<TT>();
+      }
+
+
+      //=====================================================================================
+      // Conjugate transpose multiplication with multiplication assignment
+      //=====================================================================================
+
+      // Conjugate transpose multiplication with multiplication assignment with the given tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with multiplication assignment with the given tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   %= ctrans( lhs_ * rhs_ );
+            trefres_ %= ctrans( reflhs_ * refrhs_ );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+      }
+
+      // Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector
+      {
+         test_  = "Conjugate transpose multiplication with multiplication assignment with evaluated tensor/vector";
+         error_ = "Failed multiplication assignment operation";
+
+         try {
+            initTransposeResults();
+            tdres_   %= ctrans( eval( lhs_ ) * eval( rhs_ ) );
+            trefres_ %= ctrans( eval( reflhs_ ) * eval( refrhs_ ) );
+         }
+         catch( std::exception& ex ) {
+            convertException<TT>( ex );
+         }
+
+         checkTransposeResults<TT>();
+      }
    }
-//#endif
+#endif
 }
 //*************************************************************************************************
 
@@ -1983,12 +1983,12 @@ template< typename TT    // Type of the left-hand side dense tensor
         , typename VT >  // Type of the right-hand side dense vector
 void OperationTest<TT,VT>::testAbsOperation()
 {
-//#if BLAZETEST_MATHTEST_TEST_ABS_OPERATION
-//   if( BLAZETEST_MATHTEST_TEST_ABS_OPERATION > 1 )
-//   {
+#if BLAZETEST_MATHTEST_TEST_ABS_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_ABS_OPERATION > 1 )
+   {
       testCustomOperation( blaze::Abs(), "abs" );
-//   }
-//#endif
+   }
+#endif
 }
 //*************************************************************************************************
 
@@ -2004,17 +2004,17 @@ void OperationTest<TT,VT>::testAbsOperation()
 // assignment. In case any error resulting from the multiplication or the subsequent
 // assignment is detected, a \a std::runtime_error exception is thrown.
 */
-//template< typename TT    // Type of the left-hand side dense tensor
-//        , typename VT >  // Type of the right-hand side dense vector
-//void OperationTest<TT,VT>::testConjOperation()
-//{
-//#if BLAZETEST_MATHTEST_TEST_CONJ_OPERATION
-//   if( BLAZETEST_MATHTEST_TEST_CONJ_OPERATION > 1 )
-//   {
-//      testCustomOperation( blaze::Conj(), "conj" );
-//   }
-//#endif
-//}
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testConjOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_CONJ_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_CONJ_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Conj(), "conj" );
+   }
+#endif
+}
 //*************************************************************************************************
 
 
@@ -2029,17 +2029,17 @@ void OperationTest<TT,VT>::testAbsOperation()
 // case any error resulting from the multiplication or the subsequent assignment is detected,
 // a \a std::runtime_error exception is thrown.
 */
-//template< typename TT    // Type of the left-hand side dense tensor
-//        , typename VT >  // Type of the right-hand side dense vector
-//void OperationTest<TT,VT>::testRealOperation()
-//{
-//#if BLAZETEST_MATHTEST_TEST_REAL_OPERATION
-//   if( BLAZETEST_MATHTEST_TEST_REAL_OPERATION > 1 )
-//   {
-//      testCustomOperation( blaze::Real(), "real" );
-//   }
-//#endif
-//}
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testRealOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_REAL_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_REAL_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Real(), "real" );
+   }
+#endif
+}
 //*************************************************************************************************
 
 
@@ -2054,17 +2054,17 @@ void OperationTest<TT,VT>::testAbsOperation()
 // case any error resulting from the multiplication or the subsequent assignment is detected,
 // a \a std::runtime_error exception is thrown.
 */
-//template< typename TT    // Type of the left-hand side dense tensor
-//        , typename VT >  // Type of the right-hand side dense vector
-//void OperationTest<TT,VT>::testImagOperation()
-//{
-//#if BLAZETEST_MATHTEST_TEST_IMAG_OPERATION
-//   if( BLAZETEST_MATHTEST_TEST_IMAG_OPERATION > 1 )
-//   {
-//      testCustomOperation( blaze::Imag(), "imag" );
-//   }
-//#endif
-//}
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testImagOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_IMAG_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_IMAG_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Imag(), "imag" );
+   }
+#endif
+}
 //*************************************************************************************************
 
 
@@ -2079,17 +2079,17 @@ void OperationTest<TT,VT>::testAbsOperation()
 // assignment. In case any error resulting from the multiplication or the subsequent
 // assignment is detected, a \a std::runtime_error exception is thrown.
 */
-//template< typename TT    // Type of the left-hand side dense tensor
-//        , typename VT >  // Type of the right-hand side dense vector
-//void OperationTest<TT,VT>::testEvalOperation()
-//{
-//#if BLAZETEST_MATHTEST_TEST_EVAL_OPERATION
-//   if( BLAZETEST_MATHTEST_TEST_EVAL_OPERATION > 1 )
-//   {
-//      testCustomOperation( blaze::Eval(), "eval" );
-//   }
-//#endif
-//}
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testEvalOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_EVAL_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_EVAL_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Eval(), "eval" );
+   }
+#endif
+}
 //*************************************************************************************************
 
 
@@ -2104,17 +2104,17 @@ void OperationTest<TT,VT>::testAbsOperation()
 // assignment. In case any error resulting from the multiplication or the subsequent
 // assignment is detected, a \a std::runtime_error exception is thrown.
 */
-//template< typename TT    // Type of the left-hand side dense tensor
-//        , typename VT >  // Type of the right-hand side dense vector
-//void OperationTest<TT,VT>::testSerialOperation()
-//{
-//#if BLAZETEST_MATHTEST_TEST_SERIAL_OPERATION
-//   if( BLAZETEST_MATHTEST_TEST_SERIAL_OPERATION > 1 )
-//   {
-//      testCustomOperation( blaze::Serial(), "serial" );
-//   }
-//#endif
-//}
+template< typename TT    // Type of the left-hand side dense tensor
+        , typename VT >  // Type of the right-hand side dense vector
+void OperationTest<TT,VT>::testSerialOperation()
+{
+#if BLAZETEST_MATHTEST_TEST_SERIAL_OPERATION
+   if( BLAZETEST_MATHTEST_TEST_SERIAL_OPERATION > 1 )
+   {
+      testCustomOperation( blaze::Serial(), "serial" );
+   }
+#endif
+}
 //*************************************************************************************************
 
 
@@ -2836,299 +2836,141 @@ void OperationTest<TT,VT>::testCustomOperation( OP op, const std::string& name )
 
       checkResults<TT>();
    }
-//
-//   // Customized multiplication with evaluated tensor/vector
-//   {
-//      test_  = "Customized multiplication with evaluated tensor/vector (" + name + ")";
-//      error_ = "Failed multiplication operation";
-//
-//      try {
-//         initResults();
-//         dres_   = op( eval( lhs_ ) * eval( rhs_ ) );
-//         sres_   = op( eval( lhs_ ) * eval( rhs_ ) );
-//         refres_ = op( eval( reflhs_ ) * eval( refrhs_ ) );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TT>( ex );
-//      }
-//
-//      checkResults<TT>();
-//
-//      try {
-//         initResults();
-//         dres_   = op( eval( olhs_ ) * eval( rhs_ ) );
-//         sres_   = op( eval( olhs_ ) * eval( rhs_ ) );
-//         refres_ = op( eval( reflhs_ ) * eval( refrhs_ ) );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TTT>( ex );
-//      }
-//
-//      checkResults<TTT>();
-//   }
-//
-//
-//   //=====================================================================================
-//   // Customized multiplication with addition assignment
-//   //=====================================================================================
-//
-//   // Customized multiplication with addition assignment with the given tensor/vector
-//   {
-//      test_  = "Customized multiplication with addition assignment with the given tensor/vector (" + name + ")";
-//      error_ = "Failed addition assignment operation";
-//
-//      try {
-//         initResults();
-//         dres_   += op( lhs_ * rhs_ );
-//         sres_   += op( lhs_ * rhs_ );
-//         refres_ += op( reflhs_ * refrhs_ );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TT>( ex );
-//      }
-//
-//      checkResults<TT>();
-//
-//      try {
-//         initResults();
-//         dres_   += op( olhs_ * rhs_ );
-//         sres_   += op( olhs_ * rhs_ );
-//         refres_ += op( reflhs_ * refrhs_ );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TTT>( ex );
-//      }
-//
-//      checkResults<TTT>();
-//   }
-//
-//   // Customized multiplication with addition assignment with evaluated tensor/vector
-//   {
-//      test_  = "Customized multiplication with addition assignment with evaluated tensor/vector (" + name + ")";
-//      error_ = "Failed addition assignment operation";
-//
-//      try {
-//         initResults();
-//         dres_   += op( eval( lhs_ ) * eval( rhs_ ) );
-//         sres_   += op( eval( lhs_ ) * eval( rhs_ ) );
-//         refres_ += op( eval( reflhs_ ) * eval( refrhs_ ) );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TT>( ex );
-//      }
-//
-//      checkResults<TT>();
-//
-//      try {
-//         initResults();
-//         dres_   += op( eval( olhs_ ) * eval( rhs_ ) );
-//         sres_   += op( eval( olhs_ ) * eval( rhs_ ) );
-//         refres_ += op( eval( reflhs_ ) * eval( refrhs_ ) );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TTT>( ex );
-//      }
-//
-//      checkResults<TTT>();
-//   }
-//
-//
-//   //=====================================================================================
-//   // Customized multiplication with subtraction assignment
-//   //=====================================================================================
-//
-//   // Customized multiplication with subtraction assignment with the given tensor/vector
-//   {
-//      test_  = "Customized multiplication with subtraction assignment with the given tensor/vector (" + name + ")";
-//      error_ = "Failed subtraction assignment operation";
-//
-//      try {
-//         initResults();
-//         dres_   -= op( lhs_ * rhs_ );
-//         sres_   -= op( lhs_ * rhs_ );
-//         refres_ -= op( reflhs_ * refrhs_ );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TT>( ex );
-//      }
-//
-//      checkResults<TT>();
-//
-//      try {
-//         initResults();
-//         dres_   -= op( olhs_ * rhs_ );
-//         sres_   -= op( olhs_ * rhs_ );
-//         refres_ -= op( reflhs_ * refrhs_ );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TTT>( ex );
-//      }
-//
-//      checkResults<TTT>();
-//   }
-//
-//   // Customized multiplication with subtraction assignment with evaluated tensor/vector
-//   {
-//      test_  = "Customized multiplication with subtraction assignment with evaluated tensor/vector (" + name + ")";
-//      error_ = "Failed subtraction assignment operation";
-//
-//      try {
-//         initResults();
-//         dres_   -= op( eval( lhs_ ) * eval( rhs_ ) );
-//         sres_   -= op( eval( lhs_ ) * eval( rhs_ ) );
-//         refres_ -= op( eval( reflhs_ ) * eval( refrhs_ ) );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TT>( ex );
-//      }
-//
-//      checkResults<TT>();
-//
-//      try {
-//         initResults();
-//         dres_   -= op( eval( olhs_ ) * eval( rhs_ ) );
-//         sres_   -= op( eval( olhs_ ) * eval( rhs_ ) );
-//         refres_ -= op( eval( reflhs_ ) * eval( refrhs_ ) );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TTT>( ex );
-//      }
-//
-//      checkResults<TTT>();
-//   }
-//
-//
-//   //=====================================================================================
-//   // Customized multiplication with multiplication assignment
-//   //=====================================================================================
-//
-//   // Customized multiplication with multiplication assignment with the given tensor/vector
-//   {
-//      test_  = "Customized multiplication with multiplication assignment with the given tensor/vector (" + name + ")";
-//      error_ = "Failed multiplication assignment operation";
-//
-//      try {
-//         initResults();
-//         dres_   *= op( lhs_ * rhs_ );
-//         sres_   *= op( lhs_ * rhs_ );
-//         refres_ *= op( reflhs_ * refrhs_ );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TT>( ex );
-//      }
-//
-//      checkResults<TT>();
-//
-//      try {
-//         initResults();
-//         dres_   *= op( olhs_ * rhs_ );
-//         sres_   *= op( olhs_ * rhs_ );
-//         refres_ *= op( reflhs_ * refrhs_ );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TTT>( ex );
-//      }
-//
-//      checkResults<TTT>();
-//   }
-//
-//   // Customized multiplication with multiplication assignment with evaluated tensor/vector
-//   {
-//      test_  = "Customized multiplication with multiplication assignment with evaluated tensor/vector (" + name + ")";
-//      error_ = "Failed multiplication assignment operation";
-//
-//      try {
-//         initResults();
-//         dres_   *= op( eval( lhs_ ) * eval( rhs_ ) );
-//         sres_   *= op( eval( lhs_ ) * eval( rhs_ ) );
-//         refres_ *= op( eval( reflhs_ ) * eval( refrhs_ ) );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TT>( ex );
-//      }
-//
-//      checkResults<TT>();
-//
-//      try {
-//         initResults();
-//         dres_   *= op( eval( olhs_ ) * eval( rhs_ ) );
-//         sres_   *= op( eval( olhs_ ) * eval( rhs_ ) );
-//         refres_ *= op( eval( reflhs_ ) * eval( refrhs_ ) );
-//      }
-//      catch( std::exception& ex ) {
-//         convertException<TTT>( ex );
-//      }
-//
-//      checkResults<TTT>();
-//   }
-//
-//
-//   //=====================================================================================
-//   // Customized multiplication with division assignment
-//   //=====================================================================================
-//
-//   if( !blaze::IsUniform_v<VT> && !blaze::IsUniform_v<TT> && blaze::isDivisor( op( lhs_ * rhs_ ) ) )
-//   {
-//      // Customized multiplication with division assignment with the given tensor/vector
-//      {
-//         test_  = "Customized multiplication with division assignment with the given tensor/vector (" + name + ")";
-//         error_ = "Failed division assignment operation";
-//
-//         try {
-//            initResults();
-//            dres_   /= op( lhs_ * rhs_ );
-//            sres_   /= op( lhs_ * rhs_ );
-//            refres_ /= op( reflhs_ * refrhs_ );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkResults<TT>();
-//
-//         try {
-//            initResults();
-//            dres_   /= op( olhs_ * rhs_ );
-//            sres_   /= op( olhs_ * rhs_ );
-//            refres_ /= op( reflhs_ * refrhs_ );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TTT>( ex );
-//         }
-//
-//         checkResults<TTT>();
-//      }
-//
-//      // Customized multiplication with division assignment with evaluated tensor/vector
-//      {
-//         test_  = "Customized multiplication with division assignment with evaluated tensor/vector (" + name + ")";
-//         error_ = "Failed division assignment operation";
-//
-//         try {
-//            initResults();
-//            dres_   /= op( eval( lhs_ ) * eval( rhs_ ) );
-//            sres_   /= op( eval( lhs_ ) * eval( rhs_ ) );
-//            refres_ /= op( eval( reflhs_ ) * eval( refrhs_ ) );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TT>( ex );
-//         }
-//
-//         checkResults<TT>();
-//
-//         try {
-//            initResults();
-//            dres_   /= op( eval( olhs_ ) * eval( rhs_ ) );
-//            sres_   /= op( eval( olhs_ ) * eval( rhs_ ) );
-//            refres_ /= op( eval( reflhs_ ) * eval( refrhs_ ) );
-//         }
-//         catch( std::exception& ex ) {
-//            convertException<TTT>( ex );
-//         }
-//
-//         checkResults<TTT>();
-//      }
-   //}
+
+   // Customized multiplication with evaluated tensor/vector
+   {
+      test_  = "Customized multiplication with evaluated tensor/vector (" + name + ")";
+      error_ = "Failed multiplication operation";
+
+      try {
+         initResults();
+         dres_   = op( eval( lhs_ ) * eval( rhs_ ) );
+         refres_ = op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+   }
+
+
+   //=====================================================================================
+   // Customized multiplication with addition assignment
+   //=====================================================================================
+
+   // Customized multiplication with addition assignment with the given tensor/vector
+   {
+      test_  = "Customized multiplication with addition assignment with the given tensor/vector (" + name + ")";
+      error_ = "Failed addition assignment operation";
+
+      try {
+         initResults();
+         dres_   += op( lhs_ * rhs_ );
+         refres_ += op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+   }
+
+   // Customized multiplication with addition assignment with evaluated tensor/vector
+   {
+      test_  = "Customized multiplication with addition assignment with evaluated tensor/vector (" + name + ")";
+      error_ = "Failed addition assignment operation";
+
+      try {
+         initResults();
+         dres_   += op( eval( lhs_ ) * eval( rhs_ ) );
+         refres_ += op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+   }
+
+
+   //=====================================================================================
+   // Customized multiplication with subtraction assignment
+   //=====================================================================================
+
+   // Customized multiplication with subtraction assignment with the given tensor/vector
+   {
+      test_  = "Customized multiplication with subtraction assignment with the given tensor/vector (" + name + ")";
+      error_ = "Failed subtraction assignment operation";
+
+      try {
+         initResults();
+         dres_   -= op( lhs_ * rhs_ );
+         refres_ -= op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+   }
+
+   // Customized multiplication with subtraction assignment with evaluated tensor/vector
+   {
+      test_  = "Customized multiplication with subtraction assignment with evaluated tensor/vector (" + name + ")";
+      error_ = "Failed subtraction assignment operation";
+
+      try {
+         initResults();
+         dres_   -= op( eval( lhs_ ) * eval( rhs_ ) );
+         refres_ -= op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+   }
+
+
+   //=====================================================================================
+   // Customized multiplication with schur assignment
+   //=====================================================================================
+
+   // Customized multiplication with schur assignment with the given tensor/vector
+   {
+      test_  = "Customized multiplication with schur assignment with the given tensor/vector (" + name + ")";
+      error_ = "Failed schur assignment operation";
+
+      try {
+         initResults();
+         dres_   %= op( lhs_ * rhs_ );
+         refres_ %= op( reflhs_ * refrhs_ );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+   }
+
+   // Customized multiplication with multiplication assignment with evaluated tensor/vector
+   {
+      test_  = "Customized multiplication with multiplication assignment with evaluated tensor/vector (" + name + ")";
+      error_ = "Failed multiplication assignment operation";
+
+      try {
+         initResults();
+         dres_   %= op( eval( lhs_ ) * eval( rhs_ ) );
+         refres_ %= op( eval( reflhs_ ) * eval( refrhs_ ) );
+      }
+      catch( std::exception& ex ) {
+         convertException<TT>( ex );
+      }
+
+      checkResults<TT>();
+   }
+
 }
 //*************************************************************************************************
 

--- a/blazetest/src/mathtest/dtensdvecmult/AliasingTest.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/AliasingTest.cpp
@@ -66,14 +66,10 @@ namespace dtensdvecmult {
 // \exception std::runtime_error Operation error detected.
 */
 AliasingTest::AliasingTest()
-   : dA2x3x4_ ( 2UL, 3UL, 4UL )
-   , dB2x4x3_ ( 2UL, 4UL, 3UL )
-   , da4_   ( 4UL )
-   , db4_   ( 4UL )
+   : dB3x3x3_ ( 3UL, 3UL, 3UL )
    , dc3_   ( 3UL )
    , dd3_   ( 3UL )
-   , de3_   ( 3UL )
-   , result_()
+   , res_()
 {
    testDTensDVecMult ();
 }
@@ -109,269 +105,114 @@ void AliasingTest::testDTensDVecMult()
 
       initialize();
 
-      //result_ = (dB2x4x3_ * dc3_) * da4_;
-      //da4_    = (dB2x4x3_ * dc3_) * da4_;
+      res_ = (dB3x3x3_ * dc3_) * dc3_;
+      dc3_ = (dB3x3x3_ * dc3_) * dc3_;
 
-      //checkResult( da4_, result_ );
+      checkResult( dc3_, res_ );
    }
 
-   // Assignment to first operand of left-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Assignment to first operand of left-hand side compound";
+   // Assignment to first operand of right-hand side compound
+   {
+      test_ = "DTensDVecMult - Assignment to first operand of right-hand side compound";
 
-   //   initialize();
+      initialize();
 
-   //   result_ = ( dc3_ * trans( da4_ ) ) * db4_;
-   //   dc3_    = ( dc3_ * trans( da4_ ) ) * db4_;
+      res_ = dB3x3x3_ * ( dc3_ + dd3_ ) * dc3_;
+      dc3_ = dB3x3x3_ * ( dc3_ + dd3_ ) * dc3_;
 
-   //   checkResult( dc3_, result_ );
-   //}
+      checkResult( dc3_, res_ );
+   }
 
-   //// Assignment to second operand of left-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Assignment to second operand of left-hand side compound";
+   //=====================================================================================
+   // Multiplication with addition assignment
+   //=====================================================================================
 
-   //   initialize();
+   // Addition assignment to left-hand side operand
+   {
+      test_ = "DTensDVecMult - Addition assignment to right-hand side vector operand";
 
-   //   result_ = ( dc3_ * trans( da4_ ) ) * db4_;
-   //   da4_    = ( dc3_ * trans( da4_ ) ) * db4_;
+      initialize();
 
-   //   checkResult( da4_, result_ );
-   //}
+      res_ =  dc3_;
+      res_ += (dB3x3x3_ * dc3_) * dc3_;
+      dc3_ += (dB3x3x3_ * dc3_) * dc3_;
 
-   //// Assignment to first operand of right-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Assignment to first operand of right-hand side compound";
+      checkResult( dc3_, res_ );
+   }
 
-   //   initialize();
+   // Addition assignment to first operand of right-hand side compound
+   {
+      test_ = "DTensDVecMult - Addition assignment to first operand of left-hand side compound";
 
-   //   result_ = dA3x4_ * ( da4_ + sa4_ );
-   //   da4_    = dA3x4_ * ( da4_ + sa4_ );
+      initialize();
 
-   //   checkResult( da4_, result_ );
-   //}
+      res_ =  dc3_;
+      res_ += dB3x3x3_ * ( dc3_ + dd3_ ) * dc3_;
+      dc3_ += dB3x3x3_ * ( dc3_ + dd3_ ) * dc3_;
 
-   //// Assignment to second operand of right-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Assignment to second operand of right-hand side compound";
+      checkResult( dc3_, res_ );
+   }
 
-   //   initialize();
+   //=====================================================================================
+   // Multiplication with subtraction assignment
+   //=====================================================================================
 
-   //   result_ = dA3x4_ * ( da4_ + sa4_ );
-   //   sa4_    = dA3x4_ * ( da4_ + sa4_ );
+   // subtraction assignment to left-hand side operand
+   {
+      test_ = "DTensDVecMult - subtraction assignment to right-hand side vector operand";
 
-   //   checkResult( sa4_, result_ );
-   //}
+      initialize();
 
+      res_ =  dc3_;
+      res_ -= (dB3x3x3_ * dc3_) * dc3_;
+      dc3_ -= (dB3x3x3_ * dc3_) * dc3_;
 
-   ////=====================================================================================
-   //// Multiplication with addition assignment
-   ////=====================================================================================
+      checkResult( dc3_, res_ );
+   }
 
-   //// Addition assignment to left-hand side operand
-   //{
-   //   test_ = "DTensDVecMult - Addition assignment to right-hand side vector operand";
+   // subtraction assignment to first operand of right-hand side compound
+   {
+      test_ = "DTensDVecMult - subtraction assignment to first operand of left-hand side compound";
 
-   //   initialize();
+      initialize();
 
-   //   result_ =  dc3_;
-   //   result_ += dB3x3_ * dc3_;
-   //   dc3_    += dB3x3_ * dc3_;
+      res_ =  dc3_;
+      res_ -= dB3x3x3_ * ( dc3_ + dd3_ ) * dc3_;
+      dc3_ -= dB3x3x3_ * ( dc3_ + dd3_ ) * dc3_;
 
-   //   checkResult( dc3_, result_ );
-   //}
+      checkResult( dc3_, res_ );
+   }
 
-   //// Addition assignment to first operand of left-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Addition assignment to first operand of left-hand side compound";
+   //=====================================================================================
+   // Multiplication with schur assignment
+   //=====================================================================================
 
-   //   initialize();
+   // schur assignment to left-hand side operand
+   {
+      test_ = "DTensDVecMult - schur assignment to right-hand side vector operand";
 
-   //   result_ =  dc3_;
-   //   result_ += ( dc3_ * trans( dd3_ ) ) * de3_;
-   //   dc3_    += ( dc3_ * trans( dd3_ ) ) * de3_;
+      initialize();
 
-   //   checkResult( dc3_, result_ );
-   //}
+      res_ =  dc3_;
+      res_ %= (dB3x3x3_ * dc3_) * dc3_;
+      dc3_ %= (dB3x3x3_ * dc3_) * dc3_;
 
-   //// Addition assignment to second operand of left-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Addition assignment to second operand of left-hand side compound";
+      checkResult( dc3_, res_ );
+   }
 
-   //   initialize();
+   // schur assignment to first operand of right-hand side compound
+   {
+      test_ = "DTensDVecMult - schur assignment to first operand of left-hand side compound";
 
-   //   result_ =  dd3_;
-   //   result_ += ( dc3_ * trans( dd3_ ) ) * de3_;
-   //   dd3_    += ( dc3_ * trans( dd3_ ) ) * de3_;
+      initialize();
 
-   //   checkResult( dd3_, result_ );
-   //}
+      res_ =  dc3_;
+      res_ %= dB3x3x3_ * ( dc3_ + dd3_ ) * dc3_;
+      dc3_ %= dB3x3x3_ * ( dc3_ + dd3_ ) * dc3_;
 
-   //// Addition assignment to first operand of right-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Addition assignment to first operand of left-hand side compound";
+      checkResult( dc3_, res_ );
+   }
 
-   //   initialize();
-
-   //   result_ =  dc3_;
-   //   result_ += dB3x3_ * ( dc3_ + sb3_ );
-   //   dc3_    += dB3x3_ * ( dc3_ + sb3_ );
-
-   //   checkResult( dc3_, result_ );
-   //}
-
-   //// Addition assignment to second operand of right-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Addition assignment to second operand of left-hand side compound";
-
-   //   initialize();
-
-   //   result_ =  sb3_;
-   //   result_ += dB3x3_ * ( dc3_ + sb3_ );
-   //   sb3_    += dB3x3_ * ( dc3_ + sb3_ );
-
-   //   checkResult( sb3_, result_ );
-   //}
-
-
-   ////=====================================================================================
-   //// Multiplication with subtraction assignment
-   ////=====================================================================================
-
-   //// Subtraction assignment to left-hand side operand
-   //{
-   //   test_ = "DTensDVecMult - Subtraction assignment to right-hand side vector operand";
-
-   //   initialize();
-
-   //   result_ =  dc3_;
-   //   result_ -= dB3x3_ * dc3_;
-   //   dc3_    -= dB3x3_ * dc3_;
-
-   //   checkResult( dc3_, result_ );
-   //}
-
-   //// Subtraction assignment to first operand of left-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Subtraction assignment to first operand of left-hand side compound";
-
-   //   initialize();
-
-   //   result_ =  dc3_;
-   //   result_ -= ( dc3_ * trans( dd3_ ) ) * de3_;
-   //   dc3_    -= ( dc3_ * trans( dd3_ ) ) * de3_;
-
-   //   checkResult( dc3_, result_ );
-   //}
-
-   //// Subtraction assignment to second operand of left-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Subtraction assignment to second operand of left-hand side compound";
-
-   //   initialize();
-
-   //   result_ =  dd3_;
-   //   result_ -= ( dc3_ * trans( dd3_ ) ) * de3_;
-   //   dd3_    -= ( dc3_ * trans( dd3_ ) ) * de3_;
-
-   //   checkResult( dd3_, result_ );
-   //}
-
-   //// Subtraction assignment to first operand of right-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Subtraction assignment to first operand of left-hand side compound";
-
-   //   initialize();
-
-   //   result_ =  dc3_;
-   //   result_ -= dB3x3_ * ( dc3_ + sb3_ );
-   //   dc3_    -= dB3x3_ * ( dc3_ + sb3_ );
-
-   //   checkResult( dc3_, result_ );
-   //}
-
-   //// Subtraction assignment to second operand of right-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Subtraction assignment to second operand of left-hand side compound";
-
-   //   initialize();
-
-   //   result_ =  sb3_;
-   //   result_ -= dB3x3_ * ( dc3_ + sb3_ );
-   //   sb3_    -= dB3x3_ * ( dc3_ + sb3_ );
-
-   //   checkResult( sb3_, result_ );
-   //}
-
-
-   ////=====================================================================================
-   //// Multiplication with multiplication assignment
-   ////=====================================================================================
-
-   //// Multiplication assignment to left-hand side operand
-   //{
-   //   test_ = "DTensDVecMult - Multiplication assignment to right-hand side vector operand";
-
-   //   initialize();
-
-   //   result_ =  dc3_;
-   //   result_ *= dB3x3_ * dc3_;
-   //   dc3_    *= dB3x3_ * dc3_;
-
-   //   checkResult( dc3_, result_ );
-   //}
-
-   //// Multiplication assignment to first operand of left-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Multiplication assignment to first operand of left-hand side compound";
-
-   //   initialize();
-
-   //   result_ =  dc3_;
-   //   result_ *= ( dc3_ * trans( dd3_ ) ) * de3_;
-   //   dc3_    *= ( dc3_ * trans( dd3_ ) ) * de3_;
-
-   //   checkResult( dc3_, result_ );
-   //}
-
-   //// Multiplication assignment to second operand of left-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Multiplication assignment to second operand of left-hand side compound";
-
-   //   initialize();
-
-   //   result_ =  dd3_;
-   //   result_ *= ( dc3_ * trans( dd3_ ) ) * de3_;
-   //   dd3_    *= ( dc3_ * trans( dd3_ ) ) * de3_;
-
-   //   checkResult( dd3_, result_ );
-   //}
-
-   //// Multiplication assignment to first operand of right-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Multiplication assignment to first operand of left-hand side compound";
-
-   //   initialize();
-
-   //   result_ =  dc3_;
-   //   result_ *= dB3x3_ * ( dc3_ + sb3_ );
-   //   dc3_    *= dB3x3_ * ( dc3_ + sb3_ );
-
-   //   checkResult( dc3_, result_ );
-   //}
-
-   //// Multiplication assignment to second operand of right-hand side compound
-   //{
-   //   test_ = "DTensDVecMult - Multiplication assignment to second operand of left-hand side compound";
-
-   //   initialize();
-
-   //   result_ =  sb3_;
-   //   result_ *= dB3x3_ * ( dc3_ + sb3_ );
-   //   sb3_    *= dB3x3_ * ( dc3_ + sb3_ );
-
-   //   checkResult( sb3_, result_ );
-   //}
 }
 //*************************************************************************************************
 
@@ -398,79 +239,40 @@ void AliasingTest::initialize()
    // Initialization of the dense tensors
    //=====================================================================================
 
-   // Initializing the first dense tensor
-   dA2x3x4_.resize( 2UL, 3UL, 4UL, false );
-   dA2x3x4_(0,0,0) = -1;
-   dA2x3x4_(0,0,1) =  0;
-   dA2x3x4_(0,0,2) = -2;
-   dA2x3x4_(0,0,3) =  0;
-   dA2x3x4_(0,1,0) =  0;
-   dA2x3x4_(0,1,1) =  2;
-   dA2x3x4_(0,1,2) = -3;
-   dA2x3x4_(0,1,3) =  1;
-   dA2x3x4_(0,2,0) =  0;
-   dA2x3x4_(0,2,1) =  1;
-   dA2x3x4_(0,2,2) =  2;
-   dA2x3x4_(0,2,3) =  2;
-   dA2x3x4_(1,0,0) = -1;
-   dA2x3x4_(1,0,1) =  0;
-   dA2x3x4_(1,0,2) = -2;
-   dA2x3x4_(1,0,3) =  0;
-   dA2x3x4_(1,1,0) =  0;
-   dA2x3x4_(1,1,1) =  2;
-   dA2x3x4_(1,1,2) = -3;
-   dA2x3x4_(1,1,3) =  1;
-   dA2x3x4_(1,2,0) =  0;
-   dA2x3x4_(1,2,1) =  1;
-   dA2x3x4_(1,2,2) =  2;
-   dA2x3x4_(1,2,3) =  2;
-
-   // Initializing the second row-major dense tensor
-   dB2x4x3_.resize( 2UL, 4UL, 3UL, false );
-   dB2x4x3_(0,0,0) =  1;
-   dB2x4x3_(0,0,1) =  0;
-   dB2x4x3_(0,0,2) = -3;
-   dB2x4x3_(0,1,0) =  0;
-   dB2x4x3_(0,1,1) = -1;
-   dB2x4x3_(0,1,2) =  0;
-   dB2x4x3_(0,2,0) =  0;
-   dB2x4x3_(0,2,1) =  2;
-   dB2x4x3_(0,2,2) =  1;
-   dB2x4x3_(0,3,0) =  2;
-   dB2x4x3_(0,3,1) =  1;
-   dB2x4x3_(0,3,2) = -2;
-   dB2x4x3_(1,0,0) =  1;
-   dB2x4x3_(1,0,1) =  0;
-   dB2x4x3_(1,0,2) = -3;
-   dB2x4x3_(1,1,0) =  0;
-   dB2x4x3_(1,1,1) = -1;
-   dB2x4x3_(1,1,2) =  0;
-   dB2x4x3_(1,2,0) =  0;
-   dB2x4x3_(1,2,1) =  2;
-   dB2x4x3_(1,2,2) =  1;
-   dB2x4x3_(1,3,0) =  2;
-   dB2x4x3_(1,3,1) =  1;
-   dB2x4x3_(1,3,2) = -2;
-
+   // Initializing the fisrt row-major dense tensor
+   dB3x3x3_.resize( 3UL, 3UL, 3UL, false );
+   dB3x3x3_(0,0,0) =  1;
+   dB3x3x3_(0,0,1) =  0;
+   dB3x3x3_(0,0,2) = -3;
+   dB3x3x3_(0,1,0) =  0;
+   dB3x3x3_(0,1,1) = -1;
+   dB3x3x3_(0,1,2) =  0;
+   dB3x3x3_(0,2,0) =  0;
+   dB3x3x3_(0,2,1) =  2;
+   dB3x3x3_(0,2,2) =  1;
+   dB3x3x3_(1,0,0) =  1;
+   dB3x3x3_(1,0,1) =  0;
+   dB3x3x3_(1,0,2) = -3;
+   dB3x3x3_(1,1,0) =  0;
+   dB3x3x3_(1,1,1) = -1;
+   dB3x3x3_(1,1,2) =  0;
+   dB3x3x3_(1,2,0) =  0;
+   dB3x3x3_(1,2,1) =  2;
+   dB3x3x3_(1,2,2) =  1;
+   dB3x3x3_(2,0,0) = -1;
+   dB3x3x3_(2,0,1) = -2;
+   dB3x3x3_(2,0,2) = -3;
+   dB3x3x3_(2,1,0) =  0;
+   dB3x3x3_(2,1,1) = -1;
+   dB3x3x3_(2,1,2) =  4;
+   dB3x3x3_(2,2,0) =  0;
+   dB3x3x3_(2,2,1) =  2;
+   dB3x3x3_(2,2,2) =  2;
 
 
    //=====================================================================================
    // Initialization of the dense vectors
    //=====================================================================================
-
-   // Initializing the first dense column vector
-   da4_.resize( 4UL, false );
-   da4_[0] = -1;
-   da4_[1] =  0;
-   da4_[2] = -3;
-   da4_[3] =  2;
-
-   // Initializing the second dense column vector
-   db4_.resize( 4UL, false );
-   db4_[0] =  0;
-   db4_[1] =  1;
-   db4_[2] =  2;
-   db4_[3] = -1;
 
    // Initializing the third dense column vector
    dc3_.resize( 3UL, false );
@@ -484,11 +286,6 @@ void AliasingTest::initialize()
    dd3_[1] = 2;
    dd3_[2] = 1;
 
-   // Initializing the fifth dense column vector
-   de3_.resize( 3UL, false );
-   de3_[0] = 0;
-   de3_[1] = 1;
-   de3_[2] = 3;
 
 }
 //*************************************************************************************************

--- a/blazetest/src/mathtest/dtensdvecmult/AliasingTest.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/AliasingTest.cpp
@@ -1,0 +1,528 @@
+//=================================================================================================
+/*!
+//  \file src/mathtest/dtensdvecmult/AliasingTest.cpp
+//  \brief Source file for the dense tensrix/dense vector multiplication aliasing test
+//
+//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
+//
+//  This file is part of the Blaze library. You can redistribute it and/or modify it under
+//  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
+//  forms, with or without modification, are permitted provided that the following conditions
+//  are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of
+//     conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list
+//     of conditions and the following disclaimer in the documentation and/or other tenserials
+//     provided with the distribution.
+//  3. Neither the names of the Blaze development group nor the names of its contributors
+//     may be used to endorse or promote products derived from this software without specific
+//     prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+//  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+//  BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+*/
+//=================================================================================================
+
+
+//*************************************************************************************************
+// Includes
+//*************************************************************************************************
+
+#include <cstdlib>
+#include <iostream>
+#include <blazetest/mathtest/dtensdvecmult/AliasingTest.h>
+
+#ifdef BLAZE_USE_HPX_THREADS
+#  include <hpx/hpx_main.hpp>
+#endif
+
+
+namespace blazetest {
+
+namespace mathtest {
+
+namespace dtensdvecmult {
+
+//=================================================================================================
+//
+//  CONSTRUCTORS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Constructor for the aliasing test class.
+//
+// \exception std::runtime_error Operation error detected.
+*/
+AliasingTest::AliasingTest()
+   : dA2x3x4_ ( 2UL, 3UL, 4UL )
+   , dB2x4x3_ ( 2UL, 4UL, 3UL )
+   , da4_   ( 4UL )
+   , db4_   ( 4UL )
+   , dc3_   ( 3UL )
+   , dd3_   ( 3UL )
+   , de3_   ( 3UL )
+   , result_()
+{
+   testDTensDVecMult ();
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  TEST FUNCTIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Test of the dense tensrix/dense vector multiplication.
+//
+// \return void
+// \exception std::runtime_error Error detected.
+//
+// This function performs aliasing tests for the dense tensrix/dense vector multiplication.
+// In case an error is detected, a \a std::runtime_error exception is thrown.
+*/
+void AliasingTest::testDTensDVecMult()
+{
+   //=====================================================================================
+   // Multiplication
+   //=====================================================================================
+
+   // Assignment to left-hand side operand
+   {
+      test_ = "DTensDVecMult - Assignment to right-hand side vector operand";
+
+      initialize();
+
+      result_ = (dB2x4x3_ * dc3_) * da4_;
+      da4_    = (dB2x4x3_ * dc3_) * da4_;
+
+      checkResult( da4_, result_ );
+   }
+
+   // Assignment to first operand of left-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Assignment to first operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ = ( dc3_ * trans( da4_ ) ) * db4_;
+   //   dc3_    = ( dc3_ * trans( da4_ ) ) * db4_;
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Assignment to second operand of left-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Assignment to second operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ = ( dc3_ * trans( da4_ ) ) * db4_;
+   //   da4_    = ( dc3_ * trans( da4_ ) ) * db4_;
+
+   //   checkResult( da4_, result_ );
+   //}
+
+   //// Assignment to first operand of right-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Assignment to first operand of right-hand side compound";
+
+   //   initialize();
+
+   //   result_ = dA3x4_ * ( da4_ + sa4_ );
+   //   da4_    = dA3x4_ * ( da4_ + sa4_ );
+
+   //   checkResult( da4_, result_ );
+   //}
+
+   //// Assignment to second operand of right-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Assignment to second operand of right-hand side compound";
+
+   //   initialize();
+
+   //   result_ = dA3x4_ * ( da4_ + sa4_ );
+   //   sa4_    = dA3x4_ * ( da4_ + sa4_ );
+
+   //   checkResult( sa4_, result_ );
+   //}
+
+
+   ////=====================================================================================
+   //// Multiplication with addition assignment
+   ////=====================================================================================
+
+   //// Addition assignment to left-hand side operand
+   //{
+   //   test_ = "DTensDVecMult - Addition assignment to right-hand side vector operand";
+
+   //   initialize();
+
+   //   result_ =  dc3_;
+   //   result_ += dB3x3_ * dc3_;
+   //   dc3_    += dB3x3_ * dc3_;
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Addition assignment to first operand of left-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Addition assignment to first operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  dc3_;
+   //   result_ += ( dc3_ * trans( dd3_ ) ) * de3_;
+   //   dc3_    += ( dc3_ * trans( dd3_ ) ) * de3_;
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Addition assignment to second operand of left-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Addition assignment to second operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  dd3_;
+   //   result_ += ( dc3_ * trans( dd3_ ) ) * de3_;
+   //   dd3_    += ( dc3_ * trans( dd3_ ) ) * de3_;
+
+   //   checkResult( dd3_, result_ );
+   //}
+
+   //// Addition assignment to first operand of right-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Addition assignment to first operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  dc3_;
+   //   result_ += dB3x3_ * ( dc3_ + sb3_ );
+   //   dc3_    += dB3x3_ * ( dc3_ + sb3_ );
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Addition assignment to second operand of right-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Addition assignment to second operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  sb3_;
+   //   result_ += dB3x3_ * ( dc3_ + sb3_ );
+   //   sb3_    += dB3x3_ * ( dc3_ + sb3_ );
+
+   //   checkResult( sb3_, result_ );
+   //}
+
+
+   ////=====================================================================================
+   //// Multiplication with subtraction assignment
+   ////=====================================================================================
+
+   //// Subtraction assignment to left-hand side operand
+   //{
+   //   test_ = "DTensDVecMult - Subtraction assignment to right-hand side vector operand";
+
+   //   initialize();
+
+   //   result_ =  dc3_;
+   //   result_ -= dB3x3_ * dc3_;
+   //   dc3_    -= dB3x3_ * dc3_;
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Subtraction assignment to first operand of left-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Subtraction assignment to first operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  dc3_;
+   //   result_ -= ( dc3_ * trans( dd3_ ) ) * de3_;
+   //   dc3_    -= ( dc3_ * trans( dd3_ ) ) * de3_;
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Subtraction assignment to second operand of left-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Subtraction assignment to second operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  dd3_;
+   //   result_ -= ( dc3_ * trans( dd3_ ) ) * de3_;
+   //   dd3_    -= ( dc3_ * trans( dd3_ ) ) * de3_;
+
+   //   checkResult( dd3_, result_ );
+   //}
+
+   //// Subtraction assignment to first operand of right-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Subtraction assignment to first operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  dc3_;
+   //   result_ -= dB3x3_ * ( dc3_ + sb3_ );
+   //   dc3_    -= dB3x3_ * ( dc3_ + sb3_ );
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Subtraction assignment to second operand of right-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Subtraction assignment to second operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  sb3_;
+   //   result_ -= dB3x3_ * ( dc3_ + sb3_ );
+   //   sb3_    -= dB3x3_ * ( dc3_ + sb3_ );
+
+   //   checkResult( sb3_, result_ );
+   //}
+
+
+   ////=====================================================================================
+   //// Multiplication with multiplication assignment
+   ////=====================================================================================
+
+   //// Multiplication assignment to left-hand side operand
+   //{
+   //   test_ = "DTensDVecMult - Multiplication assignment to right-hand side vector operand";
+
+   //   initialize();
+
+   //   result_ =  dc3_;
+   //   result_ *= dB3x3_ * dc3_;
+   //   dc3_    *= dB3x3_ * dc3_;
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Multiplication assignment to first operand of left-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Multiplication assignment to first operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  dc3_;
+   //   result_ *= ( dc3_ * trans( dd3_ ) ) * de3_;
+   //   dc3_    *= ( dc3_ * trans( dd3_ ) ) * de3_;
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Multiplication assignment to second operand of left-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Multiplication assignment to second operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  dd3_;
+   //   result_ *= ( dc3_ * trans( dd3_ ) ) * de3_;
+   //   dd3_    *= ( dc3_ * trans( dd3_ ) ) * de3_;
+
+   //   checkResult( dd3_, result_ );
+   //}
+
+   //// Multiplication assignment to first operand of right-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Multiplication assignment to first operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  dc3_;
+   //   result_ *= dB3x3_ * ( dc3_ + sb3_ );
+   //   dc3_    *= dB3x3_ * ( dc3_ + sb3_ );
+
+   //   checkResult( dc3_, result_ );
+   //}
+
+   //// Multiplication assignment to second operand of right-hand side compound
+   //{
+   //   test_ = "DTensDVecMult - Multiplication assignment to second operand of left-hand side compound";
+
+   //   initialize();
+
+   //   result_ =  sb3_;
+   //   result_ *= dB3x3_ * ( dc3_ + sb3_ );
+   //   sb3_    *= dB3x3_ * ( dc3_ + sb3_ );
+
+   //   checkResult( sb3_, result_ );
+   //}
+}
+//*************************************************************************************************
+
+
+
+
+//=================================================================================================
+//
+//  UTILITY FUNCTIONS
+//
+//=================================================================================================
+
+//*************************************************************************************************
+/*!\brief Initialization of all member vectors and tensors.
+//
+// \return void
+// \exception std::runtime_error Error detected.
+//
+// This function initializes all member vectors and tensors to specific predetermined values.
+*/
+void AliasingTest::initialize()
+{
+   //=====================================================================================
+   // Initialization of the dense tensors
+   //=====================================================================================
+
+   // Initializing the first dense tensor
+   dA2x3x4_.resize( 2UL, 3UL, 4UL, false );
+   dA2x3x4_(0,0,0) = -1;
+   dA2x3x4_(0,0,1) =  0;
+   dA2x3x4_(0,0,2) = -2;
+   dA2x3x4_(0,0,3) =  0;
+   dA2x3x4_(0,1,0) =  0;
+   dA2x3x4_(0,1,1) =  2;
+   dA2x3x4_(0,1,2) = -3;
+   dA2x3x4_(0,1,3) =  1;
+   dA2x3x4_(0,2,0) =  0;
+   dA2x3x4_(0,2,1) =  1;
+   dA2x3x4_(0,2,2) =  2;
+   dA2x3x4_(0,2,3) =  2;
+   dA2x3x4_(1,0,0) = -1;
+   dA2x3x4_(1,0,1) =  0;
+   dA2x3x4_(1,0,2) = -2;
+   dA2x3x4_(1,0,3) =  0;
+   dA2x3x4_(1,1,0) =  0;
+   dA2x3x4_(1,1,1) =  2;
+   dA2x3x4_(1,1,2) = -3;
+   dA2x3x4_(1,1,3) =  1;
+   dA2x3x4_(1,2,0) =  0;
+   dA2x3x4_(1,2,1) =  1;
+   dA2x3x4_(1,2,2) =  2;
+   dA2x3x4_(1,2,3) =  2;
+
+   // Initializing the second row-major dense tensor
+   dB2x4x3_.resize( 2UL, 4UL, 3UL, false );
+   dB2x4x3_(0,0,0) =  1;
+   dB2x4x3_(0,0,1) =  0;
+   dB2x4x3_(0,0,2) = -3;
+   dB2x4x3_(0,1,0) =  0;
+   dB2x4x3_(0,1,1) = -1;
+   dB2x4x3_(0,1,2) =  0;
+   dB2x4x3_(0,2,0) =  0;
+   dB2x4x3_(0,2,1) =  2;
+   dB2x4x3_(0,2,2) =  1;
+   dB2x4x3_(0,3,0) =  2;
+   dB2x4x3_(0,3,1) =  1;
+   dB2x4x3_(0,3,2) = -2;
+   dB2x4x3_(1,0,0) =  1;
+   dB2x4x3_(1,0,1) =  0;
+   dB2x4x3_(1,0,2) = -3;
+   dB2x4x3_(1,1,0) =  0;
+   dB2x4x3_(1,1,1) = -1;
+   dB2x4x3_(1,1,2) =  0;
+   dB2x4x3_(1,2,0) =  0;
+   dB2x4x3_(1,2,1) =  2;
+   dB2x4x3_(1,2,2) =  1;
+   dB2x4x3_(1,3,0) =  2;
+   dB2x4x3_(1,3,1) =  1;
+   dB2x4x3_(1,3,2) = -2;
+
+
+
+   //=====================================================================================
+   // Initialization of the dense vectors
+   //=====================================================================================
+
+   // Initializing the first dense column vector
+   da4_.resize( 4UL, false );
+   da4_[0] = -1;
+   da4_[1] =  0;
+   da4_[2] = -3;
+   da4_[3] =  2;
+
+   // Initializing the second dense column vector
+   db4_.resize( 4UL, false );
+   db4_[0] =  0;
+   db4_[1] =  1;
+   db4_[2] =  2;
+   db4_[3] = -1;
+
+   // Initializing the third dense column vector
+   dc3_.resize( 3UL, false );
+   dc3_[0] = 1;
+   dc3_[1] = 2;
+   dc3_[2] = 3;
+
+   // Initializing the fourth dense column vector
+   dd3_.resize( 3UL, false );
+   dd3_[0] = 0;
+   dd3_[1] = 2;
+   dd3_[2] = 1;
+
+   // Initializing the fifth dense column vector
+   de3_.resize( 3UL, false );
+   de3_[0] = 0;
+   de3_[1] = 1;
+   de3_[2] = 3;
+
+}
+//*************************************************************************************************
+
+} // namespace dtensdvecmult
+
+} // namespace mathtest
+
+} // namespace blazetest
+
+
+
+
+//=================================================================================================
+//
+//  MAIN FUNCTION
+//
+//=================================================================================================
+
+//*************************************************************************************************
+int main()
+{
+   std::cout << "   Running aliasing test..." << std::endl;
+
+   try
+   {
+      RUN_DTENSDVECMULT_ALIASING_TEST;
+   }
+   catch( std::exception& ex ) {
+      std::cerr << "\n\n ERROR DETECTED during aliasing test:\n"
+                << ex.what() << "\n";
+      return EXIT_FAILURE;
+   }
+
+   return EXIT_SUCCESS;
+}
+//*************************************************************************************************

--- a/blazetest/src/mathtest/dtensdvecmult/AliasingTest.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/AliasingTest.cpp
@@ -109,10 +109,10 @@ void AliasingTest::testDTensDVecMult()
 
       initialize();
 
-      result_ = (dB2x4x3_ * dc3_) * da4_;
-      da4_    = (dB2x4x3_ * dc3_) * da4_;
+      //result_ = (dB2x4x3_ * dc3_) * da4_;
+      //da4_    = (dB2x4x3_ * dc3_) * da4_;
 
-      checkResult( da4_, result_ );
+      //checkResult( da4_, result_ );
    }
 
    // Assignment to first operand of left-hand side compound

--- a/blazetest/src/mathtest/dtensdvecmult/CMakeLists.txt
+++ b/blazetest/src/mathtest/dtensdvecmult/CMakeLists.txt
@@ -35,6 +35,12 @@ set(category DTensDVecMult)
 
 set(tests
     AliasingTest
+    T2x3x4aV4a
+    T2x3x4aV4b
+    T2x3x4aVDa
+    T2x3x4aVDb
+    TDaV4a
+    TDaV4b
 )
 
 foreach(test ${tests})

--- a/blazetest/src/mathtest/dtensdvecmult/CMakeLists.txt
+++ b/blazetest/src/mathtest/dtensdvecmult/CMakeLists.txt
@@ -39,6 +39,7 @@ set(tests
     T2x3x4aV4b
     T2x3x4aVDa
     T2x3x4aVDb
+    T2x3x4aVHa
     TDaV4a
     TDaV4b
 )

--- a/blazetest/src/mathtest/dtensdvecmult/CMakeLists.txt
+++ b/blazetest/src/mathtest/dtensdvecmult/CMakeLists.txt
@@ -1,7 +1,8 @@
 # =================================================================================================
 #
 #   Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
-#   Copyright (C) 2018 Hartmut Kaiser - All Rights Reserved
+#   Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+#   Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 #
 #   This file is part of the Blaze library. You can redistribute it and/or modify it under
 #   the terms of the New (Revised) BSD License. Redistribution and use in source and binary
@@ -30,27 +31,14 @@
 #
 # =================================================================================================
 
-set(subdirs
-   columnslice
-   customtensor
-   densetensor
-   dilatedsubvector
-   dilatedsubmatrix
-   dmatexpand
-   dmatravel
-   dtensdtensadd
-   dtensdvecmult
-   dtensravel
-   dynamictensor
-   initializertensor
-   pageslice
-   rowslice
-   statictensor
-   subtensor
-   uniformtensor
+set(category DTensDVecMult)
+
+set(tests
+    AliasingTest
 )
 
-foreach(dir ${subdirs})
-   add_subdirectory(${dir})
+foreach(test ${tests})
+   add_blaze_tensor_test(${category}${test}
+      SOURCES ${test}
+      FOLDER "Tests/${category}")
 endforeach()
-

--- a/blazetest/src/mathtest/dtensdvecmult/T2x3x4aV4a.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/T2x3x4aV4a.cpp
@@ -1,9 +1,9 @@
 //=================================================================================================
 /*!
-//  \file blaze/math/expressions/MatVecMultExpr.h
-//  \brief Header file for the MatVecMultExpr base class
+//  \file src/mathtest/dtensdvecmult/T2x3x4aV4a.cpp
+//  \brief Source file for the T2x3x4aV4a dense tensor/dense vector multiplication math test
 //
-//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
 //  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
 //  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
@@ -34,43 +34,60 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-#define _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/expressions/MultExpr.h>
+#include <cstdlib>
+#include <iostream>
+#include <blaze/math/StaticVector.h>
+#include <blazetest/mathtest/creator/StaticTensor.h>
+#include <blazetest/mathtest/dtensdvecmult/OperationTest.h>
+#include <blazetest/system/MathTest.h>
 
+#include <blaze_tensor/math/dense/StaticMatrix.h>
+#include <blaze_tensor/math/dense/StaticVector.h>
+#include <blaze_tensor/math/StaticTensor.h>
 
-namespace blaze {
 
 //=================================================================================================
 //
-//  CLASS DEFINITION
+//  MAIN FUNCTION
 //
 //=================================================================================================
 
-//*************************************************************************************************
-/*!\brief Base class for all matrix/vector multiplication expression templates.
-// \ingroup math
-//
-// The MatVecMultExpr class serves as a tag for all expression templates that implement a
-// matrix/vector multiplication. All classes, that represent a matrix/vector multiplication
-// and that are used within the expression template environment of the Blaze library have
-// to derive publicly from this class in order to qualify as matrix/vector multiplication
-// expression template. Only in case a class is derived publicly from the MatVecMultExpr
-// base class, the IsMatVecMultExpr type trait recognizes the class as valid matrix/vector
-// multiplication expression template.
-*/
-template< typename MT >  // Matrix base type of the expression
-struct TensVecMultExpr
-   : public MultExpr<MT>
-{};
-//*************************************************************************************************
-
-} // namespace blaze
-
+#if defined(BLAZE_USE_HPX_THREADS)
+#include <hpx/hpx_main.hpp>
 #endif
+
+//*************************************************************************************************
+int main()
+
+{
+   std::cout << "   Running 'T2x3x4aV4a'..." << std::endl;
+
+   using blazetest::mathtest::TypeA;
+
+   try
+   {
+      // Tensor type definitions
+      using T2x3x4a = blaze::StaticTensor<TypeA,2UL,3UL,4UL>;
+      using V4a     = blaze::StaticVector<TypeA,4UL>;
+
+      // Creator type definitions
+      using CT2x3x4a = blazetest::Creator<T2x3x4a>;
+      using CV4a     = blazetest::Creator<V4a>;
+
+      // Running the tests
+      RUN_DTENSDVECMULT_OPERATION_TEST( CT2x3x4a(), CV4a() );
+   }
+   catch( std::exception& ex ) {
+      std::cerr << "\n\n ERROR DETECTED during dense tensor/dense vector multiplication:\n"
+                << ex.what() << "\n";
+      return EXIT_FAILURE;
+   }
+
+   return EXIT_SUCCESS;
+}
+//*************************************************************************************************

--- a/blazetest/src/mathtest/dtensdvecmult/T2x3x4aV4b.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/T2x3x4aV4b.cpp
@@ -1,9 +1,9 @@
 //=================================================================================================
 /*!
-//  \file blaze/math/expressions/MatVecMultExpr.h
-//  \brief Header file for the MatVecMultExpr base class
+//  \file src/mathtest/dtensdvecmult/T2x3x4aV4b.cpp
+//  \brief Source file for the T2x3x4aV4b dense tensor/dense vector multiplication math test
 //
-//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
 //  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
 //  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
@@ -34,43 +34,61 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-#define _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/expressions/MultExpr.h>
+#include <cstdlib>
+#include <iostream>
+#include <blaze/math/StaticVector.h>
+#include <blazetest/mathtest/creator/StaticTensor.h>
+#include <blazetest/mathtest/dtensdvecmult/OperationTest.h>
+#include <blazetest/system/MathTest.h>
 
+#include <blaze_tensor/math/dense/StaticMatrix.h>
+#include <blaze_tensor/math/dense/StaticVector.h>
+#include <blaze_tensor/math/StaticTensor.h>
 
-namespace blaze {
 
 //=================================================================================================
 //
-//  CLASS DEFINITION
+//  MAIN FUNCTION
 //
 //=================================================================================================
 
-//*************************************************************************************************
-/*!\brief Base class for all matrix/vector multiplication expression templates.
-// \ingroup math
-//
-// The MatVecMultExpr class serves as a tag for all expression templates that implement a
-// matrix/vector multiplication. All classes, that represent a matrix/vector multiplication
-// and that are used within the expression template environment of the Blaze library have
-// to derive publicly from this class in order to qualify as matrix/vector multiplication
-// expression template. Only in case a class is derived publicly from the MatVecMultExpr
-// base class, the IsMatVecMultExpr type trait recognizes the class as valid matrix/vector
-// multiplication expression template.
-*/
-template< typename MT >  // Matrix base type of the expression
-struct TensVecMultExpr
-   : public MultExpr<MT>
-{};
-//*************************************************************************************************
-
-} // namespace blaze
-
+#if defined(BLAZE_USE_HPX_THREADS)
+#include <hpx/hpx_main.hpp>
 #endif
+
+//*************************************************************************************************
+int main()
+
+{
+   std::cout << "   Running 'T2x3x4aV4b'..." << std::endl;
+
+   using blazetest::mathtest::TypeA;
+   using blazetest::mathtest::TypeB;
+
+   try
+   {
+      // Tensor type definitions
+      using T2x3x4a = blaze::StaticTensor<TypeA,2UL,3UL,4UL>;
+      using V4b     = blaze::StaticVector<TypeB,4UL>;
+
+      // Creator type definitions
+      using CT2x3x4a = blazetest::Creator<T2x3x4a>;
+      using CV4b     = blazetest::Creator<V4b>;
+
+      // Running the tests
+      RUN_DTENSDVECMULT_OPERATION_TEST( CT2x3x4a(), CV4b() );
+   }
+   catch( std::exception& ex ) {
+      std::cerr << "\n\n ERROR DETECTED during dense tensor/dense vector multiplication:\n"
+                << ex.what() << "\n";
+      return EXIT_FAILURE;
+   }
+
+   return EXIT_SUCCESS;
+}
+//*************************************************************************************************

--- a/blazetest/src/mathtest/dtensdvecmult/T2x3x4aVDa.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/T2x3x4aVDa.cpp
@@ -1,9 +1,9 @@
 //=================================================================================================
 /*!
-//  \file blaze/math/expressions/MatVecMultExpr.h
-//  \brief Header file for the MatVecMultExpr base class
+//  \file src/mathtest/dtensdvecmult/T2x3x4aVDa.cpp
+//  \brief Source file for the T2x3x4aVDa dense tensor/dense vector multiplication math test
 //
-//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
 //  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
 //  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
@@ -34,43 +34,60 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-#define _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/expressions/MultExpr.h>
+#include <cstdlib>
+#include <iostream>
+#include <blaze/math/DynamicVector.h>
+#include <blazetest/mathtest/creator/StaticTensor.h>
+#include <blazetest/mathtest/dtensdvecmult/OperationTest.h>
+#include <blazetest/system/MathTest.h>
 
+#include <blaze_tensor/math/dense/DynamicMatrix.h>
+#include <blaze_tensor/math/dense/DynamicVector.h>
+#include <blaze_tensor/math/StaticTensor.h>
 
-namespace blaze {
 
 //=================================================================================================
 //
-//  CLASS DEFINITION
+//  MAIN FUNCTION
 //
 //=================================================================================================
 
-//*************************************************************************************************
-/*!\brief Base class for all matrix/vector multiplication expression templates.
-// \ingroup math
-//
-// The MatVecMultExpr class serves as a tag for all expression templates that implement a
-// matrix/vector multiplication. All classes, that represent a matrix/vector multiplication
-// and that are used within the expression template environment of the Blaze library have
-// to derive publicly from this class in order to qualify as matrix/vector multiplication
-// expression template. Only in case a class is derived publicly from the MatVecMultExpr
-// base class, the IsMatVecMultExpr type trait recognizes the class as valid matrix/vector
-// multiplication expression template.
-*/
-template< typename MT >  // Matrix base type of the expression
-struct TensVecMultExpr
-   : public MultExpr<MT>
-{};
-//*************************************************************************************************
-
-} // namespace blaze
-
+#if defined(BLAZE_USE_HPX_THREADS)
+#include <hpx/hpx_main.hpp>
 #endif
+
+//*************************************************************************************************
+int main()
+
+{
+   std::cout << "   Running 'T2x3x4aVDa'..." << std::endl;
+
+   using blazetest::mathtest::TypeA;
+
+   try
+   {
+      // Tensor type definitions
+      using T2x3x4a = blaze::StaticTensor<TypeA,2UL,3UL,4UL>;
+      using VDa     = blaze::DynamicVector<TypeA>;
+
+      // Creator type definitions
+      using CT2x3x4a = blazetest::Creator<T2x3x4a>;
+      using CVDa     = blazetest::Creator<VDa>;
+
+      // Running the tests
+      RUN_DTENSDVECMULT_OPERATION_TEST( CT2x3x4a(), CVDa( 4UL ) );
+   }
+   catch( std::exception& ex ) {
+      std::cerr << "\n\n ERROR DETECTED during dense tensor/dense vector multiplication:\n"
+                << ex.what() << "\n";
+      return EXIT_FAILURE;
+   }
+
+   return EXIT_SUCCESS;
+}
+//*************************************************************************************************

--- a/blazetest/src/mathtest/dtensdvecmult/T2x3x4aVDb.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/T2x3x4aVDb.cpp
@@ -1,9 +1,9 @@
 //=================================================================================================
 /*!
-//  \file blaze/math/expressions/MatVecMultExpr.h
-//  \brief Header file for the MatVecMultExpr base class
+//  \file src/mathtest/dtensdvecmult/T2x3x4aVDb.cpp
+//  \brief Source file for the T2x3x4aVDb dense tensor/dense vector multiplication math test
 //
-//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
 //  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
 //  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
@@ -34,43 +34,61 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-#define _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/expressions/MultExpr.h>
+#include <cstdlib>
+#include <iostream>
+#include <blaze/math/DynamicVector.h>
+#include <blazetest/mathtest/creator/StaticTensor.h>
+#include <blazetest/mathtest/dtensdvecmult/OperationTest.h>
+#include <blazetest/system/MathTest.h>
 
+#include <blaze_tensor/math/dense/DynamicMatrix.h>
+#include <blaze_tensor/math/dense/DynamicVector.h>
+#include <blaze_tensor/math/StaticTensor.h>
 
-namespace blaze {
 
 //=================================================================================================
 //
-//  CLASS DEFINITION
+//  MAIN FUNCTION
 //
 //=================================================================================================
 
-//*************************************************************************************************
-/*!\brief Base class for all matrix/vector multiplication expression templates.
-// \ingroup math
-//
-// The MatVecMultExpr class serves as a tag for all expression templates that implement a
-// matrix/vector multiplication. All classes, that represent a matrix/vector multiplication
-// and that are used within the expression template environment of the Blaze library have
-// to derive publicly from this class in order to qualify as matrix/vector multiplication
-// expression template. Only in case a class is derived publicly from the MatVecMultExpr
-// base class, the IsMatVecMultExpr type trait recognizes the class as valid matrix/vector
-// multiplication expression template.
-*/
-template< typename MT >  // Matrix base type of the expression
-struct TensVecMultExpr
-   : public MultExpr<MT>
-{};
-//*************************************************************************************************
-
-} // namespace blaze
-
+#if defined(BLAZE_USE_HPX_THREADS)
+#include <hpx/hpx_main.hpp>
 #endif
+
+//*************************************************************************************************
+int main()
+
+{
+   std::cout << "   Running 'T2x3x4aVDb'..." << std::endl;
+
+   using blazetest::mathtest::TypeA;
+   using blazetest::mathtest::TypeB;
+
+   try
+   {
+      // Tensor type definitions
+      using T2x3x4a = blaze::StaticTensor<TypeA,2UL,3UL,4UL>;
+      using VDb     = blaze::DynamicVector<TypeB>;
+
+      // Creator type definitions
+      using CT2x3x4a = blazetest::Creator<T2x3x4a>;
+      using CVDb     = blazetest::Creator<VDb>;
+
+      // Running the tests
+      RUN_DTENSDVECMULT_OPERATION_TEST( CT2x3x4a(), CVDb( 4UL ) );
+   }
+   catch( std::exception& ex ) {
+      std::cerr << "\n\n ERROR DETECTED during dense tensor/dense vector multiplication:\n"
+                << ex.what() << "\n";
+      return EXIT_FAILURE;
+   }
+
+   return EXIT_SUCCESS;
+}
+//*************************************************************************************************

--- a/blazetest/src/mathtest/dtensdvecmult/T2x3x4aVHa.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/T2x3x4aVHa.cpp
@@ -1,10 +1,11 @@
 //=================================================================================================
 /*!
-//  \file blaze_tensor/math/dense/StaticVector.h
-//  \brief Header file for the implementation of a fixed-size vector
+//  \file src/mathtest/dtensdvecmult/T2x3x4aVHa.cpp
+//  \brief Source file for the T2x3x4aVHa dense tensor/dense vector multiplication math test
 //
-//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
 //  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
+//  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
 //  This file is part of the Blaze library. You can redistribute it and/or modify it under
 //  the terms of the New (Revised) BSD License. Redistribution and use in source and binary
@@ -33,40 +34,60 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_DENSE_STATICVECTOR_H_
-#define _BLAZE_TENSOR_MATH_DENSE_STATICVECTOR_H_
-
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/dense/StaticVector.h>
-#include <blaze/math/typetraits/IsDenseVector.h>
-#include <blaze_tensor/math/traits/DilatedSubvectorTrait.h>
+#include <cstdlib>
+#include <iostream>
+#include <blaze/math/HybridVector.h>
+#include <blazetest/mathtest/creator/StaticTensor.h>
+#include <blazetest/mathtest/dtensdvecmult/OperationTest.h>
+#include <blazetest/system/MathTest.h>
 
+#include <blaze_tensor/math/dense/HybridMatrix.h>
+#include <blaze_tensor/math/dense/StaticVector.h>
+#include <blaze_tensor/math/StaticTensor.h>
 
-
-namespace blaze {
 
 //=================================================================================================
 //
-//  DILATEDSUBVECTORTRAIT SPECIALIZATIONS
+//  MAIN FUNCTION
 //
 //=================================================================================================
 
-//*************************************************************************************************
-/*! \cond BLAZE_INTERNAL */
-template< typename VT, size_t I, size_t N, size_t Dilation >
-struct DilatedSubvectorTraitEval2< VT, I, N, Dilation
-                          , EnableIf_t< I != inf && N != inf && Dilation != inf &&
-                                        IsDenseVector_v<VT> > >
-{
-   using Type = StaticVector< RemoveConst_t< ElementType_t<VT> >, N, TransposeFlag_v<VT> >;
-};
-/*! \endcond */
-//*************************************************************************************************
-
-} // namespace blaze
-
+#if defined(BLAZE_USE_HPX_THREADS)
+#include <hpx/hpx_main.hpp>
 #endif
+
+//*************************************************************************************************
+int main()
+
+{
+   std::cout << "   Running 'T2x3x4aVHa'..." << std::endl;
+
+   using blazetest::mathtest::TypeA;
+
+   try
+   {
+      // Tensor type definitions
+      using T2x3x4a = blaze::StaticTensor<TypeA,2UL,3UL,4UL>;
+      using VHa     = blaze::HybridVector<TypeA,4UL>;
+
+      // Creator type definitions
+      using CT2x3x4a = blazetest::Creator<T2x3x4a>;
+      using CVHa     = blazetest::Creator<VHa>;
+
+      // Running the tests
+      RUN_DTENSDVECMULT_OPERATION_TEST( CT2x3x4a(), CVHa( 4UL ) );
+   }
+   catch( std::exception& ex ) {
+      std::cerr << "\n\n ERROR DETECTED during dense tensor/dense vector multiplication:\n"
+                << ex.what() << "\n";
+      return EXIT_FAILURE;
+   }
+
+   return EXIT_SUCCESS;
+}
+//*************************************************************************************************

--- a/blazetest/src/mathtest/dtensdvecmult/TDaV4a.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/TDaV4a.cpp
@@ -1,9 +1,9 @@
 //=================================================================================================
 /*!
-//  \file blaze/math/expressions/MatVecMultExpr.h
-//  \brief Header file for the MatVecMultExpr base class
+//  \file src/mathtest/dtensdvecmult/TDaV4a.cpp
+//  \brief Source file for the TDaV4a dense tensor/dense vector multiplication math test
 //
-//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
 //  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
 //  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
@@ -34,43 +34,64 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-#define _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/expressions/MultExpr.h>
+#include <cstdlib>
+#include <iostream>
+#include <blaze/math/StaticVector.h>
+#include <blazetest/mathtest/creator/DynamicTensor.h>
+#include <blazetest/mathtest/dtensdvecmult/OperationTest.h>
+#include <blazetest/system/MathTest.h>
 
+#include <blaze_tensor/math/dense/DynamicMatrix.h>
+#include <blaze_tensor/math/dense/StaticVector.h>
+#include <blaze_tensor/math/StaticTensor.h>
 
-namespace blaze {
 
 //=================================================================================================
 //
-//  CLASS DEFINITION
+//  MAIN FUNCTION
 //
 //=================================================================================================
 
-//*************************************************************************************************
-/*!\brief Base class for all matrix/vector multiplication expression templates.
-// \ingroup math
-//
-// The MatVecMultExpr class serves as a tag for all expression templates that implement a
-// matrix/vector multiplication. All classes, that represent a matrix/vector multiplication
-// and that are used within the expression template environment of the Blaze library have
-// to derive publicly from this class in order to qualify as matrix/vector multiplication
-// expression template. Only in case a class is derived publicly from the MatVecMultExpr
-// base class, the IsMatVecMultExpr type trait recognizes the class as valid matrix/vector
-// multiplication expression template.
-*/
-template< typename MT >  // Matrix base type of the expression
-struct TensVecMultExpr
-   : public MultExpr<MT>
-{};
-//*************************************************************************************************
-
-} // namespace blaze
-
+#if defined(BLAZE_USE_HPX_THREADS)
+#include <hpx/hpx_main.hpp>
 #endif
+
+//*************************************************************************************************
+int main()
+
+{
+   std::cout << "   Running 'TDaV4a'..." << std::endl;
+
+   using blazetest::mathtest::TypeA;
+
+   try
+   {
+      // Tensor type definitions
+      using TDa = blaze::DynamicTensor<TypeA>;
+      using V4a = blaze::StaticVector<TypeA,4UL>;
+
+      // Creator type definitions
+      using CTDa = blazetest::Creator<TDa>;
+      using CV4a = blazetest::Creator<V4a>;
+
+      // Running the tests
+      for (size_t k = 0UL; k <= 5UL; ++k) {
+         for (size_t i = 0UL; i <= 6UL; ++i) {
+            RUN_DTENSDVECMULT_OPERATION_TEST( CTDa( k, i, 4UL ), CV4a() );
+         }
+      }
+   }
+   catch( std::exception& ex ) {
+      std::cerr << "\n\n ERROR DETECTED during dense tensor/dense vector multiplication:\n"
+                << ex.what() << "\n";
+      return EXIT_FAILURE;
+   }
+
+   return EXIT_SUCCESS;
+}
+//*************************************************************************************************

--- a/blazetest/src/mathtest/dtensdvecmult/TDaV4b.cpp
+++ b/blazetest/src/mathtest/dtensdvecmult/TDaV4b.cpp
@@ -1,9 +1,9 @@
 //=================================================================================================
 /*!
-//  \file blaze/math/expressions/MatVecMultExpr.h
-//  \brief Header file for the MatVecMultExpr base class
+//  \file src/mathtest/dtensdvecmult/TDaV4b.cpp
+//  \brief Source file for the TDaV4b dense tensor/dense vector multiplication math test
 //
-//  Copyright (C) 2012-2019 Klaus Iglberger - All Rights Reserved
+//  Copyright (C) 2012-2018 Klaus Iglberger - All Rights Reserved
 //  Copyright (C) 2018-2019 Hartmut Kaiser - All Rights Reserved
 //  Copyright (C) 2019 Bita Hasheminezhad - All Rights Reserved
 //
@@ -34,43 +34,65 @@
 */
 //=================================================================================================
 
-#ifndef _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-#define _BLAZE_TENSOR_MATH_EXPRESSIONS_TENSVECMULTEXPR_H_
-
 
 //*************************************************************************************************
 // Includes
 //*************************************************************************************************
 
-#include <blaze/math/expressions/MultExpr.h>
+#include <cstdlib>
+#include <iostream>
+#include <blaze/math/StaticVector.h>
+#include <blazetest/mathtest/creator/DynamicTensor.h>
+#include <blazetest/mathtest/dtensdvecmult/OperationTest.h>
+#include <blazetest/system/MathTest.h>
 
+#include <blaze_tensor/math/dense/DynamicMatrix.h>
+#include <blaze_tensor/math/dense/StaticVector.h>
+#include <blaze_tensor/math/StaticTensor.h>
 
-namespace blaze {
 
 //=================================================================================================
 //
-//  CLASS DEFINITION
+//  MAIN FUNCTION
 //
 //=================================================================================================
 
-//*************************************************************************************************
-/*!\brief Base class for all matrix/vector multiplication expression templates.
-// \ingroup math
-//
-// The MatVecMultExpr class serves as a tag for all expression templates that implement a
-// matrix/vector multiplication. All classes, that represent a matrix/vector multiplication
-// and that are used within the expression template environment of the Blaze library have
-// to derive publicly from this class in order to qualify as matrix/vector multiplication
-// expression template. Only in case a class is derived publicly from the MatVecMultExpr
-// base class, the IsMatVecMultExpr type trait recognizes the class as valid matrix/vector
-// multiplication expression template.
-*/
-template< typename MT >  // Matrix base type of the expression
-struct TensVecMultExpr
-   : public MultExpr<MT>
-{};
-//*************************************************************************************************
-
-} // namespace blaze
-
+#if defined(BLAZE_USE_HPX_THREADS)
+#include <hpx/hpx_main.hpp>
 #endif
+
+//*************************************************************************************************
+int main()
+
+{
+   std::cout << "   Running 'TDaV4b'..." << std::endl;
+
+   using blazetest::mathtest::TypeA;
+   using blazetest::mathtest::TypeB;
+
+   try
+   {
+      // Tensor type definitions
+      using TDa = blaze::DynamicTensor<TypeA>;
+      using V4b = blaze::StaticVector<TypeB,4UL>;
+
+      // Creator type definitions
+      using CTDa = blazetest::Creator<TDa>;
+      using CV4b = blazetest::Creator<V4b>;
+
+      // Running the tests
+      for (size_t k = 0UL; k <= 5UL; ++k) {
+         for (size_t i = 0UL; i <= 6UL; ++i) {
+            RUN_DTENSDVECMULT_OPERATION_TEST( CTDa( k, i, 4UL ), CV4b() );
+         }
+      }
+   }
+   catch( std::exception& ex ) {
+      std::cerr << "\n\n ERROR DETECTED during dense tensor/dense vector multiplication:\n"
+                << ex.what() << "\n";
+      return EXIT_FAILURE;
+   }
+
+   return EXIT_SUCCESS;
+}
+//*************************************************************************************************


### PR DESCRIPTION
This PR overloads `*` given a tensor to its left-hand side and a vector to its right-hand side to calculate their dot product.
We might need to add two overloads of DTensDVecMult to `pageslices` and `rowslices` views when we implement them, which enables us to call `rows` and `columns` views on a tensor vector multiplication.
Working towards #24 