### PR TITLE
Fix the vectorized compute kernels of the 'DTensDVecMultExpr' class template

### DIFF
--- a/blaze_tensor/math/dense/CustomArray.h
+++ b/blaze_tensor/math/dense/CustomArray.h
@@ -929,9 +929,9 @@ inline size_t CustomArray<N,Type,AF,PF,RT>::row_index( size_t i, Dims... dims ) 
    size_t indices[] = { size_t(dims)..., i, 0 };
 
    size_t idx = 0UL;
-   for( size_t i = N - 1; i > 1; --i ) {
-      BLAZE_USER_ASSERT(indices[N - i - 1] < dims_[i], "Invalid access index" );
-      idx = (idx + indices[N - i - 1]) * dims_[i - 1];
+   for( size_t j = N - 1; j > 1; --j ) {
+      BLAZE_USER_ASSERT(indices[N - j - 1] < dims_[j], "Invalid access index" );
+      idx = (idx + indices[N - j - 1]) * dims_[j - 1];
    }
 
    BLAZE_USER_ASSERT(indices[N - 2] < dims_[1], "Invalid access index" );
@@ -2312,8 +2312,8 @@ inline size_t CustomArray<N,Type,AF,PF,RT>::capacity( size_t i, Dims... dims ) c
 #if defined(BLAZE_USER_ASSERTION)
    size_t indices[] = { size_t(dims)..., i, 0 };
 
-   ArrayDimForEach( dims_, [&]( size_t i, size_t dim ) {
-      BLAZE_USER_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
+   ArrayDimForEach( dims_, [&]( size_t j, size_t dim ) {
+      BLAZE_USER_ASSERT( indices[N - j - 1] < dim, "Invalid array access index" );
    } );
 #endif
 
@@ -2371,8 +2371,8 @@ inline size_t CustomArray<N,Type,AF,PF,RT>::nonZeros( size_t i, Dims... dims ) c
 #if defined(BLAZE_USER_ASSERTION)
    size_t indices[] = { size_t(dims)..., i, 0 };
 
-   ArrayDimForEach( dims_, [&]( size_t i, size_t dim ) {
-      BLAZE_USER_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
+   ArrayDimForEach( dims_, [&]( size_t j, size_t dim ) {
+      BLAZE_USER_ASSERT( indices[N - j - 1] < dim, "Invalid array access index" );
    } );
 #endif
 
@@ -2431,8 +2431,8 @@ inline void CustomArray<N,Type,AF,PF,RT>::reset( size_t i, Dims... dims )
 #if defined(BLAZE_USER_ASSERTION)
    size_t indices[] = { size_t(dims)..., i, 0 };
 
-   ArrayDimForEach( dims_, [&]( size_t i, size_t dim ) {
-      BLAZE_USER_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
+   ArrayDimForEach( dims_, [&]( size_t j, size_t dim ) {
+      BLAZE_USER_ASSERT( indices[N - j - 1] < dim, "Invalid array access index" );
    } );
 #endif
 
@@ -2868,9 +2868,9 @@ BLAZE_ALWAYS_INLINE typename CustomArray<N,Type,AF,PF,RT>::SIMDType
    } );
 #endif
 
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( !PF || j % SIMDSIZE == 0UL, "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( !PF || j % SIMDSIZE == 0UL, "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
 
    return loada( v_ + index( dims... ) );
 }
@@ -2911,7 +2911,7 @@ BLAZE_ALWAYS_INLINE typename CustomArray<N,Type,AF,PF,RT>::SIMDType
       BLAZE_INTERNAL_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
    } );
 #endif
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
 
    return loadu( v_ + index( dims... ) );
 }
@@ -2986,9 +2986,9 @@ BLAZE_ALWAYS_INLINE void
       BLAZE_INTERNAL_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
    } );
 #endif
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( !PF || j % SIMDSIZE == 0UL, "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( !PF || j % SIMDSIZE == 0UL, "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
 
    storea( v_ + index( dims... ), value );
 }
@@ -3030,7 +3030,7 @@ BLAZE_ALWAYS_INLINE void
       BLAZE_INTERNAL_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
    } );
 #endif
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
 
    storeu( v_ + index( dims... ), value );
 }
@@ -3073,9 +3073,9 @@ BLAZE_ALWAYS_INLINE void
       BLAZE_INTERNAL_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
    } );
 #endif
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( !PF || j % SIMDSIZE == 0UL, "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= ( PF ? nn_ : n_ ), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( !PF || j % SIMDSIZE == 0UL, "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
 
    stream( v_ + index( dims... ), value );
 }

--- a/blaze_tensor/math/dense/DenseArray.h
+++ b/blaze_tensor/math/dense/DenseArray.h
@@ -487,8 +487,8 @@ bool isUniform_backend( const DenseArray<MT>& dm )
    const auto& cmp( (~dm)( dims ) );
 
    return ArrayForEachGroupedAllOf( ( ~dm ).dimensions(),
-      [&]( std::array< size_t, N > const& dims ) {
-         return equal< RF >( ( ~dm )( dims ), cmp );
+      [&]( std::array< size_t, N > const& ds ) {
+         return equal< RF >( ( ~dm )( ds ), cmp );
       } );
 }
 /*! \endcond */

--- a/blaze_tensor/math/dense/DynamicArray.h
+++ b/blaze_tensor/math/dense/DynamicArray.h
@@ -2055,8 +2055,8 @@ inline size_t DynamicArray<N, Type>::capacity( size_t i, Dims... dims ) const no
 
 #if defined(BLAZE_USER_ASSERTION)
    size_t indices[] = { size_t(dims)..., i, 0 };
-   ArrayDimForEach( dims_, [&]( size_t i, size_t dim ) {
-      BLAZE_USER_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
+   ArrayDimForEach( dims_, [&]( size_t j, size_t dim ) {
+      BLAZE_USER_ASSERT( indices[N - j - 1] < dim, "Invalid array access index" );
    } );
    MAYBE_UNUSED( indices );
 #endif
@@ -2109,8 +2109,8 @@ inline size_t DynamicArray<N, Type>::nonZeros( size_t i, Dims... dims ) const
 
 #if defined(BLAZE_USER_ASSERTION)
    size_t indices[] = { size_t(dims)..., i, 0 };
-   ArrayDimForEach( dims_, [&]( size_t i, size_t dim ) {
-      BLAZE_USER_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
+   ArrayDimForEach( dims_, [&]( size_t j, size_t dim ) {
+      BLAZE_USER_ASSERT( indices[N - j - 1] < dim, "Invalid array access index" );
    } );
    MAYBE_UNUSED( indices );
 #endif
@@ -2303,7 +2303,7 @@ template< size_t N         // The dimensionality of the array
         , typename Type >  // Data type of the array
 inline void DynamicArray<N, Type>::extend( std::array< size_t, N > const& dims, bool preserve )
 {
-   BLAZE_USER_ASSERT( N == n, "invalid dimensionality specified" );
+   //BLAZE_USER_ASSERT( N == n, "invalid dimensionality specified" );
 
    std::array< size_t, N > newdims;
    ArrayDimForEach(
@@ -2475,9 +2475,9 @@ inline size_t DynamicArray<N, Type>::row_index( size_t i, Dims... dims ) const n
    const size_t indices[] = { static_cast<size_t>(dims)..., i, 0UL };
 
    size_t idx = 0UL;
-   for( size_t i = N - 1; i > 1; --i ) {
-      BLAZE_USER_ASSERT(indices[N - i - 1] < dims_[i], "Invalid access index" );
-      idx = (idx + indices[N - i - 1]) * dims_[i - 1];
+   for( size_t j = N - 1; j > 1; --j ) {
+      BLAZE_USER_ASSERT(indices[N - j - 1] < dims_[j], "Invalid access index" );
+      idx = (idx + indices[N - j - 1]) * dims_[j - 1];
    }
 
    BLAZE_USER_ASSERT(indices[N - 2] < dims_[1], "Invalid access index" );
@@ -2985,8 +2985,8 @@ BLAZE_ALWAYS_INLINE typename DynamicArray<N, Type>::SIMDType
    } );
    MAYBE_UNUSED( indices );
 #endif
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims ) ), "Invalid alignment detected" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims ) ), "Invalid alignment detected" );
 
    return loada( v_ + index( dims... ) );
 }
@@ -3025,7 +3025,7 @@ BLAZE_ALWAYS_INLINE typename DynamicArray<N, Type>::SIMDType
    } );
    MAYBE_UNUSED( indices );
 #endif
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
 
    return loadu( v_ + index( dims... ) );
 }
@@ -3091,8 +3091,8 @@ BLAZE_ALWAYS_INLINE void
       BLAZE_INTERNAL_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
    } );
 #endif
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
 
    storea( v_ + index( dims... ), value );
 }
@@ -3131,7 +3131,7 @@ BLAZE_ALWAYS_INLINE void
       BLAZE_INTERNAL_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
    } );
 #endif
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
 
    storeu( v_ + index( dims... ), value );
 }
@@ -3171,8 +3171,8 @@ BLAZE_ALWAYS_INLINE void
       BLAZE_INTERNAL_ASSERT( indices[N - i - 1] < dim, "Invalid array access index" );
    } );
 #endif
-   BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
+   //BLAZE_INTERNAL_ASSERT( j + SIMDSIZE <= nn_, "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( checkAlignment( v_ + index( dims... ) ), "Invalid alignment detected" );
 
    stream( v_ + index( dims... ), value );
 }

--- a/blaze_tensor/math/expressions/DArrDArrMapExpr.h
+++ b/blaze_tensor/math/expressions/DArrDArrMapExpr.h
@@ -631,7 +631,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs_).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense array operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense array operand
@@ -664,7 +664,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs_).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense array operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense array operand
@@ -697,7 +697,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs_).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense array operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense array operand
@@ -730,7 +730,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs_).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense array operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense array operand
@@ -763,7 +763,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs_).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense array operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense array operand
@@ -797,7 +797,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs_).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense array operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense array operand
@@ -831,7 +831,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs_).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense array operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense array operand
@@ -865,7 +865,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs_).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense array operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense array operand

--- a/blaze_tensor/math/expressions/DArrNormExpr.h
+++ b/blaze_tensor/math/expressions/DArrNormExpr.h
@@ -181,8 +181,8 @@ decltype(auto) norm_backend( const DenseArray<MT>& dm, Abs abs, Power power, Roo
    ET norm( power( abs( tmp( dims ) ) ) );
 
    ArrayForEachGrouped( ( ~dm ).dimensions(),
-      [&]( std::array< size_t, N > const& dims ) {
-         norm += power( abs( tmp( dims ) ) );
+      [&]( std::array< size_t, N > const& ds ) {
+         norm += power( abs( tmp( ds ) ) );
       } );
 
    return evaluate( root( norm ) );

--- a/blaze_tensor/math/expressions/DArrReduceExpr.h
+++ b/blaze_tensor/math/expressions/DArrReduceExpr.h
@@ -963,8 +963,8 @@ inline ElementType_t<MT> darrayreduce( const DenseArray<MT>& dm, OP op )
 
    std::array< size_t, N > starts_with{1};
    ArrayForEachGroupedStartsWith( ( ~dm ).dimensions(),
-      [&]( std::array< size_t, N > const& dims ) {
-         redux = op( redux, tmp( dims ) );
+      [&]( std::array< size_t, N > const& ds ) {
+         redux = op( redux, tmp( ds ) );
       },
       starts_with );
 

--- a/blaze_tensor/math/expressions/DQuatTransExprData.h
+++ b/blaze_tensor/math/expressions/DQuatTransExprData.h
@@ -132,6 +132,7 @@ struct DQuatTransExprData<0UL, 1UL, 2UL, 3UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -146,6 +147,7 @@ struct DQuatTransExprData<0UL, 1UL, 2UL, 3UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -160,6 +162,7 @@ struct DQuatTransExprData<0UL, 1UL, 2UL, 3UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -174,6 +177,7 @@ struct DQuatTransExprData<0UL, 1UL, 2UL, 3UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -190,6 +194,7 @@ struct DQuatTransExprData<0UL, 1UL, 2UL, 3UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -204,6 +209,7 @@ struct DQuatTransExprData<0UL, 1UL, 2UL, 3UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -218,6 +224,7 @@ struct DQuatTransExprData<0UL, 1UL, 2UL, 3UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -232,6 +239,7 @@ struct DQuatTransExprData<0UL, 1UL, 2UL, 3UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -302,6 +310,7 @@ struct DQuatTransExprData<0UL, 1UL, 3UL, 2UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -316,6 +325,7 @@ struct DQuatTransExprData<0UL, 1UL, 3UL, 2UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -330,6 +340,7 @@ struct DQuatTransExprData<0UL, 1UL, 3UL, 2UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -344,6 +355,7 @@ struct DQuatTransExprData<0UL, 1UL, 3UL, 2UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -360,6 +372,7 @@ struct DQuatTransExprData<0UL, 1UL, 3UL, 2UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -374,6 +387,7 @@ struct DQuatTransExprData<0UL, 1UL, 3UL, 2UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -388,6 +402,7 @@ struct DQuatTransExprData<0UL, 1UL, 3UL, 2UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -402,6 +417,7 @@ struct DQuatTransExprData<0UL, 1UL, 3UL, 2UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -471,6 +487,7 @@ struct DQuatTransExprData<0UL, 2UL, 1UL, 3UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -485,6 +502,7 @@ struct DQuatTransExprData<0UL, 2UL, 1UL, 3UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -499,6 +517,7 @@ struct DQuatTransExprData<0UL, 2UL, 1UL, 3UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -513,6 +532,7 @@ struct DQuatTransExprData<0UL, 2UL, 1UL, 3UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -529,6 +549,7 @@ struct DQuatTransExprData<0UL, 2UL, 1UL, 3UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -543,6 +564,7 @@ struct DQuatTransExprData<0UL, 2UL, 1UL, 3UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -557,6 +579,7 @@ struct DQuatTransExprData<0UL, 2UL, 1UL, 3UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -571,6 +594,7 @@ struct DQuatTransExprData<0UL, 2UL, 1UL, 3UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -639,6 +663,7 @@ struct DQuatTransExprData<0UL, 2UL, 3UL, 1UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -653,6 +678,7 @@ struct DQuatTransExprData<0UL, 2UL, 3UL, 1UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -667,6 +693,7 @@ struct DQuatTransExprData<0UL, 2UL, 3UL, 1UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -681,6 +708,7 @@ struct DQuatTransExprData<0UL, 2UL, 3UL, 1UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -697,6 +725,7 @@ struct DQuatTransExprData<0UL, 2UL, 3UL, 1UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -711,6 +740,7 @@ struct DQuatTransExprData<0UL, 2UL, 3UL, 1UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -725,6 +755,7 @@ struct DQuatTransExprData<0UL, 2UL, 3UL, 1UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -739,6 +770,7 @@ struct DQuatTransExprData<0UL, 2UL, 3UL, 1UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -808,6 +840,7 @@ struct DQuatTransExprData<0UL, 3UL, 1UL, 2UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -822,6 +855,7 @@ struct DQuatTransExprData<0UL, 3UL, 1UL, 2UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -836,6 +870,7 @@ struct DQuatTransExprData<0UL, 3UL, 1UL, 2UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -850,6 +885,7 @@ struct DQuatTransExprData<0UL, 3UL, 1UL, 2UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -866,6 +902,7 @@ struct DQuatTransExprData<0UL, 3UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -880,6 +917,7 @@ struct DQuatTransExprData<0UL, 3UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -894,6 +932,7 @@ struct DQuatTransExprData<0UL, 3UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -908,6 +947,7 @@ struct DQuatTransExprData<0UL, 3UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -976,6 +1016,7 @@ struct DQuatTransExprData<0UL, 3UL, 2UL, 1UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -990,6 +1031,7 @@ struct DQuatTransExprData<0UL, 3UL, 2UL, 1UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -1004,6 +1046,7 @@ struct DQuatTransExprData<0UL, 3UL, 2UL, 1UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -1018,6 +1061,7 @@ struct DQuatTransExprData<0UL, 3UL, 2UL, 1UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -1034,6 +1078,7 @@ struct DQuatTransExprData<0UL, 3UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1048,6 +1093,7 @@ struct DQuatTransExprData<0UL, 3UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -1062,6 +1108,7 @@ struct DQuatTransExprData<0UL, 3UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -1076,6 +1123,7 @@ struct DQuatTransExprData<0UL, 3UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -1145,6 +1193,7 @@ struct DQuatTransExprData<1UL, 0UL, 2UL, 3UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -1159,6 +1208,7 @@ struct DQuatTransExprData<1UL, 0UL, 2UL, 3UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1173,6 +1223,7 @@ struct DQuatTransExprData<1UL, 0UL, 2UL, 3UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -1187,6 +1238,7 @@ struct DQuatTransExprData<1UL, 0UL, 2UL, 3UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -1203,6 +1255,7 @@ struct DQuatTransExprData<1UL, 0UL, 2UL, 3UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -1217,6 +1270,7 @@ struct DQuatTransExprData<1UL, 0UL, 2UL, 3UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1231,6 +1285,7 @@ struct DQuatTransExprData<1UL, 0UL, 2UL, 3UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -1245,6 +1300,7 @@ struct DQuatTransExprData<1UL, 0UL, 2UL, 3UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -1315,6 +1371,7 @@ struct DQuatTransExprData<1UL, 0UL, 3UL, 2UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -1329,6 +1386,7 @@ struct DQuatTransExprData<1UL, 0UL, 3UL, 2UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1343,6 +1401,7 @@ struct DQuatTransExprData<1UL, 0UL, 3UL, 2UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -1357,6 +1416,7 @@ struct DQuatTransExprData<1UL, 0UL, 3UL, 2UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -1373,6 +1433,7 @@ struct DQuatTransExprData<1UL, 0UL, 3UL, 2UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -1387,6 +1448,7 @@ struct DQuatTransExprData<1UL, 0UL, 3UL, 2UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1401,6 +1463,7 @@ struct DQuatTransExprData<1UL, 0UL, 3UL, 2UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -1415,6 +1478,7 @@ struct DQuatTransExprData<1UL, 0UL, 3UL, 2UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -1484,6 +1548,7 @@ struct DQuatTransExprData<1UL, 2UL, 0UL, 3UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -1498,6 +1563,7 @@ struct DQuatTransExprData<1UL, 2UL, 0UL, 3UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -1512,6 +1578,7 @@ struct DQuatTransExprData<1UL, 2UL, 0UL, 3UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1526,6 +1593,7 @@ struct DQuatTransExprData<1UL, 2UL, 0UL, 3UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -1542,6 +1610,7 @@ struct DQuatTransExprData<1UL, 2UL, 0UL, 3UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -1556,6 +1625,7 @@ struct DQuatTransExprData<1UL, 2UL, 0UL, 3UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1570,6 +1640,7 @@ struct DQuatTransExprData<1UL, 2UL, 0UL, 3UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -1584,6 +1655,7 @@ struct DQuatTransExprData<1UL, 2UL, 0UL, 3UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -1653,6 +1725,7 @@ struct DQuatTransExprData<1UL, 2UL, 3UL, 0UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -1667,6 +1740,7 @@ struct DQuatTransExprData<1UL, 2UL, 3UL, 0UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -1681,6 +1755,7 @@ struct DQuatTransExprData<1UL, 2UL, 3UL, 0UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -1695,6 +1770,7 @@ struct DQuatTransExprData<1UL, 2UL, 3UL, 0UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}
@@ -1711,6 +1787,7 @@ struct DQuatTransExprData<1UL, 2UL, 3UL, 0UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -1725,6 +1802,7 @@ struct DQuatTransExprData<1UL, 2UL, 3UL, 0UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1739,6 +1817,7 @@ struct DQuatTransExprData<1UL, 2UL, 3UL, 0UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -1753,6 +1832,7 @@ struct DQuatTransExprData<1UL, 2UL, 3UL, 0UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -1823,6 +1903,7 @@ struct DQuatTransExprData<1UL, 3UL, 0UL, 2UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -1837,6 +1918,7 @@ struct DQuatTransExprData<1UL, 3UL, 0UL, 2UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -1851,6 +1933,7 @@ struct DQuatTransExprData<1UL, 3UL, 0UL, 2UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1865,6 +1948,7 @@ struct DQuatTransExprData<1UL, 3UL, 0UL, 2UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -1881,6 +1965,7 @@ struct DQuatTransExprData<1UL, 3UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -1895,6 +1980,7 @@ struct DQuatTransExprData<1UL, 3UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -1909,6 +1995,7 @@ struct DQuatTransExprData<1UL, 3UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -1923,6 +2010,7 @@ struct DQuatTransExprData<1UL, 3UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -1992,6 +2080,7 @@ struct DQuatTransExprData<2UL, 0UL, 1UL, 3UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2006,6 +2095,7 @@ struct DQuatTransExprData<2UL, 0UL, 1UL, 3UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2020,6 +2110,7 @@ struct DQuatTransExprData<2UL, 0UL, 1UL, 3UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -2034,6 +2125,7 @@ struct DQuatTransExprData<2UL, 0UL, 1UL, 3UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -2050,6 +2142,7 @@ struct DQuatTransExprData<2UL, 0UL, 1UL, 3UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -2064,6 +2157,7 @@ struct DQuatTransExprData<2UL, 0UL, 1UL, 3UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2078,6 +2172,7 @@ struct DQuatTransExprData<2UL, 0UL, 1UL, 3UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2092,6 +2187,7 @@ struct DQuatTransExprData<2UL, 0UL, 1UL, 3UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -2160,6 +2256,7 @@ struct DQuatTransExprData<2UL, 0UL, 3UL, 1UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2174,6 +2271,7 @@ struct DQuatTransExprData<2UL, 0UL, 3UL, 1UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2188,6 +2286,7 @@ struct DQuatTransExprData<2UL, 0UL, 3UL, 1UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -2202,6 +2301,7 @@ struct DQuatTransExprData<2UL, 0UL, 3UL, 1UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -2218,6 +2318,7 @@ struct DQuatTransExprData<2UL, 0UL, 3UL, 1UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -2232,6 +2333,7 @@ struct DQuatTransExprData<2UL, 0UL, 3UL, 1UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -2246,6 +2348,7 @@ struct DQuatTransExprData<2UL, 0UL, 3UL, 1UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2260,6 +2363,7 @@ struct DQuatTransExprData<2UL, 0UL, 3UL, 1UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -2329,6 +2433,7 @@ struct DQuatTransExprData<2UL, 1UL, 0UL, 3UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2343,6 +2448,7 @@ struct DQuatTransExprData<2UL, 1UL, 0UL, 3UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -2357,6 +2463,7 @@ struct DQuatTransExprData<2UL, 1UL, 0UL, 3UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2371,6 +2478,7 @@ struct DQuatTransExprData<2UL, 1UL, 0UL, 3UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -2387,6 +2495,7 @@ struct DQuatTransExprData<2UL, 1UL, 0UL, 3UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2401,6 +2510,7 @@ struct DQuatTransExprData<2UL, 1UL, 0UL, 3UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -2415,6 +2525,7 @@ struct DQuatTransExprData<2UL, 1UL, 0UL, 3UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2429,6 +2540,7 @@ struct DQuatTransExprData<2UL, 1UL, 0UL, 3UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
    //@}
@@ -2498,6 +2610,7 @@ struct DQuatTransExprData<2UL, 1UL, 3UL, 0UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2512,6 +2625,7 @@ struct DQuatTransExprData<2UL, 1UL, 3UL, 0UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -2526,6 +2640,7 @@ struct DQuatTransExprData<2UL, 1UL, 3UL, 0UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -2540,6 +2655,7 @@ struct DQuatTransExprData<2UL, 1UL, 3UL, 0UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}
@@ -2556,6 +2672,7 @@ struct DQuatTransExprData<2UL, 1UL, 3UL, 0UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -2570,6 +2687,7 @@ struct DQuatTransExprData<2UL, 1UL, 3UL, 0UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -2584,6 +2702,7 @@ struct DQuatTransExprData<2UL, 1UL, 3UL, 0UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2598,6 +2717,7 @@ struct DQuatTransExprData<2UL, 1UL, 3UL, 0UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -2667,6 +2787,7 @@ struct DQuatTransExprData<2UL, 3UL, 0UL, 1UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2681,6 +2802,7 @@ struct DQuatTransExprData<2UL, 3UL, 0UL, 1UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -2695,6 +2817,7 @@ struct DQuatTransExprData<2UL, 3UL, 0UL, 1UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2709,6 +2832,7 @@ struct DQuatTransExprData<2UL, 3UL, 0UL, 1UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -2725,6 +2849,7 @@ struct DQuatTransExprData<2UL, 3UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2739,6 +2864,7 @@ struct DQuatTransExprData<2UL, 3UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -2753,6 +2879,7 @@ struct DQuatTransExprData<2UL, 3UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2767,6 +2894,7 @@ struct DQuatTransExprData<2UL, 3UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -2836,6 +2964,7 @@ struct DQuatTransExprData<2UL, 3UL, 1UL, 0UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2850,6 +2979,7 @@ struct DQuatTransExprData<2UL, 3UL, 1UL, 0UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -2864,6 +2994,7 @@ struct DQuatTransExprData<2UL, 3UL, 1UL, 0UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -2878,6 +3009,7 @@ struct DQuatTransExprData<2UL, 3UL, 1UL, 0UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}
@@ -2894,6 +3026,7 @@ struct DQuatTransExprData<2UL, 3UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -2908,6 +3041,7 @@ struct DQuatTransExprData<2UL, 3UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -2922,6 +3056,7 @@ struct DQuatTransExprData<2UL, 3UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -2936,6 +3071,7 @@ struct DQuatTransExprData<2UL, 3UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -3005,6 +3141,7 @@ struct DQuatTransExprData<3UL, 0UL, 1UL, 2UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3019,6 +3156,7 @@ struct DQuatTransExprData<3UL, 0UL, 1UL, 2UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -3033,6 +3171,7 @@ struct DQuatTransExprData<3UL, 0UL, 1UL, 2UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -3047,6 +3186,7 @@ struct DQuatTransExprData<3UL, 0UL, 1UL, 2UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -3063,6 +3203,7 @@ struct DQuatTransExprData<3UL, 0UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -3077,6 +3218,7 @@ struct DQuatTransExprData<3UL, 0UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3091,6 +3233,7 @@ struct DQuatTransExprData<3UL, 0UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3105,6 +3248,7 @@ struct DQuatTransExprData<3UL, 0UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}
@@ -3174,6 +3318,7 @@ struct DQuatTransExprData<3UL, 0UL, 2UL, 1UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3188,6 +3333,7 @@ struct DQuatTransExprData<3UL, 0UL, 2UL, 1UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -3202,6 +3348,7 @@ struct DQuatTransExprData<3UL, 0UL, 2UL, 1UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3216,6 +3363,7 @@ struct DQuatTransExprData<3UL, 0UL, 2UL, 1UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -3232,6 +3380,7 @@ struct DQuatTransExprData<3UL, 0UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -3246,6 +3395,7 @@ struct DQuatTransExprData<3UL, 0UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3260,6 +3410,7 @@ struct DQuatTransExprData<3UL, 0UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3274,6 +3425,7 @@ struct DQuatTransExprData<3UL, 0UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}
@@ -3343,6 +3495,7 @@ struct DQuatTransExprData<3UL, 1UL, 0UL, 2UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3357,6 +3510,7 @@ struct DQuatTransExprData<3UL, 1UL, 0UL, 2UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -3371,6 +3525,7 @@ struct DQuatTransExprData<3UL, 1UL, 0UL, 2UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -3385,6 +3540,7 @@ struct DQuatTransExprData<3UL, 1UL, 0UL, 2UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
    //@}
@@ -3401,6 +3557,7 @@ struct DQuatTransExprData<3UL, 1UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3415,6 +3572,7 @@ struct DQuatTransExprData<3UL, 1UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -3429,6 +3587,7 @@ struct DQuatTransExprData<3UL, 1UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3443,6 +3602,7 @@ struct DQuatTransExprData<3UL, 1UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}
@@ -3512,6 +3672,7 @@ struct DQuatTransExprData<3UL, 1UL, 2UL, 0UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3526,6 +3687,7 @@ struct DQuatTransExprData<3UL, 1UL, 2UL, 0UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -3540,6 +3702,7 @@ struct DQuatTransExprData<3UL, 1UL, 2UL, 0UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3554,6 +3717,7 @@ struct DQuatTransExprData<3UL, 1UL, 2UL, 0UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}
@@ -3570,6 +3734,7 @@ struct DQuatTransExprData<3UL, 1UL, 2UL, 0UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3584,6 +3749,7 @@ struct DQuatTransExprData<3UL, 1UL, 2UL, 0UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -3598,6 +3764,7 @@ struct DQuatTransExprData<3UL, 1UL, 2UL, 0UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3612,6 +3779,7 @@ struct DQuatTransExprData<3UL, 1UL, 2UL, 0UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}
@@ -3681,6 +3849,7 @@ struct DQuatTransExprData<3UL, 2UL, 0UL, 1UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3695,6 +3864,7 @@ struct DQuatTransExprData<3UL, 2UL, 0UL, 1UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3709,6 +3879,7 @@ struct DQuatTransExprData<3UL, 2UL, 0UL, 1UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -3723,6 +3894,7 @@ struct DQuatTransExprData<3UL, 2UL, 0UL, 1UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -3739,6 +3911,7 @@ struct DQuatTransExprData<3UL, 2UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3753,6 +3926,7 @@ struct DQuatTransExprData<3UL, 2UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3767,6 +3941,7 @@ struct DQuatTransExprData<3UL, 2UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
 
@@ -3781,6 +3956,7 @@ struct DQuatTransExprData<3UL, 2UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
    //@}
@@ -3851,6 +4027,7 @@ struct DQuatTransExprData<3UL, 2UL, 1UL, 0UL>
    */
    static inline constexpr size_t quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3865,6 +4042,7 @@ struct DQuatTransExprData<3UL, 2UL, 1UL, 0UL>
    */
    static inline constexpr size_t page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3879,6 +4057,7 @@ struct DQuatTransExprData<3UL, 2UL, 1UL, 0UL>
    */
    static inline constexpr size_t row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -3893,6 +4072,7 @@ struct DQuatTransExprData<3UL, 2UL, 1UL, 0UL>
    */
    static inline constexpr size_t column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}
@@ -3909,6 +4089,7 @@ struct DQuatTransExprData<3UL, 2UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_quat  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, i );
       return j;
    }
 
@@ -3923,6 +4104,7 @@ struct DQuatTransExprData<3UL, 2UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_page  ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, k, j );
       return i;
    }
 
@@ -3937,6 +4119,7 @@ struct DQuatTransExprData<3UL, 2UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_row   ( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( l, i, j );
       return k;
    }
 
@@ -3951,6 +4134,7 @@ struct DQuatTransExprData<3UL, 2UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_column( size_t l, size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i, j );
       return l;
    }
    //@}

--- a/blaze_tensor/math/expressions/DTensDTensAddExpr.h
+++ b/blaze_tensor/math/expressions/DTensDTensAddExpr.h
@@ -42,6 +42,7 @@
 //*************************************************************************************************
 
 #include <blaze/math/expressions/DMatDMatAddExpr.h>
+#include <blaze/math/typetraits/IsHermitian.h>
 
 #include <blaze_tensor/math/constraints/DenseTensor.h>
 #include <blaze_tensor/math/constraints/TensTensAddExpr.h>

--- a/blaze_tensor/math/expressions/DTensDVecMultExpr.h
+++ b/blaze_tensor/math/expressions/DTensDVecMultExpr.h
@@ -446,7 +446,7 @@ class DTensDVecMultExpr
       if( A.pages() * A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD )
          selectSmallAssignKernel( y, A, x );
       else
-         selectBlasAssignKernel( y, A, x );
+         selectLargeAssignKernel( y, A, x );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -500,213 +500,197 @@ class DTensDVecMultExpr
    /*! \endcond */
    //**********************************************************************************************
 
-   ////**Vectorized default assignment to dense vectors (small tensors)*****************************
-   ///*! \cond BLAZE_INTERNAL */
-   ///*!\brief Vectorized default assignment of a small dense tensor-dense vector multiplication
-   ////        (\f$ \vec{y}=A*\vec{x} \f$).
-   //// \ingroup dense_vector
-   ////
-   //// \param y The target left-hand side dense matrix.
-   //// \param A The left-hand side dense tensor operand.
-   //// \param x The right-hand side dense vector operand.
-   //// \return void
-   ////
-   //// This function implements the vectorized default assignment kernel for the dense tensor-
-   //// dense vector multiplication. This kernel is optimized for small tensors.
-   //*/
-   //template< typename MT1    // Type of the left-hand side target vector
-   //        , typename TT1    // Type of the left-hand side tensor operand
-   //        , typename VT1 >  // Type of the right-hand side vector operand
-   //static inline auto selectSmallAssignKernel( MT1& y, const TT1& A, const VT1& x )
-   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
-   //{
-   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+   //**Vectorized default assignment to dense vectors (small tensors)*****************************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Vectorized default assignment of a small dense tensor-dense vector multiplication
+   //        (\f$ \vec{y}=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense matrix.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function implements the vectorized default assignment kernel for the dense tensor-
+   // dense vector multiplication. This kernel is optimized for small tensors.
+   */
+   template< typename MT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectSmallAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   {
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
 
-   //   const size_t M( A.rows()    );
-   //   const size_t N( A.columns() );
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
 
-   //   size_t i( 0UL );
+      for( size_t p=0UL; p<P; ++ p )
+      {
+         size_t i( 0UL );
 
-   //   for( ; (i+8UL) <= M; i+=8UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //         xmm3 += A.load(i+2UL,j) * x1;
-   //         xmm4 += A.load(i+3UL,j) * x1;
-   //         xmm5 += A.load(i+4UL,j) * x1;
-   //         xmm6 += A.load(i+5UL,j) * x1;
-   //         xmm7 += A.load(i+6UL,j) * x1;
-   //         xmm8 += A.load(i+7UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+               xmm5 += A.load(p,i+4UL,j) * x1;
+               xmm6 += A.load(p,i+5UL,j) * x1;
+               xmm7 += A.load(p,i+6UL,j) * x1;
+               xmm8 += A.load(p,i+7UL,j) * x1;
+            }
 
-   //      y[i    ] = sum( xmm1 );
-   //      y[i+1UL] = sum( xmm2 );
-   //      y[i+2UL] = sum( xmm3 );
-   //      y[i+3UL] = sum( xmm4 );
-   //      y[i+4UL] = sum( xmm5 );
-   //      y[i+5UL] = sum( xmm6 );
-   //      y[i+6UL] = sum( xmm7 );
-   //      y[i+7UL] = sum( xmm8 );
+            y(p,i    ) = sum( xmm1 );
+            y(p,i+1UL) = sum( xmm2 );
+            y(p,i+2UL) = sum( xmm3 );
+            y(p,i+3UL) = sum( xmm4 );
+            y(p,i+4UL) = sum( xmm5 );
+            y(p,i+5UL) = sum( xmm6 );
+            y(p,i+6UL) = sum( xmm7 );
+            y(p,i+7UL) = sum( xmm8 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //         y[i+3UL] += A(i+3UL,j) * x[j];
-   //         y[i+4UL] += A(i+4UL,j) * x[j];
-   //         y[i+5UL] += A(i+5UL,j) * x[j];
-   //         y[i+6UL] += A(i+6UL,j) * x[j];
-   //         y[i+7UL] += A(i+7UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+               y(p,i+4UL) += A(p,i+4UL,j) * x[j];
+               y(p,i+5UL) += A(p,i+5UL,j) * x[j];
+               y(p,i+6UL) += A(p,i+6UL,j) * x[j];
+               y(p,i+7UL) += A(p,i+7UL,j) * x[j];
+            }
+         }
 
-   //   for( ; (i+4UL) <= M; i+=4UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2, xmm3, xmm4;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2, xmm3, xmm4;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //         xmm3 += A.load(i+2UL,j) * x1;
-   //         xmm4 += A.load(i+3UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+            }
 
-   //      y[i    ] = sum( xmm1 );
-   //      y[i+1UL] = sum( xmm2 );
-   //      y[i+2UL] = sum( xmm3 );
-   //      y[i+3UL] = sum( xmm4 );
+            y(p,i    ) = sum( xmm1 );
+            y(p,i+1UL) = sum( xmm2 );
+            y(p,i+2UL) = sum( xmm3 );
+            y(p,i+3UL) = sum( xmm4 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //         y[i+3UL] += A(i+3UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+            }
+         }
 
-   //   for( ; (i+3UL) <= M; i+=3UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+3UL) <= M; i+=3UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2, xmm3;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2, xmm3;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //         xmm3 += A.load(i+2UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+            }
 
-   //      y[i    ] = sum( xmm1 );
-   //      y[i+1UL] = sum( xmm2 );
-   //      y[i+2UL] = sum( xmm3 );
+            y(p,i    ) = sum( xmm1 );
+            y(p,i+1UL) = sum( xmm2 );
+            y(p,i+2UL) = sum( xmm3 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+            }
+         }
 
-   //   for( ; (i+2UL) <= M; i+=2UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+            }
 
-   //      y[i    ] = sum( xmm1 );
-   //      y[i+1UL] = sum( xmm2 );
+            y(p,i    ) = sum( xmm1 );
+            y(p,i+1UL) = sum( xmm2 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+            }
+         }
 
-   //   if( i < M )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1;
-   //      size_t j( jbegin );
+            SIMDType xmm1;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         xmm1 += A.load(i,j) * x.load(j);
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               xmm1 += A.load(p,i,j) * x.load(j);
+            }
 
-   //      y[i] = sum( xmm1 );
+            y(p,i) = sum( xmm1 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i] += A(i,j) * x[j];
-   //      }
-   //   }
-   //}
-   ///*! \endcond */
-   ////**********************************************************************************************
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) += A(p,i,j) * x[j];
+            }
+         }
+      }
+   }
+   /*! \endcond */
+   //**********************************************************************************************
 
    //**Default assignment to dense vectors (large tensors)****************************************
    /*! \cond BLAZE_INTERNAL */
@@ -733,313 +717,245 @@ class DTensDVecMultExpr
    /*! \endcond */
    //**********************************************************************************************
 
-   ////**Vectorized default assignment to dense vectors (large tensors)*****************************
-   ///*! \cond BLAZE_INTERNAL */
-   ///*!\brief Vectorized default assignment of a large dense tensor-dense vector multiplication
-   ////        (\f$ \vec{y}=A*\vec{x} \f$).
-   //// \ingroup dense_vector
-   ////
-   //// \param y The target left-hand side dense vector.
-   //// \param A The left-hand side dense tensor operand.
-   //// \param x The right-hand side dense vector operand.
-   //// \return void
-   ////
-   //// This function implements the vectorized default assignment kernel for the dense tensor-
-   //// dense vector multiplication. This kernel is optimized for large tensors.
-   //*/
-   //template< typename MT1    // Type of the left-hand side target matrix
-   //        , typename TT1    // Type of the left-hand side tensor operand
-   //        , typename VT1 >  // Type of the right-hand side vector operand
-   //static inline auto selectLargeAssignKernel( MT1& y, const TT1& A, const VT1& x )
-   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
-   //{
-   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
-
-   //   const size_t M( A.rows()    );
-   //   const size_t N( A.columns() );
-
-   //   reset( y );
-
-   //   size_t i( 0UL );
-
-   //   for( ; (i+8UL) <= M; i+=8UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
-   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 );
-   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 );
-   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 );
-   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
-   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 );
-   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 );
-   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 );
-   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
-   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 );
-   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 );
-   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 );
-   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //         y[i+3UL] += A(i+3UL,j) * x[j];
-   //         y[i+4UL] += A(i+4UL,j) * x[j];
-   //         y[i+5UL] += A(i+5UL,j) * x[j];
-   //         y[i+6UL] += A(i+6UL,j) * x[j];
-   //         y[i+7UL] += A(i+7UL,j) * x[j];
-   //      }
-   //   }
-
-   //   for( ; (i+4UL) <= M; i+=4UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //         y[i+3UL] += A(i+3UL,j) * x[j];
-   //      }
-   //   }
-
-   //   for( ; (i+2UL) <= M; i+=2UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //      }
-   //   }
-
-   //   if( i < M )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i] += sum( A.load(i,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i] += A(i,j) * x[j];
-   //      }
-   //   }
-   //}
-   ///*! \endcond */
-   ////**********************************************************************************************
-
-   //**BLAS-based assignment to dense vectors (default)********************************************
+   //**Vectorized default assignment to dense vectors (large tensors)*****************************
    /*! \cond BLAZE_INTERNAL */
-   /*!\brief Default assignment of a dense tensor-dense vector multiplication
+   /*!\brief Vectorized default assignment of a large dense tensor-dense vector multiplication
    //        (\f$ \vec{y}=A*\vec{x} \f$).
    // \ingroup dense_vector
    //
-   // \param y The target left-hand side dense matrix.
+   // \param y The target left-hand side dense vector.
    // \param A The left-hand side dense tensor operand.
    // \param x The right-hand side dense vector operand.
    // \return void
    //
-   // This function relays to the default implementation of the assignment of a large dense
-   // tensor-dense vector multiplication expression to a dense vector.
+   // This function implements the vectorized default assignment kernel for the dense tensor-
+   // dense vector multiplication. This kernel is optimized for large tensors.
    */
    template< typename MT1    // Type of the left-hand side target matrix
            , typename TT1    // Type of the left-hand side tensor operand
            , typename VT1 >  // Type of the right-hand side vector operand
-   static inline auto selectBlasAssignKernel( MT1& y, const TT1& A, const VT1& x )
-      -> EnableIf_t< !UseBlasKernel_v<MT1,TT1,VT1> >
+   static inline auto selectLargeAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
    {
-      selectLargeAssignKernel( y, A, x );
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
+
+      reset( y );
+
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
+
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( ( IsUpper_v<TT1> )
+                                 ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+                                 :( 0UL ) );
+            const size_t jend( ( IsLower_v<TT1> )
+                               ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+                               :( N ) );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 );
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 + A.load(p,i+4UL,j2) * x3 + A.load(p,i+4UL,j3) * x4 );
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 + A.load(p,i+5UL,j2) * x3 + A.load(p,i+5UL,j3) * x4 );
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 + A.load(p,i+6UL,j2) * x3 + A.load(p,i+6UL,j3) * x4 );
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 + A.load(p,i+7UL,j2) * x3 + A.load(p,i+7UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 );
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 );
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 );
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 );
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 );
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 );
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 );
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 );
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+               y(p,i+4UL) += A(p,i+4UL,j) * x[j];
+               y(p,i+5UL) += A(p,i+5UL,j) * x[j];
+               y(p,i+6UL) += A(p,i+6UL,j) * x[j];
+               y(p,i+7UL) += A(p,i+7UL,j) * x[j];
+            }
+         }
+
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+            }
+         }
+
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+            }
+         }
+
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i) += sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 + A.load(p,i,j2) * x3 + A.load(p,i,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i) += sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i) += sum( A.load(p,i,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) += A(p,i,j) * x[j];
+            }
+         }
+      }
    }
    /*! \endcond */
-   //**********************************************************************************************
-
-   //**BLAS-based assignment to dense vectors******************************************************
-#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION
-   ///*! \cond BLAZE_INTERNAL */
-   ///*!\brief BLAS-based assignment of a dense tensor-dense vector multiplication
-   ////        (\f$ \vec{y}=A*\vec{x} \f$).
-   //// \ingroup dense_vector
-   ////
-   //// \param y The target left-hand side dense vector.
-   //// \param A The left-hand side dense tensor operand.
-   //// \param x The right-hand side dense vector operand.
-   //// \return void
-   ////
-   //// This function performs the dense tensor-dense vector multiplication based on the according
-   //// BLAS functionality.
-   //*/
-   //template< typename MT1    // Type of the left-hand side target vector
-   //        , typename TT1    // Type of the left-hand side tensor operand
-   //        , typename VT1 >  // Type of the right-hand side vector operand
-   //static inline auto selectBlasAssignKernel( MT1& y, const TT1& A, const VT1& x )
-   //   -> EnableIf_t< UseBlasKernel_v<MT1,TT1,VT1> >
-   //{
-   //   using ET = ElementType_t<MT1>;
-
-   //   if( IsTriangular_v<TT1> ) {
-   //      assign( y, x );
-   //      trmv( y, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
-   //   }
-   //   else {
-   //      gemv( y, A, x, ET(1), ET(0) );
-   //   }
-   //}
-   ///*! \endcond */
-#endif
-   //**********************************************************************************************
+   ////**********************************************************************************************
 
    ////**Assignment to sparse matrices***************************************************************
    ///*! \cond BLAZE_INTERNAL */
@@ -1129,7 +1045,7 @@ class DTensDVecMultExpr
       if ( A.pages() * A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD )
          selectSmallAddAssignKernel( y, A, x );
       else
-         selectBlasAddAssignKernel( y, A, x );
+         selectLargeAddAssignKernel( y, A, x );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1183,213 +1099,197 @@ class DTensDVecMultExpr
    /*! \endcond */
    //**********************************************************************************************
 
-   ////**Vectorized default addition assignment to dense vectors (small tensors)********************
-   ///*! \cond BLAZE_INTERNAL */
-   ///*!\brief Vectorized default addition assignment of a small dense tensor-dense vector
-   ////        multiplication (\f$ \vec{y}+=A*\vec{x} \f$).
-   //// \ingroup dense_vector
-   ////
-   //// \param y The target left-hand side dense vector.
-   //// \param A The left-hand side dense tensor operand.
-   //// \param x The right-hand side dense vector operand.
-   //// \return void
-   ////
-   //// This function implements the vectorized default addition assignment kernel for the dense
-   //// tensor-dense vector multiplication. This kernel is optimized for small tensors.
-   //*/
-   //template< typename MT1    // Type of the left-hand side target vector
-   //        , typename TT1    // Type of the left-hand side tensor operand
-   //        , typename VT1 >  // Type of the right-hand side vector operand
-   //static inline auto selectSmallAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
-   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
-   //{
-   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+   //**Vectorized default addition assignment to dense vectors (small tensors)********************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Vectorized default addition assignment of a small dense tensor-dense vector
+   //        multiplication (\f$ \vec{y}+=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function implements the vectorized default addition assignment kernel for the dense
+   // tensor-dense vector multiplication. This kernel is optimized for small tensors.
+   */
+   template< typename MT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectSmallAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   {
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
 
-   //   const size_t M( A.rows()    );
-   //   const size_t N( A.columns() );
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
 
-   //   size_t i( 0UL );
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
 
-   //   for( ; (i+8UL) <= M; i+=8UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //         xmm3 += A.load(i+2UL,j) * x1;
-   //         xmm4 += A.load(i+3UL,j) * x1;
-   //         xmm5 += A.load(i+4UL,j) * x1;
-   //         xmm6 += A.load(i+5UL,j) * x1;
-   //         xmm7 += A.load(i+6UL,j) * x1;
-   //         xmm8 += A.load(i+7UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+               xmm5 += A.load(p,i+4UL,j) * x1;
+               xmm6 += A.load(p,i+5UL,j) * x1;
+               xmm7 += A.load(p,i+6UL,j) * x1;
+               xmm8 += A.load(p,i+7UL,j) * x1;
+            }
 
-   //      y[i    ] += sum( xmm1 );
-   //      y[i+1UL] += sum( xmm2 );
-   //      y[i+2UL] += sum( xmm3 );
-   //      y[i+3UL] += sum( xmm4 );
-   //      y[i+4UL] += sum( xmm5 );
-   //      y[i+5UL] += sum( xmm6 );
-   //      y[i+6UL] += sum( xmm7 );
-   //      y[i+7UL] += sum( xmm8 );
+            y(p,i    ) += sum( xmm1 );
+            y(p,i+1UL) += sum( xmm2 );
+            y(p,i+2UL) += sum( xmm3 );
+            y(p,i+3UL) += sum( xmm4 );
+            y(p,i+4UL) += sum( xmm5 );
+            y(p,i+5UL) += sum( xmm6 );
+            y(p,i+6UL) += sum( xmm7 );
+            y(p,i+7UL) += sum( xmm8 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //         y[i+3UL] += A(i+3UL,j) * x[j];
-   //         y[i+4UL] += A(i+4UL,j) * x[j];
-   //         y[i+5UL] += A(i+5UL,j) * x[j];
-   //         y[i+6UL] += A(i+6UL,j) * x[j];
-   //         y[i+7UL] += A(i+7UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+               y(p,i+4UL) += A(p,i+4UL,j) * x[j];
+               y(p,i+5UL) += A(p,i+5UL,j) * x[j];
+               y(p,i+6UL) += A(p,i+6UL,j) * x[j];
+               y(p,i+7UL) += A(p,i+7UL,j) * x[j];
+            }
+         }
 
-   //   for( ; (i+4UL) <= M; i+=4UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2, xmm3, xmm4;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2, xmm3, xmm4;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //         xmm3 += A.load(i+2UL,j) * x1;
-   //         xmm4 += A.load(i+3UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+            }
 
-   //      y[i    ] += sum( xmm1 );
-   //      y[i+1UL] += sum( xmm2 );
-   //      y[i+2UL] += sum( xmm3 );
-   //      y[i+3UL] += sum( xmm4 );
+            y(p,i    ) += sum( xmm1 );
+            y(p,i+1UL) += sum( xmm2 );
+            y(p,i+2UL) += sum( xmm3 );
+            y(p,i+3UL) += sum( xmm4 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //         y[i+3UL] += A(i+3UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+            }
+         }
 
-   //   for( ; (i+3UL) <= M; i+=3UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+3UL) <= M; i+=3UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2, xmm3;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2, xmm3;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //         xmm3 += A.load(i+2UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+            }
 
-   //      y[i    ] += sum( xmm1 );
-   //      y[i+1UL] += sum( xmm2 );
-   //      y[i+2UL] += sum( xmm3 );
+            y(p,i    ) += sum( xmm1 );
+            y(p,i+1UL) += sum( xmm2 );
+            y(p,i+2UL) += sum( xmm3 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+            }
+         }
 
-   //   for( ; (i+2UL) <= M; i+=2UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+            }
 
-   //      y[i    ] += sum( xmm1 );
-   //      y[i+1UL] += sum( xmm2 );
+            y(p,i    ) += sum( xmm1 );
+            y(p,i+1UL) += sum( xmm2 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+            }
+         }
 
-   //   if( i < M )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1;
-   //      size_t j( jbegin );
+            SIMDType xmm1;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         xmm1 += A.load(i,j) * x.load(j);
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               xmm1 += A.load(p,i,j) * x.load(j);
+            }
 
-   //      y[i] += sum( xmm1 );
+            y(p,i) += sum( xmm1 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i] += A(i,j) * x[j];
-   //      }
-   //   }
-   //}
-   ///*! \endcond */
-   ////**********************************************************************************************
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) += A(p,i,j) * x[j];
+            }
+         }
+      }
+   }
+   /*! \endcond */
+   //**********************************************************************************************
 
    //**Default addition assignment to dense vectors (large tensors)*******************************
    /*! \cond BLAZE_INTERNAL */
@@ -1416,256 +1316,10 @@ class DTensDVecMultExpr
    /*! \endcond */
    //**********************************************************************************************
 
-   ////**Vectorized default addition assignment to dense vectors (large tensors)********************
-   ///*! \cond BLAZE_INTERNAL */
-   ///*!\brief Vectorized default addition assignment of a large dense tensor-dense vector
-   ////        multiplication (\f$ \vec{y}+=A*\vec{x} \f$).
-   //// \ingroup dense_vector
-   ////
-   //// \param y The target left-hand side dense vector.
-   //// \param A The left-hand side dense tensor operand.
-   //// \param x The right-hand side dense vector operand.
-   //// \return void
-   ////
-   //// This function implements the vectorized default addition assignment kernel for the dense
-   //// tensor-dense vector multiplication. This kernel is optimized for large tensors.
-   //*/
-   //template< typename MT1    // Type of the left-hand side target vector
-   //        , typename TT1    // Type of the left-hand side tensor operand
-   //        , typename VT1 >  // Type of the right-hand side vector operand
-   //static inline auto selectLargeAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
-   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
-   //{
-   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
-
-   //   const size_t M( A.rows()    );
-   //   const size_t N( A.columns() );
-
-   //   size_t i( 0UL );
-
-   //   for( ; (i+8UL) <= M; i+=8UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
-   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 );
-   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 );
-   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 );
-   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
-   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 );
-   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 );
-   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 );
-   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
-   //         y[i+4UL] += sum( A.load(i+4UL,j) * x1 );
-   //         y[i+5UL] += sum( A.load(i+5UL,j) * x1 );
-   //         y[i+6UL] += sum( A.load(i+6UL,j) * x1 );
-   //         y[i+7UL] += sum( A.load(i+7UL,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //         y[i+3UL] += A(i+3UL,j) * x[j];
-   //         y[i+4UL] += A(i+4UL,j) * x[j];
-   //         y[i+5UL] += A(i+5UL,j) * x[j];
-   //         y[i+6UL] += A(i+6UL,j) * x[j];
-   //         y[i+7UL] += A(i+7UL,j) * x[j];
-   //      }
-   //   }
-
-   //   for( ; (i+4UL) <= M; i+=4UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
-   //         y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
-   //         y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //         y[i+2UL] += A(i+2UL,j) * x[j];
-   //         y[i+3UL] += A(i+3UL,j) * x[j];
-   //      }
-   //   }
-
-   //   for( ; (i+2UL) <= M; i+=2UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i    ] += sum( A.load(i    ,j) * x1 );
-   //         y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] += A(i    ,j) * x[j];
-   //         y[i+1UL] += A(i+1UL,j) * x[j];
-   //      }
-   //   }
-
-   //   if( i < M )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i] += sum( A.load(i,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i] += A(i,j) * x[j];
-   //      }
-   //   }
-   //}
-   ///*! \endcond */
-   ////**********************************************************************************************
-
-   //**BLAS-based addition assignment to dense vectors (default)***********************************
+   //**Vectorized default addition assignment to dense vectors (large tensors)********************
    /*! \cond BLAZE_INTERNAL */
-   /*!\brief Default addition assignment of a dense tensor-dense vector multiplication
-   //        (\f$ \vec{y}+=A*\vec{x} \f$).
+   /*!\brief Vectorized default addition assignment of a large dense tensor-dense vector
+   //        multiplication (\f$ \vec{y}+=A*\vec{x} \f$).
    // \ingroup dense_vector
    //
    // \param y The target left-hand side dense vector.
@@ -1673,55 +1327,228 @@ class DTensDVecMultExpr
    // \param x The right-hand side dense vector operand.
    // \return void
    //
-   // This function relays to the default implementation of the addition assignment of a large
-   // dense tensor-dense vector multiplication expression to a dense vector.
+   // This function implements the vectorized default addition assignment kernel for the dense
+   // tensor-dense vector multiplication. This kernel is optimized for large tensors.
    */
-   template< typename MT1    // Type of the left-hand side target matrix
+   template< typename MT1    // Type of the left-hand side target vector
            , typename TT1    // Type of the left-hand side tensor operand
            , typename VT1 >  // Type of the right-hand side vector operand
-   static inline auto selectBlasAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
-      -> EnableIf_t< !UseBlasKernel_v<MT1,TT1,VT1> >
+   static inline auto selectLargeAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
    {
-      selectLargeAddAssignKernel( y, A, x );
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
+
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
+
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 );
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 + A.load(p,i+4UL,j2) * x3 + A.load(p,i+4UL,j3) * x4 );
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 + A.load(p,i+5UL,j2) * x3 + A.load(p,i+5UL,j3) * x4 );
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 + A.load(p,i+6UL,j2) * x3 + A.load(p,i+6UL,j3) * x4 );
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 + A.load(p,i+7UL,j2) * x3 + A.load(p,i+7UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 );
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 );
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 );
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 );
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 );
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 );
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 );
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 );
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+               y(p,i+4UL) += A(p,i+4UL,j) * x[j];
+               y(p,i+5UL) += A(p,i+5UL,j) * x[j];
+               y(p,i+6UL) += A(p,i+6UL,j) * x[j];
+               y(p,i+7UL) += A(p,i+7UL,j) * x[j];
+            }
+         }
+
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+            }
+         }
+
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+            }
+         }
+
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i) += sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 + A.load(p,i,j2) * x3 + A.load(p,i,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i) += sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i) += sum( A.load(p,i,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) += A(p,i,j) * x[j];
+            }
+         }
+      }
    }
    /*! \endcond */
-   //**********************************************************************************************
-
-   //**BLAS-based addition assignment to dense vectors*********************************************
-#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION
-   ///*! \cond BLAZE_INTERNAL */
-   ///*!\brief BLAS-based addition assignment of a tensor-vector multiplication
-   ////        (\f$ \vec{y}+=A*\vec{x} \f$).
-   //// \ingroup dense_vector
-   ////
-   //// \param y The target left-hand side dense vector.
-   //// \param A The left-hand side dense tensor operand.
-   //// \param x The right-hand side dense vector operand.
-   //// \return void
-   ////
-   //// This function performs the dense tensor-dense vector multiplication based on the according
-   //// BLAS functionality.
-   //*/
-   //template< typename MT1    // Type of the left-hand side target vector
-   //        , typename TT1    // Type of the left-hand side tensor operand
-   //        , typename VT1 >  // Type of the right-hand side vector operand
-   //static inline auto selectBlasAddAssignKernel( MT1& y, const TT1& A, const VT1& x )
-   //   -> EnableIf_t< UseBlasKernel_v<MT1,TT1,VT1> >
-   //{
-   //   using ET = ElementType_t<MT1>;
-
-   //   if( IsTriangular_v<TT1> ) {
-   //      ResultType_t<MT1> tmp( serial( x ) );
-   //      trmv( tmp, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
-   //      addAssign( y, tmp );
-   //   }
-   //   else {
-   //      gemv( y, A, x, ET(1), ET(1) );
-   //   }
-   //}
-   ///*! \endcond */
-#endif
-   //**********************************************************************************************
+   ////**********************************************************************************************
 
    //**Addition assignment to sparse matrices******************************************************
    // No special implementation for the addition assignment to sparse vectors.
@@ -1785,7 +1612,7 @@ class DTensDVecMultExpr
       if( A.pages() * A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD )
          selectSmallSubAssignKernel( y, A, x );
       else
-         selectBlasSubAssignKernel( y, A, x );
+         selectLargeSubAssignKernel( y, A, x );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1839,212 +1666,196 @@ class DTensDVecMultExpr
    /*! \endcond */
    //**********************************************************************************************
 
-   ////**Vectorized default subtraction assignment to dense vectors (small tensors)*****************
-   ///*! \cond BLAZE_INTERNAL */
-   ///*!\brief Vectorized default subtraction assignment of a small dense tensor-dense vector
-   ////        multiplication (\f$ \vec{y}-=A*\vec{x} \f$).
-   //// \ingroup dense_vector
-   ////
-   //// \param y The target left-hand side dense vector.
-   //// \param A The left-hand side dense tensor operand.
-   //// \param x The right-hand side dense vector operand.
-   //// \return void
-   ////
-   //// This function implements the vectorized default subtraction assignment kernel for the dense
-   //// tensor-dense vector multiplication. This kernel is optimized for small tensors.
-   //*/
-   //template< typename MT1    // Type of the left-hand side target vector
-   //        , typename TT1    // Type of the left-hand side tensor operand
-   //        , typename VT1 >  // Type of the right-hand side vector operand
-   //static inline auto selectSmallSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
-   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
-   //{
-   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+   //**Vectorized default subtraction assignment to dense vectors (small tensors)*****************
+   /*! \cond BLAZE_INTERNAL */
+   /*!\brief Vectorized default subtraction assignment of a small dense tensor-dense vector
+   //        multiplication (\f$ \vec{y}-=A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \return void
+   //
+   // This function implements the vectorized default subtraction assignment kernel for the dense
+   // tensor-dense vector multiplication. This kernel is optimized for small tensors.
+   */
+   template< typename MT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT1 >  // Type of the right-hand side vector operand
+   static inline auto selectSmallSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
+   {
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
 
-   //   const size_t M( A.rows()    );
-   //   const size_t N( A.columns() );
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
 
-   //   size_t i( 0UL );
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
 
-   //   for( ; (i+8UL) <= M; i+=8UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //         xmm3 += A.load(i+2UL,j) * x1;
-   //         xmm4 += A.load(i+3UL,j) * x1;
-   //         xmm5 += A.load(i+4UL,j) * x1;
-   //         xmm6 += A.load(i+5UL,j) * x1;
-   //         xmm7 += A.load(i+6UL,j) * x1;
-   //         xmm8 += A.load(i+7UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+               xmm5 += A.load(p,i+4UL,j) * x1;
+               xmm6 += A.load(p,i+5UL,j) * x1;
+               xmm7 += A.load(p,i+6UL,j) * x1;
+               xmm8 += A.load(p,i+7UL,j) * x1;
+            }
 
-   //      y[i    ] -= sum( xmm1 );
-   //      y[i+1UL] -= sum( xmm2 );
-   //      y[i+2UL] -= sum( xmm3 );
-   //      y[i+3UL] -= sum( xmm4 );
-   //      y[i+4UL] -= sum( xmm5 );
-   //      y[i+5UL] -= sum( xmm6 );
-   //      y[i+6UL] -= sum( xmm7 );
-   //      y[i+7UL] -= sum( xmm8 );
+            y(p,i    ) -= sum( xmm1 );
+            y(p,i+1UL) -= sum( xmm2 );
+            y(p,i+2UL) -= sum( xmm3 );
+            y(p,i+3UL) -= sum( xmm4 );
+            y(p,i+4UL) -= sum( xmm5 );
+            y(p,i+5UL) -= sum( xmm6 );
+            y(p,i+6UL) -= sum( xmm7 );
+            y(p,i+7UL) -= sum( xmm8 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] -= A(i    ,j) * x[j];
-   //         y[i+1UL] -= A(i+1UL,j) * x[j];
-   //         y[i+2UL] -= A(i+2UL,j) * x[j];
-   //         y[i+3UL] -= A(i+3UL,j) * x[j];
-   //         y[i+4UL] -= A(i+4UL,j) * x[j];
-   //         y[i+5UL] -= A(i+5UL,j) * x[j];
-   //         y[i+6UL] -= A(i+6UL,j) * x[j];
-   //         y[i+7UL] -= A(i+7UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j];
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) -= A(p,i+3UL,j) * x[j];
+               y(p,i+4UL) -= A(p,i+4UL,j) * x[j];
+               y(p,i+5UL) -= A(p,i+5UL,j) * x[j];
+               y(p,i+6UL) -= A(p,i+6UL,j) * x[j];
+               y(p,i+7UL) -= A(p,i+7UL,j) * x[j];
+            }
+         }
 
-   //   for( ; (i+4UL) <= M; i+=4UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2, xmm3, xmm4;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2, xmm3, xmm4;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //         xmm3 += A.load(i+2UL,j) * x1;
-   //         xmm4 += A.load(i+3UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+            }
 
-   //      y[i    ] -= sum( xmm1 );
-   //      y[i+1UL] -= sum( xmm2 );
-   //      y[i+2UL] -= sum( xmm3 );
-   //      y[i+3UL] -= sum( xmm4 );
+            y(p,i    ) -= sum( xmm1 );
+            y(p,i+1UL) -= sum( xmm2 );
+            y(p,i+2UL) -= sum( xmm3 );
+            y(p,i+3UL) -= sum( xmm4 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] -= A(i    ,j) * x[j];
-   //         y[i+1UL] -= A(i+1UL,j) * x[j];
-   //         y[i+2UL] -= A(i+2UL,j) * x[j];
-   //         y[i+3UL] -= A(i+3UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j];
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) -= A(p,i+3UL,j) * x[j];
+            }
+         }
 
-   //   for( ; (i+3UL) <= M; i+=3UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+3UL) <= M; i+=3UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2, xmm3;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2, xmm3;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //         xmm3 += A.load(i+2UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+            }
 
-   //      y[i    ] -= sum( xmm1 );
-   //      y[i+1UL] -= sum( xmm2 );
-   //      y[i+2UL] -= sum( xmm3 );
+            y(p,i    ) -= sum( xmm1 );
+            y(p,i+1UL) -= sum( xmm2 );
+            y(p,i+2UL) -= sum( xmm3 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] -= A(i    ,j) * x[j];
-   //         y[i+1UL] -= A(i+1UL,j) * x[j];
-   //         y[i+2UL] -= A(i+2UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j];
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j];
+            }
+         }
 
-   //   for( ; (i+2UL) <= M; i+=2UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1, xmm2;
-   //      size_t j( jbegin );
+            SIMDType xmm1, xmm2;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         xmm1 += A.load(i    ,j) * x1;
-   //         xmm2 += A.load(i+1UL,j) * x1;
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+            }
 
-   //      y[i    ] -= sum( xmm1 );
-   //      y[i+1UL] -= sum( xmm2 );
+            y(p,i    ) -= sum( xmm1 );
+            y(p,i+1UL) -= sum( xmm2 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] -= A(i    ,j) * x[j];
-   //         y[i+1UL] -= A(i+1UL,j) * x[j];
-   //      }
-   //   }
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j];
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j];
+            }
+         }
 
-   //   if( i < M )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
-   //      SIMDType xmm1;
-   //      size_t j( jbegin );
+            SIMDType xmm1;
+            size_t j( jbegin );
 
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         xmm1 += A.load(i,j) * x.load(j);
-   //      }
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               xmm1 += A.load(p,i,j) * x.load(j);
+            }
 
-   //      y[i] -= sum( xmm1 );
+            y(p,i) -= sum( xmm1 );
 
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i] -= A(i,j) * x[j];
-   //      }
-   //   }
-   //}
-   ///*! \endcond */
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) -= A(p,i,j) * x[j];
+            }
+         }
+      }
+   }
+   /*! \endcond */
    ////**********************************************************************************************
 
    //**Default subtraction assignment to dense vectors (large tensors)****************************
@@ -2072,256 +1883,10 @@ class DTensDVecMultExpr
    /*! \endcond */
    //**********************************************************************************************
 
-   ////**Vectorized default subtraction assignment to dense vectors (large tensors)*****************
-   ///*! \cond BLAZE_INTERNAL */
-   ///*!\brief Vectorized default subtraction assignment of a large dense tensor-dense vector
-   ////        multiplication (\f$ \vec{y}-=A*\vec{x} \f$).
-   //// \ingroup dense_vector
-   ////
-   //// \param y The target left-hand side dense vector.
-   //// \param A The left-hand side dense tensor operand.
-   //// \param x The right-hand side dense vector operand.
-   //// \return void
-   ////
-   //// This function implements the vectorized default subtraction assignment kernel for the dense
-   //// tensor-dense vector multiplication. This kernel is optimized for large tensors.
-   //*/
-   //template< typename MT1    // Type of the left-hand side target vector
-   //        , typename TT1    // Type of the left-hand side tensor operand
-   //        , typename VT1 >  // Type of the right-hand side vector operand
-   //static inline auto selectLargeSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
-   //   -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
-   //{
-   //   constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
-
-   //   const size_t M( A.rows()    );
-   //   const size_t N( A.columns() );
-
-   //   size_t i( 0UL );
-
-   //   for( ; (i+8UL) <= M; i+=8UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
-   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
-   //         y[i+4UL] -= sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 );
-   //         y[i+5UL] -= sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 );
-   //         y[i+6UL] -= sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 );
-   //         y[i+7UL] -= sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
-   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
-   //         y[i+4UL] -= sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 );
-   //         y[i+5UL] -= sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 );
-   //         y[i+6UL] -= sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 );
-   //         y[i+7UL] -= sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i    ] -= sum( A.load(i    ,j) * x1 );
-   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 );
-   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 );
-   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 );
-   //         y[i+4UL] -= sum( A.load(i+4UL,j) * x1 );
-   //         y[i+5UL] -= sum( A.load(i+5UL,j) * x1 );
-   //         y[i+6UL] -= sum( A.load(i+6UL,j) * x1 );
-   //         y[i+7UL] -= sum( A.load(i+7UL,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] -= A(i    ,j) * x[j];
-   //         y[i+1UL] -= A(i+1UL,j) * x[j];
-   //         y[i+2UL] -= A(i+2UL,j) * x[j];
-   //         y[i+3UL] -= A(i+3UL,j) * x[j];
-   //         y[i+4UL] -= A(i+4UL,j) * x[j];
-   //         y[i+5UL] -= A(i+5UL,j) * x[j];
-   //         y[i+6UL] -= A(i+6UL,j) * x[j];
-   //         y[i+7UL] -= A(i+7UL,j) * x[j];
-   //      }
-   //   }
-
-   //   for( ; (i+4UL) <= M; i+=4UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
-   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
-   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i    ] -= sum( A.load(i    ,j) * x1 );
-   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 );
-   //         y[i+2UL] -= sum( A.load(i+2UL,j) * x1 );
-   //         y[i+3UL] -= sum( A.load(i+3UL,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] -= A(i    ,j) * x[j];
-   //         y[i+1UL] -= A(i+1UL,j) * x[j];
-   //         y[i+2UL] -= A(i+2UL,j) * x[j];
-   //         y[i+3UL] -= A(i+3UL,j) * x[j];
-   //      }
-   //   }
-
-   //   for( ; (i+2UL) <= M; i+=2UL )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i    ] -= sum( A.load(i    ,j) * x1 );
-   //         y[i+1UL] -= sum( A.load(i+1UL,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i    ] -= A(i    ,j) * x[j];
-   //         y[i+1UL] -= A(i+1UL,j) * x[j];
-   //      }
-   //   }
-
-   //   if( i < M )
-   //   {
-   //      const size_t jbegin( ( IsUpper_v<TT1> )
-   //                           ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-   //                           :( 0UL ) );
-   //      const size_t jend( ( IsLower_v<TT1> )
-   //                         ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-   //                         :( N ) );
-   //      BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-
-   //      const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-   //      BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-
-   //      size_t j( jbegin );
-
-   //      for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-   //         const size_t j1( j+SIMDSIZE     );
-   //         const size_t j2( j+SIMDSIZE*2UL );
-   //         const size_t j3( j+SIMDSIZE*3UL );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         const SIMDType x3( x.load(j2) );
-   //         const SIMDType x4( x.load(j3) );
-   //         y[i] -= sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 );
-   //      }
-
-   //      for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-   //         const size_t j1( j+SIMDSIZE );
-   //         const SIMDType x1( x.load(j ) );
-   //         const SIMDType x2( x.load(j1) );
-   //         y[i] -= sum( A.load(i,j) * x1 + A.load(i,j1) * x2 );
-   //      }
-
-   //      for( ; j<jpos; j+=SIMDSIZE ) {
-   //         const SIMDType x1( x.load(j) );
-   //         y[i] -= sum( A.load(i,j) * x1 );
-   //      }
-
-   //      for( ; remainder && j<jend; ++j ) {
-   //         y[i] -= A(i,j) * x[j];
-   //      }
-   //   }
-   //}
-   ///*! \endcond */
-   ////**********************************************************************************************
-
-   //**BLAS-based subtraction assignment to dense matrices (default)********************************
+   //**Vectorized default subtraction assignment to dense vectors (large tensors)*****************
    /*! \cond BLAZE_INTERNAL */
-   /*!\brief Default subtraction assignment of a dense tensor-dense vector multiplication
-   //        (\f$ \vec{y}-=A*\vec{x} \f$).
+   /*!\brief Vectorized default subtraction assignment of a large dense tensor-dense vector
+   //        multiplication (\f$ \vec{y}-=A*\vec{x} \f$).
    // \ingroup dense_vector
    //
    // \param y The target left-hand side dense vector.
@@ -2329,54 +1894,227 @@ class DTensDVecMultExpr
    // \param x The right-hand side dense vector operand.
    // \return void
    //
-   // This function relays to the default implementation of the subtraction assignment of a large
-   // dense tensor-dense vector multiplication expression to a dense vector.
+   // This function implements the vectorized default subtraction assignment kernel for the dense
+   // tensor-dense vector multiplication. This kernel is optimized for large tensors.
    */
    template< typename MT1    // Type of the left-hand side target vector
            , typename TT1    // Type of the left-hand side tensor operand
            , typename VT1 >  // Type of the right-hand side vector operand
-   static inline auto selectBlasSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
-      -> EnableIf_t< !UseBlasKernel_v<MT1,TT1,VT1> >
+   static inline auto selectLargeSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<MT1,TT1,VT1> >
    {
-      selectLargeSubAssignKernel( y, A, x );
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT1> );
+
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
+
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
+
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 );
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 );
+               y(p,i+4UL) -= sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 + A.load(p,i+4UL,j2) * x3 + A.load(p,i+4UL,j3) * x4 );
+               y(p,i+5UL) -= sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 + A.load(p,i+5UL,j2) * x3 + A.load(p,i+5UL,j3) * x4 );
+               y(p,i+6UL) -= sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 + A.load(p,i+6UL,j2) * x3 + A.load(p,i+6UL,j3) * x4 );
+               y(p,i+7UL) -= sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 + A.load(p,i+7UL,j2) * x3 + A.load(p,i+7UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 );
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 );
+               y(p,i+4UL) -= sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 );
+               y(p,i+5UL) -= sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 );
+               y(p,i+6UL) -= sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 );
+               y(p,i+7UL) -= sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 );
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 );
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 );
+               y(p,i+4UL) -= sum( A.load(p,i+4UL,j) * x1 );
+               y(p,i+5UL) -= sum( A.load(p,i+5UL,j) * x1 );
+               y(p,i+6UL) -= sum( A.load(p,i+6UL,j) * x1 );
+               y(p,i+7UL) -= sum( A.load(p,i+7UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j];
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) -= A(p,i+3UL,j) * x[j];
+               y(p,i+4UL) -= A(p,i+4UL,j) * x[j];
+               y(p,i+5UL) -= A(p,i+5UL,j) * x[j];
+               y(p,i+6UL) -= A(p,i+6UL,j) * x[j];
+               y(p,i+7UL) -= A(p,i+7UL,j) * x[j];
+            }
+         }
+
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 );
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 );
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 );
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 );
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j];
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) -= A(p,i+3UL,j) * x[j];
+            }
+         }
+
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j];
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j];
+            }
+         }
+
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i) -= sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 + A.load(p,i,j2) * x3 + A.load(p,i,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i) -= sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i) -= sum( A.load(p,i,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) -= A(p,i,j) * x[j];
+            }
+         }
+      }
    }
    /*! \endcond */
-   //**********************************************************************************************
-
-   //**BLAS-based subtraction assignment to dense vectors******************************************
-#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION
-   ///*! \cond BLAZE_INTERNAL */
-   ///*!\brief BLAS-based subtraction assignment of a tensor-vector multiplication
-   ////        (\f$ \vec{y}-=A*\vec{x} \f$).
-   //// \ingroup dense_vector
-   ////
-   //// \param y The target left-hand side dense vector.
-   //// \param A The left-hand side dense tensor operand.
-   //// \param x The right-hand side dense vector operand.
-   //// \return void
-   ////
-   //// This function performs the dense tensor-dense vector multiplication based on the according
-   //// BLAS functionality.
-   //*/
-   //template< typename MT1    // Type of the left-hand side target vector
-   //        , typename TT1    // Type of the left-hand side tensor operand
-   //        , typename VT1 >  // Type of the right-hand side vector operand
-   //static inline auto selectBlasSubAssignKernel( MT1& y, const TT1& A, const VT1& x )
-   //   -> EnableIf_t< UseBlasKernel_v<MT1,TT1,VT1> >
-   //{
-   //   using ET = ElementType_t<MT1>;
-
-   //   if( IsTriangular_v<TT1> ) {
-   //      ResultType_t<MT1> tmp( serial( x ) );
-   //      trmv( tmp, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
-   //      subAssign( y, tmp );
-   //   }
-   //   else {
-   //      gemv( y, A, x, ET(-1), ET(1) );
-   //   }
-   //}
-   ///*! \endcond */
-#endif
    //**********************************************************************************************
 
    //**Subtraction assignment to sparse vectors****************************************************
@@ -2396,8 +2134,7 @@ class DTensDVecMultExpr
    // This function implements the performance optimized multiplication assignment of a dense
    // tensor-dense vector multiplication expression to a dense vector.
    */
-   template< typename MT1  // Type of the target dense matrix
-              , bool SO >    // Storage order of the target dense matrix
+   template< typename MT1 >  // Type of the target dense matrix
    friend inline void schurAssign( DenseMatrix<MT1,false>& lhs, const DTensDVecMultExpr& rhs )
    {
       BLAZE_FUNCTION_TRACE;
@@ -2601,8 +2338,7 @@ class DTensDVecMultExpr
    // application of the SFINAE principle, this function can only be selected by the compiler
    // in case the expression specific parallel evaluation strategy is selected.
    */
-   template< typename MT1   // Type of the target dense matrix
-             , bool SO >    // Storage order of the target dense matrix
+   template< typename MT1 >  // Type of the target dense matrix
    friend inline auto smpSchurAssign( DenseMatrix<MT1,false>& lhs, const DTensDVecMultExpr& rhs )
       -> EnableIf_t< UseSMPAssign_v<MT1> >
    {
@@ -2738,6 +2474,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    using BaseType      = DenseMatrix<This,false>;           //!< Base type of this DMatScalarMultExpr instance.
    using ResultType    = MultTrait_t<RES,ST>;               //!< Result type for expression template evaluations.
    using TransposeType = TransposeType_t<ResultType>;       //!< Transpose type for expression template evaluations.
+   using OppositeType  = OppositeType_t<ResultType>;        //!< Result type with opposite storage order for expression template evaluations.
    using ElementType   = ElementType_t<ResultType>;         //!< Resulting element type.
    using SIMDType      = SIMDTrait_t<ElementType>;          //!< Resulting SIMD element type.
    using ReturnType    = const ElementType;                 //!< Return type for expression template evaluations.
@@ -2977,7 +2714,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       if( A.pages() * A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD )
          selectSmallAssignKernel( y, A, x, scalar );
       else
-         selectBlasAssignKernel( y, A, x, scalar );
+         selectLargeAssignKernel( y, A, x, scalar );
    }
    //**********************************************************************************************
 
@@ -3029,214 +2766,198 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    {
       selectDefaultAssignKernel( y, A, x, scalar );
    }
-//   //**********************************************************************************************
-//
-//   //**Vectorized default assignment to dense vectors (small tensors)*****************************
-//   /*!\brief Vectorized default assignment of a small scaled dense tensor-dense vector
-//   //        multiplication (\f$ \vec{y}=s*A*\vec{x} \f$).
-//   // \ingroup dense_vector
-//   //
-//   // \param y The target left-hand side dense vector.
-//   // \param A The left-hand side dense tensor operand.
-//   // \param x The right-hand side dense vector operand.
-//   // \param scalar The scaling factor.
-//   // \return void
-//   //
-//   // This function implements the vectorized default assignment kernel for the scaled dense
-//   // tensor-dense vector multiplication. This kernel is optimized for small tensors.
-//   */
-//   template< typename VT1    // Type of the left-hand side target vector
-//           , typename TT1    // Type of the left-hand side tensor operand
-//           , typename VT2    // Type of the right-hand side vector operand
-//           , typename ST2 >  // Type of the scalar value
-//   static inline auto selectSmallAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
-//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
-//   {
-//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
-//
-//      const size_t M( A.rows()    );
-//      const size_t N( A.columns() );
-//
-//      size_t i( 0UL );
-//
-//      for( ; (i+8UL) <= M; i+=8UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//            xmm3 += A.load(i+2UL,j) * x1;
-//            xmm4 += A.load(i+3UL,j) * x1;
-//            xmm5 += A.load(i+4UL,j) * x1;
-//            xmm6 += A.load(i+5UL,j) * x1;
-//            xmm7 += A.load(i+6UL,j) * x1;
-//            xmm8 += A.load(i+7UL,j) * x1;
-//         }
-//
-//         y[i    ] = sum( xmm1 ) * scalar;
-//         y[i+1UL] = sum( xmm2 ) * scalar;
-//         y[i+2UL] = sum( xmm3 ) * scalar;
-//         y[i+3UL] = sum( xmm4 ) * scalar;
-//         y[i+4UL] = sum( xmm5 ) * scalar;
-//         y[i+5UL] = sum( xmm6 ) * scalar;
-//         y[i+6UL] = sum( xmm7 ) * scalar;
-//         y[i+7UL] = sum( xmm8 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
-//            y[i+4UL] += A(i+4UL,j) * x[j] * scalar;
-//            y[i+5UL] += A(i+5UL,j) * x[j] * scalar;
-//            y[i+6UL] += A(i+6UL,j) * x[j] * scalar;
-//            y[i+7UL] += A(i+7UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+4UL) <= M; i+=4UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2, xmm3, xmm4;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//            xmm3 += A.load(i+2UL,j) * x1;
-//            xmm4 += A.load(i+3UL,j) * x1;
-//         }
-//
-//         y[i    ] = sum( xmm1 ) * scalar;
-//         y[i+1UL] = sum( xmm2 ) * scalar;
-//         y[i+2UL] = sum( xmm3 ) * scalar;
-//         y[i+3UL] = sum( xmm4 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+3UL) <= M; i+=3UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2, xmm3;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//            xmm3 += A.load(i+2UL,j) * x1;
-//         }
-//
-//         y[i    ] = sum( xmm1 ) * scalar;
-//         y[i+1UL] = sum( xmm2 ) * scalar;
-//         y[i+2UL] = sum( xmm3 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+2UL) <= M; i+=2UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//         }
-//
-//         y[i    ] = sum( xmm1 ) * scalar;
-//         y[i+1UL] = sum( xmm2 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      if( i < M )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            xmm1 += A.load(i,j) * x.load(j);
-//         }
-//
-//         y[i] = sum( xmm1 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i] += A(i,j) * x[j] * scalar;
-//         }
-//      }
-//   }
+   //**********************************************************************************************
+
+   //**Vectorized default assignment to dense vectors (small tensors)*****************************
+   /*!\brief Vectorized default assignment of a small scaled dense tensor-dense vector
+   //        multiplication (\f$ \vec{y}=s*A*\vec{x} \f$).
+   // \ingroup dense_vector
+   //
+   // \param y The target left-hand side dense vector.
+   // \param A The left-hand side dense tensor operand.
+   // \param x The right-hand side dense vector operand.
+   // \param scalar The scaling factor.
+   // \return void
+   //
+   // This function implements the vectorized default assignment kernel for the scaled dense
+   // tensor-dense vector multiplication. This kernel is optimized for small tensors.
+   */
+   template< typename VT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT2    // Type of the right-hand side vector operand
+           , typename ST2 >  // Type of the scalar value
+   static inline auto selectSmallAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+   {
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
+
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
+
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
+
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+               xmm5 += A.load(p,i+4UL,j) * x1;
+               xmm6 += A.load(p,i+5UL,j) * x1;
+               xmm7 += A.load(p,i+6UL,j) * x1;
+               xmm8 += A.load(p,i+7UL,j) * x1;
+            }
+
+            y(p,i    ) = sum( xmm1 ) * scalar;
+            y(p,i+1UL) = sum( xmm2 ) * scalar;
+            y(p,i+2UL) = sum( xmm3 ) * scalar;
+            y(p,i+3UL) = sum( xmm4 ) * scalar;
+            y(p,i+4UL) = sum( xmm5 ) * scalar;
+            y(p,i+5UL) = sum( xmm6 ) * scalar;
+            y(p,i+6UL) = sum( xmm7 ) * scalar;
+            y(p,i+7UL) = sum( xmm8 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j] * scalar;
+               y(p,i+4UL) += A(p,i+4UL,j) * x[j] * scalar;
+               y(p,i+5UL) += A(p,i+5UL,j) * x[j] * scalar;
+               y(p,i+6UL) += A(p,i+6UL,j) * x[j] * scalar;
+               y(p,i+7UL) += A(p,i+7UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2, xmm3, xmm4;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+            }
+
+            y(p,i    ) = sum( xmm1 ) * scalar;
+            y(p,i+1UL) = sum( xmm2 ) * scalar;
+            y(p,i+2UL) = sum( xmm3 ) * scalar;
+            y(p,i+3UL) = sum( xmm4 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+3UL) <= M; i+=3UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2, xmm3;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+            }
+
+            y(p,i    ) = sum( xmm1 ) * scalar;
+            y(p,i+1UL) = sum( xmm2 ) * scalar;
+            y(p,i+2UL) = sum( xmm3 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+            }
+
+            y(p,i    ) = sum( xmm1 ) * scalar;
+            y(p,i+1UL) = sum( xmm2 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+            }
+         }
+
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               xmm1 += A.load(p,i,j) * x.load(j);
+            }
+
+            y(p,i) = sum( xmm1 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) += A(p,i,j) * x[j] * scalar;
+            }
+         }
+      }
+   }
    //**********************************************************************************************
 
    //**Default assignment to dense vectors (large tensors)****************************************
@@ -3264,331 +2985,259 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    }
    //**********************************************************************************************
 
-//   //**Vectorized default assignment to dense vectors (large tensors)*****************************
-//   /*!\brief Vectorized default assignment of a large scaled dense tensor-dense vector
-//   //        multiplication (\f$ \vec{y}=s*A*\vec{x} \f$).
-//   // \ingroup dense_vector
-//   //
-//   // \param y The target left-hand side dense vector.
-//   // \param A The left-hand side dense tensor operand.
-//   // \param x The right-hand side dense vector operand.
-//   // \param scalar The scaling factor.
-//   // \return void
-//   //
-//   // This function implements the vectorized default assignment kernel for the scaled dense
-//   // tensor-dense vector multiplication. This kernel is optimized for large tensors.
-//   */
-//   template< typename VT1    // Type of the left-hand side target vector
-//           , typename TT1    // Type of the left-hand side tensor operand
-//           , typename VT2    // Type of the right-hand side vector operand
-//           , typename ST2 >  // Type of the scalar value
-//   static inline auto selectLargeAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
-//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
-//   {
-//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
-//
-//      const size_t M( A.rows()    );
-//      const size_t N( A.columns() );
-//
-//      reset( y );
-//
-//      size_t i( 0UL );
-//
-//      for( ; (i+8UL) <= M; i+=8UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
-//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 );
-//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 );
-//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 );
-//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 );
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
-//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 );
-//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 );
-//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 );
-//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 );
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 );
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
-//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 );
-//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 );
-//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 );
-//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 );
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j];
-//            y[i+1UL] += A(i+1UL,j) * x[j];
-//            y[i+2UL] += A(i+2UL,j) * x[j];
-//            y[i+3UL] += A(i+3UL,j) * x[j];
-//            y[i+4UL] += A(i+4UL,j) * x[j];
-//            y[i+5UL] += A(i+5UL,j) * x[j];
-//            y[i+6UL] += A(i+6UL,j) * x[j];
-//            y[i+7UL] += A(i+7UL,j) * x[j];
-//         }
-//
-//         y[i    ] *= scalar;
-//         y[i+1UL] *= scalar;
-//         y[i+2UL] *= scalar;
-//         y[i+3UL] *= scalar;
-//         y[i+4UL] *= scalar;
-//         y[i+5UL] *= scalar;
-//         y[i+6UL] *= scalar;
-//         y[i+7UL] *= scalar;
-//      }
-//
-//      for( ; (i+4UL) <= M; i+=4UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 );
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 );
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 );
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 );
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 );
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 );
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 );
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j];
-//            y[i+1UL] += A(i+1UL,j) * x[j];
-//            y[i+2UL] += A(i+2UL,j) * x[j];
-//            y[i+3UL] += A(i+3UL,j) * x[j];
-//         }
-//
-//         y[i    ] *= scalar;
-//         y[i+1UL] *= scalar;
-//         y[i+2UL] *= scalar;
-//         y[i+3UL] *= scalar;
-//      }
-//
-//      for( ; (i+2UL) <= M; i+=2UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 );
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 );
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 );
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 );
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 );
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 );
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j];
-//            y[i+1UL] += A(i+1UL,j) * x[j];
-//         }
-//
-//         y[i    ] *= scalar;
-//         y[i+1UL] *= scalar;
-//      }
-//
-//      if( i < M )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 );
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 );
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i] += sum( A.load(i,j) * x1 );
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i] += A(i,j) * x[j];
-//         }
-//
-//         y[i] *= scalar;
-//      }
-//   }
-   //**********************************************************************************************
-
-   //**BLAS-based assignment to dense vectors (default)********************************************
-   /*!\brief Default assignment of a scaled dense tensor-dense vector multiplication
-   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
+   //**Vectorized default assignment to dense vectors (large tensors)*****************************
+   /*!\brief Vectorized default assignment of a large scaled dense tensor-dense vector
+   //        multiplication (\f$ \vec{y}=s*A*\vec{x} \f$).
    // \ingroup dense_vector
    //
-   // \param y The target left-hand side dense matrix.
+   // \param y The target left-hand side dense vector.
    // \param A The left-hand side dense tensor operand.
    // \param x The right-hand side dense vector operand.
    // \param scalar The scaling factor.
    // \return void
    //
-   // This function relays to the default implementation of the assignment of a large scaled
-   // dense tensor-dense vector multiplication expression to a dense vector.
+   // This function implements the vectorized default assignment kernel for the scaled dense
+   // tensor-dense vector multiplication. This kernel is optimized for large tensors.
    */
-   template< typename MT1    // Type of the left-hand side target matrix
+   template< typename VT1    // Type of the left-hand side target vector
            , typename TT1    // Type of the left-hand side tensor operand
-           , typename VT1    // Type of the right-hand side vector operand
+           , typename VT2    // Type of the right-hand side vector operand
            , typename ST2 >  // Type of the scalar value
-   static inline auto selectBlasAssignKernel( MT1& y, const TT1& A, const VT1& x, ST2 scalar )
-      -> EnableIf_t< !UseBlasKernel_v<MT1,TT1,VT1,ST2> >
+   static inline auto selectLargeAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
    {
-      selectLargeAssignKernel( y, A, x, scalar );
-   }
-   //**********************************************************************************************
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
 
-   //**BLAS-based assignment to dense vectors******************************************************
-#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION
-//   /*!\brief BLAS-based assignment of a scaled dense tensor-dense vector multiplication
-//   //        (\f$ \vec{y}=s*A*\vec{x} \f$).
-//   // \ingroup dense_vector
-//   //
-//   // \param y The target left-hand side dense vector.
-//   // \param A The left-hand side dense tensor operand.
-//   // \param x The right-hand side dense vector operand.
-//   // \param scalar The scaling factor.
-//   // \return void
-//   //
-//   // This function performs the scaled dense tensor-dense vector multiplication based on the
-//   // according BLAS functionality.
-//   */
-//   template< typename VT1    // Type of the left-hand side target vector
-//           , typename TT1    // Type of the left-hand side tensor operand
-//           , typename VT2    // Type of the right-hand side vector operand
-//           , typename ST2 >  // Type of the scalar value
-//   static inline auto selectBlasAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
-//      -> EnableIf_t< UseBlasKernel_v<VT1,TT1,VT2,ST2> >
-//   {
-//      using ET = ElementType_t<VT1>;
-//
-//      if( IsTriangular_v<TT1> ) {
-//         assign( y, scalar * x );
-//         trmv( y, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
-//      }
-//      else {
-//         gemv( y, A, x, ET(scalar), ET(0) );
-//      }
-//   }
-#endif
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
+
+      reset( y );
+
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
+
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 );
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 + A.load(p,i+4UL,j2) * x3 + A.load(p,i+4UL,j3) * x4 );
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 + A.load(p,i+5UL,j2) * x3 + A.load(p,i+5UL,j3) * x4 );
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 + A.load(p,i+6UL,j2) * x3 + A.load(p,i+6UL,j3) * x4 );
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 + A.load(p,i+7UL,j2) * x3 + A.load(p,i+7UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 );
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 );
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 );
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 );
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 );
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 );
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 );
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 );
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+               y(p,i+4UL) += A(p,i+4UL,j) * x[j];
+               y(p,i+5UL) += A(p,i+5UL,j) * x[j];
+               y(p,i+6UL) += A(p,i+6UL,j) * x[j];
+               y(p,i+7UL) += A(p,i+7UL,j) * x[j];
+            }
+
+            y(p,i    ) *= scalar;
+            y(p,i+1UL) *= scalar;
+            y(p,i+2UL) *= scalar;
+            y(p,i+3UL) *= scalar;
+            y(p,i+4UL) *= scalar;
+            y(p,i+5UL) *= scalar;
+            y(p,i+6UL) *= scalar;
+            y(p,i+7UL) *= scalar;
+         }
+
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 );
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 );
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j];
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j];
+            }
+
+            y(p,i    ) *= scalar;
+            y(p,i+1UL) *= scalar;
+            y(p,i+2UL) *= scalar;
+            y(p,i+3UL) *= scalar;
+         }
+
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 );
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j];
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j];
+            }
+
+            y(p,i    ) *= scalar;
+            y(p,i+1UL) *= scalar;
+         }
+
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i) += sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 + A.load(p,i,j2) * x3 + A.load(p,i,j3) * x4 );
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i) += sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 );
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i) += sum( A.load(p,i,j) * x1 );
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) += A(p,i,j) * x[j];
+            }
+
+            y(p,i) *= scalar;
+         }
+      }
+   }
    //**********************************************************************************************
 
    //**Assignment to sparse vectors****************************************************************
@@ -3679,7 +3328,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       if( A.pages() * A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD )
          selectSmallAddAssignKernel( y, A, x, scalar );
       else
-         selectBlasAddAssignKernel( y, A, x, scalar );
+         selectLargeAddAssignKernel( y, A, x, scalar );
    }
    //**********************************************************************************************
 
@@ -3745,199 +3394,183 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    //
    // This function implements the vectorized default addition assignment kernel for the scaled
    // dense tensor-dense vector multiplication. This kernel is optimized for small tensors.
-//   */
-//   template< typename VT1    // Type of the left-hand side target vector
-//           , typename TT1    // Type of the left-hand side tensor operand
-//           , typename VT2    // Type of the right-hand side vector operand
-//           , typename ST2 >  // Type of the scalar value
-//   static inline auto selectSmallAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
-//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
-//   {
-//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
-//
-//      const size_t M( A.rows()    );
-//      const size_t N( A.columns() );
-//
-//      size_t i( 0UL );
-//
-//      for( ; (i+8UL) <= M; i+=8UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//            xmm3 += A.load(i+2UL,j) * x1;
-//            xmm4 += A.load(i+3UL,j) * x1;
-//            xmm5 += A.load(i+4UL,j) * x1;
-//            xmm6 += A.load(i+5UL,j) * x1;
-//            xmm7 += A.load(i+6UL,j) * x1;
-//            xmm8 += A.load(i+7UL,j) * x1;
-//         }
-//
-//         y[i    ] += sum( xmm1 ) * scalar;
-//         y[i+1UL] += sum( xmm2 ) * scalar;
-//         y[i+2UL] += sum( xmm3 ) * scalar;
-//         y[i+3UL] += sum( xmm4 ) * scalar;
-//         y[i+4UL] += sum( xmm5 ) * scalar;
-//         y[i+5UL] += sum( xmm6 ) * scalar;
-//         y[i+6UL] += sum( xmm7 ) * scalar;
-//         y[i+7UL] += sum( xmm8 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
-//            y[i+4UL] += A(i+4UL,j) * x[j] * scalar;
-//            y[i+5UL] += A(i+5UL,j) * x[j] * scalar;
-//            y[i+6UL] += A(i+6UL,j) * x[j] * scalar;
-//            y[i+7UL] += A(i+7UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+4UL) <= M; i+=4UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2, xmm3, xmm4;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//            xmm3 += A.load(i+2UL,j) * x1;
-//            xmm4 += A.load(i+3UL,j) * x1;
-//         }
-//
-//         y[i    ] += sum( xmm1 ) * scalar;
-//         y[i+1UL] += sum( xmm2 ) * scalar;
-//         y[i+2UL] += sum( xmm3 ) * scalar;
-//         y[i+3UL] += sum( xmm4 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+3UL) <= M; i+=3UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2, xmm3;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//            xmm3 += A.load(i+2UL,j) * x1;
-//         }
-//
-//         y[i    ] += sum( xmm1 ) * scalar;
-//         y[i+1UL] += sum( xmm2 ) * scalar;
-//         y[i+2UL] += sum( xmm3 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+2UL) <= M; i+=2UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//         }
-//
-//         y[i    ] += sum( xmm1 ) * scalar;
-//         y[i+1UL] += sum( xmm2 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      if( i < M )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            xmm1 += A.load(i,j) * x.load(j);
-//         }
-//
-//         y[i] += sum( xmm1 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i] += A(i,j) * x[j] * scalar;
-//         }
-//      }
-//   }
+   */
+   template< typename VT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT2    // Type of the right-hand side vector operand
+           , typename ST2 >  // Type of the scalar value
+   static inline auto selectSmallAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+   {
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
+
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
+
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
+
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+               xmm5 += A.load(p,i+4UL,j) * x1;
+               xmm6 += A.load(p,i+5UL,j) * x1;
+               xmm7 += A.load(p,i+6UL,j) * x1;
+               xmm8 += A.load(p,i+7UL,j) * x1;
+            }
+
+            y(p,i    ) += sum( xmm1 ) * scalar;
+            y(p,i+1UL) += sum( xmm2 ) * scalar;
+            y(p,i+2UL) += sum( xmm3 ) * scalar;
+            y(p,i+3UL) += sum( xmm4 ) * scalar;
+            y(p,i+4UL) += sum( xmm5 ) * scalar;
+            y(p,i+5UL) += sum( xmm6 ) * scalar;
+            y(p,i+6UL) += sum( xmm7 ) * scalar;
+            y(p,i+7UL) += sum( xmm8 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j] * scalar;
+               y(p,i+4UL) += A(p,i+4UL,j) * x[j] * scalar;
+               y(p,i+5UL) += A(p,i+5UL,j) * x[j] * scalar;
+               y(p,i+6UL) += A(p,i+6UL,j) * x[j] * scalar;
+               y(p,i+7UL) += A(p,i+7UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2, xmm3, xmm4;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+            }
+
+            y(p,i    ) += sum( xmm1 ) * scalar;
+            y(p,i+1UL) += sum( xmm2 ) * scalar;
+            y(p,i+2UL) += sum( xmm3 ) * scalar;
+            y(p,i+3UL) += sum( xmm4 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+3UL) <= M; i+=3UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2, xmm3;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+            }
+
+            y(p,i    ) += sum( xmm1 ) * scalar;
+            y(p,i+1UL) += sum( xmm2 ) * scalar;
+            y(p,i+2UL) += sum( xmm3 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+            }
+
+            y(p,i    ) += sum( xmm1 ) * scalar;
+            y(p,i+1UL) += sum( xmm2 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+            }
+         }
+
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               xmm1 += A.load(p,i,j) * x.load(j);
+            }
+
+            y(p,i) += sum( xmm1 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) += A(p,i,j) * x[j] * scalar;
+            }
+         }
+      }
+   }
    //**********************************************************************************************
 
    //**Default addition assignment to dense vectors (large tensors)*******************************
@@ -3978,298 +3611,241 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    //
    // This function implements the vectorized default addition assignment kernel for the scaled
    // dense tensor-dense vector multiplication. This kernel is optimized for large tensors.
-//   */
-//   template< typename VT1    // Type of the left-hand side target vector
-//           , typename TT1    // Type of the left-hand side tensor operand
-//           , typename VT2    // Type of the right-hand side vector operand
-//           , typename ST2 >  // Type of the scalar value
-//   static inline auto selectLargeAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
-//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
-//   {
-//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
-//
-//      const size_t M( A.rows()    );
-//      const size_t N( A.columns() );
-//
-//      size_t i( 0UL );
-//
-//      for( ; (i+8UL) <= M; i+=8UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 ) * scalar;
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 ) * scalar;
-//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 ) * scalar;
-//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 ) * scalar;
-//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 ) * scalar;
-//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 ) * scalar;
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 ) * scalar;
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 ) * scalar;
-//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 ) * scalar;
-//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 ) * scalar;
-//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 ) * scalar;
-//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 ) * scalar;
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 ) * scalar;
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 ) * scalar;
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 ) * scalar;
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 ) * scalar;
-//            y[i+4UL] += sum( A.load(i+4UL,j) * x1 ) * scalar;
-//            y[i+5UL] += sum( A.load(i+5UL,j) * x1 ) * scalar;
-//            y[i+6UL] += sum( A.load(i+6UL,j) * x1 ) * scalar;
-//            y[i+7UL] += sum( A.load(i+7UL,j) * x1 ) * scalar;
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
-//            y[i+4UL] += A(i+4UL,j) * x[j] * scalar;
-//            y[i+5UL] += A(i+5UL,j) * x[j] * scalar;
-//            y[i+6UL] += A(i+6UL,j) * x[j] * scalar;
-//            y[i+7UL] += A(i+7UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+4UL) <= M; i+=4UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 ) * scalar;
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 ) * scalar;
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 ) * scalar;
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 ) * scalar;
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 ) * scalar;
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 ) * scalar;
-//            y[i+2UL] += sum( A.load(i+2UL,j) * x1 ) * scalar;
-//            y[i+3UL] += sum( A.load(i+3UL,j) * x1 ) * scalar;
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] += A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] += A(i+3UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+2UL) <= M; i+=2UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i    ] += sum( A.load(i    ,j) * x1 ) * scalar;
-//            y[i+1UL] += sum( A.load(i+1UL,j) * x1 ) * scalar;
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] += A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] += A(i+1UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      if( i < M )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 ) * scalar;
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i] += sum( A.load(i,j) * x1 + A.load(i,j1) * x2 ) * scalar;
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i] += sum( A.load(i,j) * x1 ) * scalar;
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i] += A(i,j) * x[j] * scalar;
-//         }
-//      }
-//   }
-   //**********************************************************************************************
-
-   //**BLAS-based addition assignment to dense vectors (default)***********************************
-   /*!\brief Default addition assignment of a scaled dense tensor-dense vector multiplication
-   //        (\f$ \vec{y}+=s*A*\vec{x} \f$).
-   // \ingroup dense_vector
-   //
-   // \param y The target left-hand side dense vector.
-   // \param A The left-hand side dense tensor operand.
-   // \param x The right-hand side dense vector operand.
-   // \param scalar The scaling factor.
-   // \return void
-   //
-   // This function relays to the default implementation of the addition assignment of a large
-   // scaled dense tensor-dense vector multiplication expression to a dense vector.
    */
-   template< typename MT1    // Type of the left-hand side target matrix
+   template< typename VT1    // Type of the left-hand side target vector
            , typename TT1    // Type of the left-hand side tensor operand
-           , typename VT1    // Type of the right-hand side vector operand
+           , typename VT2    // Type of the right-hand side vector operand
            , typename ST2 >  // Type of the scalar value
-   static inline auto selectBlasAddAssignKernel( MT1& y, const TT1& A, const VT1& x, ST2 scalar )
-      -> EnableIf_t< !UseBlasKernel_v<MT1,TT1,VT1,ST2> >
+   static inline auto selectLargeAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
    {
-      selectLargeAddAssignKernel( y, A, x, scalar );
-   }
-   //**********************************************************************************************
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
 
-   //**BLAS-based addition assignment to dense vectors*********************************************
-#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION
-//   /*!\brief BLAS-based addition assignment of a scaled dense tensor-dense vector multiplication
-//   //        (\f$ \vec{y}+=s*A*\vec{x} \f$).
-//   // \ingroup dense_vector
-//   //
-//   // \param y The target left-hand side dense vector.
-//   // \param A The left-hand side dense tensor operand.
-//   // \param x The right-hand side dense vector operand.
-//   // \param scalar The scaling factor.
-//   // \return void
-//   //
-//   // This function performs the scaled dense tensor-dense vector multiplication based on the
-//   // according BLAS functionality.
-//   */
-//   template< typename VT1    // Type of the left-hand side target vector
-//           , typename TT1    // Type of the left-hand side tensor operand
-//           , typename VT2    // Type of the right-hand side vector operand
-//           , typename ST2 >  // Type of the scalar value
-//   static inline auto selectBlasAddAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
-//      -> EnableIf_t< UseBlasKernel_v<VT1,TT1,VT2,ST2> >
-//   {
-//      using ET = ElementType_t<VT1>;
-//
-//      if( IsTriangular_v<TT1> ) {
-//         ResultType_t<VT1> tmp( serial( scalar * x ) );
-//         trmv( tmp, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
-//         addAssign( y, tmp );
-//      }
-//      else {
-//         gemv( y, A, x, ET(scalar), ET(1) );
-//      }
-//   }
-#endif
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
+
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
+
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( ( IsUpper_v<TT1> )
+                                 ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+                                 :( 0UL ) );
+            const size_t jend( ( IsLower_v<TT1> )
+                               ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
+                               :( N ) );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 ) * scalar;
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 ) * scalar;
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 ) * scalar;
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 ) * scalar;
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 + A.load(p,i+4UL,j2) * x3 + A.load(p,i+4UL,j3) * x4 ) * scalar;
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 + A.load(p,i+5UL,j2) * x3 + A.load(p,i+5UL,j3) * x4 ) * scalar;
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 + A.load(p,i+6UL,j2) * x3 + A.load(p,i+6UL,j3) * x4 ) * scalar;
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 + A.load(p,i+7UL,j2) * x3 + A.load(p,i+7UL,j3) * x4 ) * scalar;
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 ) * scalar;
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 ) * scalar;
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 ) * scalar;
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 ) * scalar;
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 ) * scalar;
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 ) * scalar;
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 ) * scalar;
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 ) * scalar;
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 ) * scalar;
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 ) * scalar;
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 ) * scalar;
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 ) * scalar;
+               y(p,i+4UL) += sum( A.load(p,i+4UL,j) * x1 ) * scalar;
+               y(p,i+5UL) += sum( A.load(p,i+5UL,j) * x1 ) * scalar;
+               y(p,i+6UL) += sum( A.load(p,i+6UL,j) * x1 ) * scalar;
+               y(p,i+7UL) += sum( A.load(p,i+7UL,j) * x1 ) * scalar;
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j] * scalar;
+               y(p,i+4UL) += A(p,i+4UL,j) * x[j] * scalar;
+               y(p,i+5UL) += A(p,i+5UL,j) * x[j] * scalar;
+               y(p,i+6UL) += A(p,i+6UL,j) * x[j] * scalar;
+               y(p,i+7UL) += A(p,i+7UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( ( IsUpper_v<TT1> )
+                                 ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+                                 :( 0UL ) );
+            const size_t jend( ( IsLower_v<TT1> )
+                               ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
+                               :( N ) );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 ) * scalar;
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 ) * scalar;
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 ) * scalar;
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 ) * scalar;
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 ) * scalar;
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 ) * scalar;
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 ) * scalar;
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 ) * scalar;
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 ) * scalar;
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 ) * scalar;
+               y(p,i+2UL) += sum( A.load(p,i+2UL,j) * x1 ) * scalar;
+               y(p,i+3UL) += sum( A.load(p,i+3UL,j) * x1 ) * scalar;
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) += A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) += A(p,i+3UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( ( IsUpper_v<TT1> )
+                                 ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+                                 :( 0UL ) );
+            const size_t jend( ( IsLower_v<TT1> )
+                               ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
+                               :( N ) );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 ) * scalar;
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 ) * scalar;
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 ) * scalar;
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 ) * scalar;
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) += sum( A.load(p,i    ,j) * x1 ) * scalar;
+               y(p,i+1UL) += sum( A.load(p,i+1UL,j) * x1 ) * scalar;
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) += A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) += A(p,i+1UL,j) * x[j] * scalar;
+            }
+         }
+
+         if( i < M )
+         {
+            const size_t jbegin( ( IsUpper_v<TT1> )
+                                 ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
+                                 :( 0UL ) );
+            const size_t jend( ( IsLower_v<TT1> )
+                               ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
+                               :( N ) );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i) += sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 + A.load(p,i,j2) * x3 + A.load(p,i,j3) * x4 ) * scalar;
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i) += sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 ) * scalar;
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i) += sum( A.load(p,i,j) * x1 ) * scalar;
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) += A(p,i,j) * x[j] * scalar;
+            }
+         }
+      }
+   }
    //**********************************************************************************************
 
    //**Addition assignment to sparse vectors*******************************************************
@@ -4336,7 +3912,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       if( A.pages() * A.rows() * A.columns() < DTENSDVECMULT_THRESHOLD )
          selectSmallSubAssignKernel( y, A, x, scalar );
       else
-         selectBlasSubAssignKernel( y, A, x, scalar );
+         selectLargeSubAssignKernel( y, A, x, scalar );
    }
    //**********************************************************************************************
 
@@ -4403,198 +3979,182 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    // This function implements the vectorized default subtraction assignment kernel for the scaled
    // dense tensor-dense vector multiplication. This kernel is optimized for small tensors.
    */
-//   template< typename VT1    // Type of the left-hand side target vector
-//           , typename TT1    // Type of the left-hand side tensor operand
-//           , typename VT2    // Type of the right-hand side vector operand
-//           , typename ST2 >  // Type of the scalar value
-//   static inline auto selectSmallSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
-//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
-//   {
-//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
-//
-//      const size_t M( A.rows()    );
-//      const size_t N( A.columns() );
-//
-//      size_t i( 0UL );
-//
-//      for( ; (i+8UL) <= M; i+=8UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//            xmm3 += A.load(i+2UL,j) * x1;
-//            xmm4 += A.load(i+3UL,j) * x1;
-//            xmm5 += A.load(i+4UL,j) * x1;
-//            xmm6 += A.load(i+5UL,j) * x1;
-//            xmm7 += A.load(i+6UL,j) * x1;
-//            xmm8 += A.load(i+7UL,j) * x1;
-//         }
-//
-//         y[i    ] -= sum( xmm1 ) * scalar;
-//         y[i+1UL] -= sum( xmm2 ) * scalar;
-//         y[i+2UL] -= sum( xmm3 ) * scalar;
-//         y[i+3UL] -= sum( xmm4 ) * scalar;
-//         y[i+4UL] -= sum( xmm5 ) * scalar;
-//         y[i+5UL] -= sum( xmm6 ) * scalar;
-//         y[i+6UL] -= sum( xmm7 ) * scalar;
-//         y[i+7UL] -= sum( xmm8 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] -= A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] -= A(i+3UL,j) * x[j] * scalar;
-//            y[i+4UL] -= A(i+4UL,j) * x[j] * scalar;
-//            y[i+5UL] -= A(i+5UL,j) * x[j] * scalar;
-//            y[i+6UL] -= A(i+6UL,j) * x[j] * scalar;
-//            y[i+7UL] -= A(i+7UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+4UL) <= M; i+=4UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2, xmm3, xmm4;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//            xmm3 += A.load(i+2UL,j) * x1;
-//            xmm4 += A.load(i+3UL,j) * x1;
-//         }
-//
-//         y[i    ] -= sum( xmm1 ) * scalar;
-//         y[i+1UL] -= sum( xmm2 ) * scalar;
-//         y[i+2UL] -= sum( xmm3 ) * scalar;
-//         y[i+3UL] -= sum( xmm4 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] -= A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] -= A(i+3UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+3UL) <= M; i+=3UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+2UL : i+3UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2, xmm3;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//            xmm3 += A.load(i+2UL,j) * x1;
-//         }
-//
-//         y[i    ] -= sum( xmm1 ) * scalar;
-//         y[i+1UL] -= sum( xmm2 ) * scalar;
-//         y[i+2UL] -= sum( xmm3 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] -= A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+2UL) <= M; i+=2UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1, xmm2;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            xmm1 += A.load(i    ,j) * x1;
-//            xmm2 += A.load(i+1UL,j) * x1;
-//         }
-//
-//         y[i    ] -= sum( xmm1 ) * scalar;
-//         y[i+1UL] -= sum( xmm2 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] -= A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      if( i < M )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         SIMDType xmm1;
-//         size_t j( jbegin );
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            xmm1 += A.load(i,j) * x.load(j);
-//         }
-//
-//         y[i] -= sum( xmm1 ) * scalar;
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i] -= A(i,j) * x[j] * scalar;
-//         }
-//      }
-//   }
+   template< typename VT1    // Type of the left-hand side target vector
+           , typename TT1    // Type of the left-hand side tensor operand
+           , typename VT2    // Type of the right-hand side vector operand
+           , typename ST2 >  // Type of the scalar value
+   static inline auto selectSmallSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
+   {
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
+
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
+
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
+
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+               xmm5 += A.load(p,i+4UL,j) * x1;
+               xmm6 += A.load(p,i+5UL,j) * x1;
+               xmm7 += A.load(p,i+6UL,j) * x1;
+               xmm8 += A.load(p,i+7UL,j) * x1;
+            }
+
+            y(p,i    ) -= sum( xmm1 ) * scalar;
+            y(p,i+1UL) -= sum( xmm2 ) * scalar;
+            y(p,i+2UL) -= sum( xmm3 ) * scalar;
+            y(p,i+3UL) -= sum( xmm4 ) * scalar;
+            y(p,i+4UL) -= sum( xmm5 ) * scalar;
+            y(p,i+5UL) -= sum( xmm6 ) * scalar;
+            y(p,i+6UL) -= sum( xmm7 ) * scalar;
+            y(p,i+7UL) -= sum( xmm8 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) -= A(p,i+3UL,j) * x[j] * scalar;
+               y(p,i+4UL) -= A(p,i+4UL,j) * x[j] * scalar;
+               y(p,i+5UL) -= A(p,i+5UL,j) * x[j] * scalar;
+               y(p,i+6UL) -= A(p,i+6UL,j) * x[j] * scalar;
+               y(p,i+7UL) -= A(p,i+7UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2, xmm3, xmm4;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+               xmm4 += A.load(p,i+3UL,j) * x1;
+            }
+
+            y(p,i    ) -= sum( xmm1 ) * scalar;
+            y(p,i+1UL) -= sum( xmm2 ) * scalar;
+            y(p,i+2UL) -= sum( xmm3 ) * scalar;
+            y(p,i+3UL) -= sum( xmm4 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) -= A(p,i+3UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+3UL) <= M; i+=3UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2, xmm3;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+               xmm3 += A.load(p,i+2UL,j) * x1;
+            }
+
+            y(p,i    ) -= sum( xmm1 ) * scalar;
+            y(p,i+1UL) -= sum( xmm2 ) * scalar;
+            y(p,i+2UL) -= sum( xmm3 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1, xmm2;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               xmm1 += A.load(p,i    ,j) * x1;
+               xmm2 += A.load(p,i+1UL,j) * x1;
+            }
+
+            y(p,i    ) -= sum( xmm1 ) * scalar;
+            y(p,i+1UL) -= sum( xmm2 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j] * scalar;
+            }
+         }
+
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            SIMDType xmm1;
+            size_t j( jbegin );
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               xmm1 += A.load(p,i,j) * x.load(j);
+            }
+
+            y(p,i) -= sum( xmm1 ) * scalar;
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) -= A(p,i,j) * x[j] * scalar;
+            }
+         }
+      }
+   }
    //**********************************************************************************************
 
    //**Default subtraction assignment to dense vectors (large tensors)****************************
@@ -4620,257 +4180,11 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    {
       selectDefaultSubAssignKernel( y, A, x, scalar );
    }
-//   //**********************************************************************************************
-//
-//   //**Vectorized default subtraction assignment to dense vectors (large tensors)*****************
-//   /*!\brief Vectorized default subtraction assignment of a large scaled dense tensor-dense vector
-//   //        multiplication (\f$ \vec{y}-=s*A*\vec{x} \f$).
-//   // \ingroup dense_vector
-//   //
-//   // \param y The target left-hand side dense vector.
-//   // \param A The left-hand side dense tensor operand.
-//   // \param x The right-hand side dense vector operand.
-//   // \param scalar The scaling factor.
-//   // \return void
-//   //
-//   // This function implements the vectorized default subtraction assignment kernel for the scaled
-//   // dense tensor-dense vector multiplication. This kernel is optimized for large tensors.
-//   */
-//   template< typename VT1    // Type of the left-hand side target vector
-//           , typename TT1    // Type of the left-hand side tensor operand
-//           , typename VT2    // Type of the right-hand side vector operand
-//           , typename ST2 >  // Type of the scalar value
-//   static inline auto selectLargeSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
-//      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
-//   {
-//      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
-//
-//      const size_t M( A.rows()    );
-//      const size_t N( A.columns() );
-//
-//      size_t i( 0UL );
-//
-//      for( ; (i+8UL) <= M; i+=8UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+7UL : i+8UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
-//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
-//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 ) * scalar;
-//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 ) * scalar;
-//            y[i+4UL] -= sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 + A.load(i+4UL,j2) * x3 + A.load(i+4UL,j3) * x4 ) * scalar;
-//            y[i+5UL] -= sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 + A.load(i+5UL,j2) * x3 + A.load(i+5UL,j3) * x4 ) * scalar;
-//            y[i+6UL] -= sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 + A.load(i+6UL,j2) * x3 + A.load(i+6UL,j3) * x4 ) * scalar;
-//            y[i+7UL] -= sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 + A.load(i+7UL,j2) * x3 + A.load(i+7UL,j3) * x4 ) * scalar;
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
-//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
-//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 ) * scalar;
-//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 ) * scalar;
-//            y[i+4UL] -= sum( A.load(i+4UL,j) * x1 + A.load(i+4UL,j1) * x2 ) * scalar;
-//            y[i+5UL] -= sum( A.load(i+5UL,j) * x1 + A.load(i+5UL,j1) * x2 ) * scalar;
-//            y[i+6UL] -= sum( A.load(i+6UL,j) * x1 + A.load(i+6UL,j1) * x2 ) * scalar;
-//            y[i+7UL] -= sum( A.load(i+7UL,j) * x1 + A.load(i+7UL,j1) * x2 ) * scalar;
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i    ] -= sum( A.load(i    ,j) * x1 ) * scalar;
-//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 ) * scalar;
-//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 ) * scalar;
-//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 ) * scalar;
-//            y[i+4UL] -= sum( A.load(i+4UL,j) * x1 ) * scalar;
-//            y[i+5UL] -= sum( A.load(i+5UL,j) * x1 ) * scalar;
-//            y[i+6UL] -= sum( A.load(i+6UL,j) * x1 ) * scalar;
-//            y[i+7UL] -= sum( A.load(i+7UL,j) * x1 ) * scalar;
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] -= A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] -= A(i+3UL,j) * x[j] * scalar;
-//            y[i+4UL] -= A(i+4UL,j) * x[j] * scalar;
-//            y[i+5UL] -= A(i+5UL,j) * x[j] * scalar;
-//            y[i+6UL] -= A(i+6UL,j) * x[j] * scalar;
-//            y[i+7UL] -= A(i+7UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+4UL) <= M; i+=4UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+3UL : i+4UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
-//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
-//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 + A.load(i+2UL,j2) * x3 + A.load(i+2UL,j3) * x4 ) * scalar;
-//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 + A.load(i+3UL,j2) * x3 + A.load(i+3UL,j3) * x4 ) * scalar;
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
-//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
-//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 + A.load(i+2UL,j1) * x2 ) * scalar;
-//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 + A.load(i+3UL,j1) * x2 ) * scalar;
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i    ] -= sum( A.load(i    ,j) * x1 ) * scalar;
-//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 ) * scalar;
-//            y[i+2UL] -= sum( A.load(i+2UL,j) * x1 ) * scalar;
-//            y[i+3UL] -= sum( A.load(i+3UL,j) * x1 ) * scalar;
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] -= A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
-//            y[i+2UL] -= A(i+2UL,j) * x[j] * scalar;
-//            y[i+3UL] -= A(i+3UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      for( ; (i+2UL) <= M; i+=2UL )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i+1UL : i+2UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 + A.load(i    ,j2) * x3 + A.load(i    ,j3) * x4 ) * scalar;
-//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 + A.load(i+1UL,j2) * x3 + A.load(i+1UL,j3) * x4 ) * scalar;
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i    ] -= sum( A.load(i    ,j) * x1 + A.load(i    ,j1) * x2 ) * scalar;
-//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 + A.load(i+1UL,j1) * x2 ) * scalar;
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i    ] -= sum( A.load(i    ,j) * x1 ) * scalar;
-//            y[i+1UL] -= sum( A.load(i+1UL,j) * x1 ) * scalar;
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i    ] -= A(i    ,j) * x[j] * scalar;
-//            y[i+1UL] -= A(i+1UL,j) * x[j] * scalar;
-//         }
-//      }
-//
-//      if( i < M )
-//      {
-//         const size_t jbegin( ( IsUpper_v<TT1> )
-//                              ?( ( IsStrictlyUpper_v<TT1> ? i+1UL : i ) & size_t(-SIMDSIZE) )
-//                              :( 0UL ) );
-//         const size_t jend( ( IsLower_v<TT1> )
-//                            ?( IsStrictlyLower_v<TT1> ? i : i+1UL )
-//                            :( N ) );
-//         BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
-//
-//         const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
-//         BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
-//
-//         size_t j( jbegin );
-//
-//         for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
-//            const size_t j1( j+SIMDSIZE     );
-//            const size_t j2( j+SIMDSIZE*2UL );
-//            const size_t j3( j+SIMDSIZE*3UL );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            const SIMDType x3( x.load(j2) );
-//            const SIMDType x4( x.load(j3) );
-//            y[i] -= sum( A.load(i,j) * x1 + A.load(i,j1) * x2 + A.load(i,j2) * x3 + A.load(i,j3) * x4 ) * scalar;
-//         }
-//
-//         for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
-//            const size_t j1( j+SIMDSIZE );
-//            const SIMDType x1( x.load(j ) );
-//            const SIMDType x2( x.load(j1) );
-//            y[i] -= sum( A.load(i,j) * x1 + A.load(i,j1) * x2 ) * scalar;
-//         }
-//
-//         for( ; j<jpos; j+=SIMDSIZE ) {
-//            const SIMDType x1( x.load(j) );
-//            y[i] -= sum( A.load(i,j) * x1 ) * scalar;
-//         }
-//
-//         for( ; remainder && j<jend; ++j ) {
-//            y[i] -= A(i,j) * x[j] * scalar;
-//         }
-//      }
-//   }
    //**********************************************************************************************
 
-   //**BLAS-based subtraction assignment to dense vectors (default)********************************
-   /*!\brief Default subtraction assignment of a scaled dense tensor-dense vector multiplication
-   //        (\f$ \vec{y}-=s*A*\vec{x} \f$).
+   //**Vectorized default subtraction assignment to dense vectors (large tensors)*****************
+   /*!\brief Vectorized default subtraction assignment of a large scaled dense tensor-dense vector
+   //        multiplication (\f$ \vec{y}-=s*A*\vec{x} \f$).
    // \ingroup dense_vector
    //
    // \param y The target left-hand side dense vector.
@@ -4879,54 +4193,227 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    // \param scalar The scaling factor.
    // \return void
    //
-   // This function relays to the default implementation of the subtraction assignment of a large
-   // scaled dense tensor-dense vector multiplication expression to a dense vector.
+   // This function implements the vectorized default subtraction assignment kernel for the scaled
+   // dense tensor-dense vector multiplication. This kernel is optimized for large tensors.
    */
-   template< typename MT1    // Type of the left-hand side target vector
+   template< typename VT1    // Type of the left-hand side target vector
            , typename TT1    // Type of the left-hand side tensor operand
-           , typename VT1    // Type of the right-hand side vector operand
+           , typename VT2    // Type of the right-hand side vector operand
            , typename ST2 >  // Type of the scalar value
-   static inline auto selectBlasSubAssignKernel( MT1& y, const TT1& A, const VT1& x, ST2 scalar )
-      -> EnableIf_t< !UseBlasKernel_v<MT1,TT1,VT1,ST2> >
+   static inline auto selectLargeSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
+      -> EnableIf_t< UseVectorizedDefaultKernel_v<VT1,TT1,VT2,ST2> >
    {
-      selectLargeSubAssignKernel( y, A, x, scalar );
-   }
-   //**********************************************************************************************
+      constexpr bool remainder( !IsPadded_v<TT1> || !IsPadded_v<VT2> );
 
-   //**BLAS-based subtraction assignment to dense vectors******************************************
-#if BLAZE_BLAS_MODE && BLAZE_USE_BLAS_TENSOR_VECTOR_MULTIPLICATION
-//   /*!\brief BLAS-based subtraction assignment of a scaled dense tensor-dense vector multiplication
-//   //        (\f$ \vec{y}-=s*A*\vec{x} \f$).
-//   // \ingroup dense_vector
-//   //
-//   // \param y The target left-hand side dense vector.
-//   // \param A The left-hand side dense tensor operand.
-//   // \param x The right-hand side dense vector operand.
-//   // \param scalar The scaling factor.
-//   // \return void
-//   //
-//   // This function performs the scaled dense tensor-dense vector multiplication based on the
-//   // according BLAS functionality.
-//   */
-//   template< typename VT1    // Type of the left-hand side target vector
-//           , typename TT1    // Type of the left-hand side tensor operand
-//           , typename VT2    // Type of the right-hand side vector operand
-//           , typename ST2 >  // Type of the scalar value
-//   static inline auto selectBlasSubAssignKernel( VT1& y, const TT1& A, const VT2& x, ST2 scalar )
-//      -> EnableIf_t< UseBlasKernel_v<VT1,TT1,VT2,ST2> >
-//   {
-//      using ET = ElementType_t<VT1>;
-//
-//      if( IsTriangular_v<TT1> ) {
-//         ResultType_t<VT1> tmp( serial( scalar * x ) );
-//         trmv( tmp, A, ( IsLower_v<TT1> )?( CblasLower ):( CblasUpper ) );
-//         subAssign( y, tmp );
-//      }
-//      else {
-//         gemv( y, A, x, ET(-scalar), ET(1) );
-//      }
-//   }
-#endif
+      const size_t M( A.rows()    );
+      const size_t N( A.columns() );
+      const size_t P( A.pages()   );
+
+      for( size_t p=0UL; p<P; ++p )
+      {
+         size_t i( 0UL );
+
+         for( ; (i+8UL) <= M; i+=8UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 ) * scalar;
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 ) * scalar;
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 ) * scalar;
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 ) * scalar;
+               y(p,i+4UL) -= sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 + A.load(p,i+4UL,j2) * x3 + A.load(p,i+4UL,j3) * x4 ) * scalar;
+               y(p,i+5UL) -= sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 + A.load(p,i+5UL,j2) * x3 + A.load(p,i+5UL,j3) * x4 ) * scalar;
+               y(p,i+6UL) -= sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 + A.load(p,i+6UL,j2) * x3 + A.load(p,i+6UL,j3) * x4 ) * scalar;
+               y(p,i+7UL) -= sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 + A.load(p,i+7UL,j2) * x3 + A.load(p,i+7UL,j3) * x4 ) * scalar;
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 ) * scalar;
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 ) * scalar;
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 ) * scalar;
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 ) * scalar;
+               y(p,i+4UL) -= sum( A.load(p,i+4UL,j) * x1 + A.load(p,i+4UL,j1) * x2 ) * scalar;
+               y(p,i+5UL) -= sum( A.load(p,i+5UL,j) * x1 + A.load(p,i+5UL,j1) * x2 ) * scalar;
+               y(p,i+6UL) -= sum( A.load(p,i+6UL,j) * x1 + A.load(p,i+6UL,j1) * x2 ) * scalar;
+               y(p,i+7UL) -= sum( A.load(p,i+7UL,j) * x1 + A.load(p,i+7UL,j1) * x2 ) * scalar;
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 ) * scalar;
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 ) * scalar;
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 ) * scalar;
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 ) * scalar;
+               y(p,i+4UL) -= sum( A.load(p,i+4UL,j) * x1 ) * scalar;
+               y(p,i+5UL) -= sum( A.load(p,i+5UL,j) * x1 ) * scalar;
+               y(p,i+6UL) -= sum( A.load(p,i+6UL,j) * x1 ) * scalar;
+               y(p,i+7UL) -= sum( A.load(p,i+7UL,j) * x1 ) * scalar;
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) -= A(p,i+3UL,j) * x[j] * scalar;
+               y(p,i+4UL) -= A(p,i+4UL,j) * x[j] * scalar;
+               y(p,i+5UL) -= A(p,i+5UL,j) * x[j] * scalar;
+               y(p,i+6UL) -= A(p,i+6UL,j) * x[j] * scalar;
+               y(p,i+7UL) -= A(p,i+7UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+4UL) <= M; i+=4UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 ) * scalar;
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 ) * scalar;
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 + A.load(p,i+2UL,j2) * x3 + A.load(p,i+2UL,j3) * x4 ) * scalar;
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 + A.load(p,i+3UL,j2) * x3 + A.load(p,i+3UL,j3) * x4 ) * scalar;
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 ) * scalar;
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 ) * scalar;
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 + A.load(p,i+2UL,j1) * x2 ) * scalar;
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 + A.load(p,i+3UL,j1) * x2 ) * scalar;
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 ) * scalar;
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 ) * scalar;
+               y(p,i+2UL) -= sum( A.load(p,i+2UL,j) * x1 ) * scalar;
+               y(p,i+3UL) -= sum( A.load(p,i+3UL,j) * x1 ) * scalar;
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j] * scalar;
+               y(p,i+2UL) -= A(p,i+2UL,j) * x[j] * scalar;
+               y(p,i+3UL) -= A(p,i+3UL,j) * x[j] * scalar;
+            }
+         }
+
+         for( ; (i+2UL) <= M; i+=2UL )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 + A.load(p,i    ,j2) * x3 + A.load(p,i    ,j3) * x4 ) * scalar;
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 + A.load(p,i+1UL,j2) * x3 + A.load(p,i+1UL,j3) * x4 ) * scalar;
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 + A.load(p,i    ,j1) * x2 ) * scalar;
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 + A.load(p,i+1UL,j1) * x2 ) * scalar;
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i    ) -= sum( A.load(p,i    ,j) * x1 ) * scalar;
+               y(p,i+1UL) -= sum( A.load(p,i+1UL,j) * x1 ) * scalar;
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i    ) -= A(p,i    ,j) * x[j] * scalar;
+               y(p,i+1UL) -= A(p,i+1UL,j) * x[j] * scalar;
+            }
+         }
+
+         if( i < M )
+         {
+            const size_t jbegin( 0UL );
+            const size_t jend( N );
+            BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
+
+            const size_t jpos( remainder ? ( jend & size_t(-SIMDSIZE) ) : jend );
+            BLAZE_INTERNAL_ASSERT( !remainder || ( jend - ( jend % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
+
+            size_t j( jbegin );
+
+            for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
+               const size_t j1( j+SIMDSIZE     );
+               const size_t j2( j+SIMDSIZE*2UL );
+               const size_t j3( j+SIMDSIZE*3UL );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               const SIMDType x3( x.load(j2) );
+               const SIMDType x4( x.load(j3) );
+               y(p,i) -= sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 + A.load(p,i,j2) * x3 + A.load(p,i,j3) * x4 ) * scalar;
+            }
+
+            for( ; (j+SIMDSIZE) < jpos; j+=SIMDSIZE*2UL ) {
+               const size_t j1( j+SIMDSIZE );
+               const SIMDType x1( x.load(j ) );
+               const SIMDType x2( x.load(j1) );
+               y(p,i) -= sum( A.load(p,i,j) * x1 + A.load(p,i,j1) * x2 ) * scalar;
+            }
+
+            for( ; j<jpos; j+=SIMDSIZE ) {
+               const SIMDType x1( x.load(j) );
+               y(p,i) -= sum( A.load(p,i,j) * x1 ) * scalar;
+            }
+
+            for( ; remainder && j<jend; ++j ) {
+               y(p,i) -= A(p,i,j) * x[j] * scalar;
+            }
+         }
+      }
+   }
    //**********************************************************************************************
 
    //**Subtraction assignment to sparse vectors****************************************************
@@ -4945,14 +4432,13 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    // This function implements the performance optimized multiplication assignment of a scaled
    // dense tensor-dense vector multiplication expression to a dense vector.
    */
-   template< typename MT1   // Type of the target dense matrix
-              , bool SO >   // Storage order of the target dense matrix
+   template< typename MT1 >  // Type of the target dense matrix
    friend inline void schurAssign( DenseMatrix<MT1,false>& lhs, const DMatScalarMultExpr& rhs )
    {
       BLAZE_FUNCTION_TRACE;
 
       BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE( ResultType );
-      BLAZE_CONSTRAINT_MUST_BE_COLUMN_MAJOR_MATRIX_TYPE( ResultType );
+      BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
       BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
@@ -5154,7 +4640,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    // case the expression specific parallel evaluation strategy is selected.
    */
    template< typename MT1 >  // Type of the target dense vector
-   friend inline auto smpMultAssign( DenseMatrix<MT1,false>& lhs, const DMatScalarMultExpr& rhs )
+   friend inline auto smpSchurAssign( DenseMatrix<MT1,false>& lhs, const DMatScalarMultExpr& rhs )
       -> EnableIf_t< UseSMPAssign_v<MT1> >
    {
       BLAZE_FUNCTION_TRACE;
@@ -5167,10 +4653,9 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       const ResultType tmp( rhs );
-      smpMultAssign( ~lhs, tmp );
+      smpSchurAssign( ~lhs, tmp );
    }
    //**********************************************************************************************
-
 
    //**Compile time checks*************************************************************************
    BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE    ( MVM );

--- a/blaze_tensor/math/expressions/DTensMapExpr.h
+++ b/blaze_tensor/math/expressions/DTensMapExpr.h
@@ -47,6 +47,7 @@
 #include <blaze/math/expressions/Forward.h>
 #include <blaze/math/expressions/DMatMapExpr.h>
 #include <blaze/math/typetraits/IsSIMDEnabled.h>
+#include <blaze/math/typetraits/UnderlyingNumeric.h>
 
 #include <blaze_tensor/math/constraints/DenseTensor.h>
 #include <blaze_tensor/math/expressions/DenseTensor.h>
@@ -454,7 +455,7 @@ class DTensMapExpr
    // \param j Access index for the column. The index has to be in the range \f$[0..N-1]\f$.
    // \return Reference to the accessed values.
    */
-   BLAZE_ALWAYS_INLINE auto load( size_t i, size_t j ) const noexcept {
+   BLAZE_ALWAYS_INLINE auto load( size_t k, size_t i, size_t j ) const noexcept {
       BLAZE_INTERNAL_ASSERT( i < dm_.rows()   , "Invalid row access index"    );
       BLAZE_INTERNAL_ASSERT( j < dm_.columns(), "Invalid column access index" );
       BLAZE_INTERNAL_ASSERT( k < dm_.pages()  , "Invalid page access index" );

--- a/blaze_tensor/math/expressions/DTensScalarDivExpr.h
+++ b/blaze_tensor/math/expressions/DTensScalarDivExpr.h
@@ -42,6 +42,7 @@
 //*************************************************************************************************
 
 #include <blaze/math/expressions/DMatScalarDivExpr.h>
+#include <blaze/math/typetraits/IsMultExpr.h>
 
 #include <blaze_tensor/math/constraints/DenseTensor.h>
 #include <blaze_tensor/math/expressions/Forward.h>

--- a/blaze_tensor/math/expressions/DTensTransExprData.h
+++ b/blaze_tensor/math/expressions/DTensTransExprData.h
@@ -130,6 +130,7 @@ struct DTensTransExprData<0UL, 1UL, 2UL>
    */
    static inline constexpr size_t page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
 
@@ -143,6 +144,7 @@ struct DTensTransExprData<0UL, 1UL, 2UL>
    */
    static inline constexpr size_t row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
 
@@ -156,6 +158,7 @@ struct DTensTransExprData<0UL, 1UL, 2UL>
    */
    static inline constexpr size_t column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
    //@}
@@ -171,6 +174,7 @@ struct DTensTransExprData<0UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
 
@@ -184,6 +188,7 @@ struct DTensTransExprData<0UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
 
@@ -197,6 +202,7 @@ struct DTensTransExprData<0UL, 1UL, 2UL>
    */
    static inline constexpr size_t reverse_column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
    //@}
@@ -266,6 +272,7 @@ struct DTensTransExprData<0UL, 2UL, 1UL>
    */
    static inline constexpr size_t page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
 
@@ -279,6 +286,7 @@ struct DTensTransExprData<0UL, 2UL, 1UL>
    */
    static inline constexpr size_t row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
 
@@ -292,6 +300,7 @@ struct DTensTransExprData<0UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
    //@}
@@ -307,6 +316,7 @@ struct DTensTransExprData<0UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
 
@@ -320,6 +330,7 @@ struct DTensTransExprData<0UL, 2UL, 1UL>
    */
    static inline constexpr size_t reverse_row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
 
@@ -333,6 +344,7 @@ struct DTensTransExprData<0UL, 2UL, 1UL>
    */
    static inline constexpr size_t column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
    //@}
@@ -402,6 +414,7 @@ struct DTensTransExprData<1UL, 0UL, 2UL>
    */
    static inline constexpr size_t page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
 
@@ -415,6 +428,7 @@ struct DTensTransExprData<1UL, 0UL, 2UL>
    */
    static inline constexpr size_t row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
 
@@ -428,6 +442,7 @@ struct DTensTransExprData<1UL, 0UL, 2UL>
    */
    static inline constexpr size_t column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
    //@}
@@ -443,6 +458,7 @@ struct DTensTransExprData<1UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
 
@@ -456,6 +472,7 @@ struct DTensTransExprData<1UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
 
@@ -469,6 +486,7 @@ struct DTensTransExprData<1UL, 0UL, 2UL>
    */
    static inline constexpr size_t reverse_column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
    //@}
@@ -538,6 +556,7 @@ struct DTensTransExprData<1UL, 2UL, 0UL>
    */
    static inline constexpr size_t page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
 
@@ -551,6 +570,7 @@ struct DTensTransExprData<1UL, 2UL, 0UL>
    */
    static inline constexpr size_t row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
 
@@ -564,6 +584,7 @@ struct DTensTransExprData<1UL, 2UL, 0UL>
    */
    static inline constexpr size_t column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
    //@}
@@ -579,6 +600,7 @@ struct DTensTransExprData<1UL, 2UL, 0UL>
    */
    static inline constexpr size_t reverse_page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
 
@@ -592,6 +614,7 @@ struct DTensTransExprData<1UL, 2UL, 0UL>
    */
    static inline constexpr size_t reverse_row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
 
@@ -605,6 +628,7 @@ struct DTensTransExprData<1UL, 2UL, 0UL>
    */
    static inline constexpr size_t reverse_column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
    //@}
@@ -674,6 +698,7 @@ struct DTensTransExprData<2UL, 0UL, 1UL>
    */
    static inline constexpr size_t page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
 
@@ -687,6 +712,7 @@ struct DTensTransExprData<2UL, 0UL, 1UL>
    */
    static inline constexpr size_t row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
 
@@ -700,6 +726,7 @@ struct DTensTransExprData<2UL, 0UL, 1UL>
    */
    static inline constexpr size_t column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
    //@}
@@ -715,6 +742,7 @@ struct DTensTransExprData<2UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
 
@@ -728,6 +756,7 @@ struct DTensTransExprData<2UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
 
@@ -741,6 +770,7 @@ struct DTensTransExprData<2UL, 0UL, 1UL>
    */
    static inline constexpr size_t reverse_column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
    //@}
@@ -810,6 +840,7 @@ struct DTensTransExprData<2UL, 1UL, 0UL>
    */
    static inline constexpr size_t page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
 
@@ -823,6 +854,7 @@ struct DTensTransExprData<2UL, 1UL, 0UL>
    */
    static inline constexpr size_t row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
 
@@ -836,6 +868,7 @@ struct DTensTransExprData<2UL, 1UL, 0UL>
    */
    static inline constexpr size_t column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
    //@}
@@ -851,6 +884,7 @@ struct DTensTransExprData<2UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_page  ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, i );
       return j;
    }
 
@@ -864,6 +898,7 @@ struct DTensTransExprData<2UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_row   ( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( k, j );
       return i;
    }
 
@@ -877,6 +912,7 @@ struct DTensTransExprData<2UL, 1UL, 0UL>
    */
    static inline constexpr size_t reverse_column( size_t k, size_t i, size_t j ) noexcept
    {
+      MAYBE_UNUSED( i, j );
       return k;
    }
    //@}

--- a/blaze_tensor/math/expressions/Tensor.h
+++ b/blaze_tensor/math/expressions/Tensor.h
@@ -330,7 +330,7 @@ BLAZE_ALWAYS_INLINE bool
 /*!\brief Predict invariant violations by scaling a single element of a tensor.
 // \ingroup tensor
 //
-// \param mat The target tensor.
+// \param tens The target tensor.
 // \param i The row index of the element to be modified.
 // \param j The column index of the element to be modified.
 // \param k The page index of the element to be modified.
@@ -344,13 +344,13 @@ BLAZE_ALWAYS_INLINE bool
 */
 template< typename MT    // Type of the tensor
         , typename ET >  // Type of the element
-BLAZE_ALWAYS_INLINE bool tryDiv( const Tensor<MT>& mat, size_t k, size_t i, size_t j, const ET& value )
+BLAZE_ALWAYS_INLINE bool tryDiv( const Tensor<MT>& tens, size_t k, size_t i, size_t j, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( i < (~mat).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < (~mat).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( i < (~tens).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( j < (~tens).columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( k < (~tens).pages(), "Invalid page access index" );
 
-   MAYBE_UNUSED( mat, k, i, j, value );
+   MAYBE_UNUSED( tens, k, i, j, value );
 
    return true;
 }

--- a/blaze_tensor/math/views/ColumnSlice.h
+++ b/blaze_tensor/math/views/ColumnSlice.h
@@ -931,7 +931,7 @@ template< typename MT     // Type of the tensor
 inline bool trySet( const ColumnSlice<MT,CRAs...>& columnslice, size_t i, size_t k, const ET& value )
 {
    BLAZE_INTERNAL_ASSERT( i < columnslice.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
 
    return trySet( columnslice.operand(), i, columnslice.column(), k, value );
 }
@@ -961,7 +961,7 @@ template< typename MT     // Type of the tensor
 inline bool tryAdd( const ColumnSlice<MT,CRAs...>& columnslice, size_t i, size_t k, const ET& value )
 {
    BLAZE_INTERNAL_ASSERT( i < columnslice.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
 
    return tryAdd( columnslice.operand(), i, columnslice.column(), k, value );
 }
@@ -991,7 +991,7 @@ template< typename MT     // Type of the tensor
 inline bool trySub( const ColumnSlice<MT,CRAs...>& columnslice, size_t i, size_t k, const ET& value )
 {
    BLAZE_INTERNAL_ASSERT( i < columnslice.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
 
    return trySub( columnslice.operand(), i, columnslice.column(), k, value );
 }
@@ -1021,7 +1021,7 @@ template< typename MT     // Type of the tensor
 inline bool tryMult( const ColumnSlice<MT,CRAs...>& columnslice, size_t i, size_t k, const ET& value )
 {
    BLAZE_INTERNAL_ASSERT( i < columnslice.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
 
    return tryMult( columnslice.operand(), i, columnslice.column(), k, value );
 }
@@ -1083,7 +1083,7 @@ template< typename MT     // Type of the tensor
 inline bool tryDiv( const ColumnSlice<MT,CRAs...>& columnslice, size_t i, size_t k, const ET& value )
 {
    BLAZE_INTERNAL_ASSERT( i < columnslice.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
+   //BLAZE_INTERNAL_ASSERT( j < columnslice.columns(), "Invalid column access index" );
 
    return tryDiv( columnslice.operand(), i, columnslice.column(), k, value );
 }

--- a/blaze_tensor/math/views/Subtensor.h
+++ b/blaze_tensor/math/views/Subtensor.h
@@ -66,6 +66,7 @@
 #include <blaze/math/typetraits/IsUpper.h>
 #include <blaze/math/typetraits/Size.h>
 #include <blaze/math/views/Check.h>
+#include <blaze/math/views/submatrix/SubmatrixData.h>
 #include <blaze/util/algorithms/Max.h>
 #include <blaze/util/algorithms/Min.h>
 #include <blaze/util/Assert.h>

--- a/blaze_tensor/math/views/columnslice/Dense.h
+++ b/blaze_tensor/math/views/columnslice/Dense.h
@@ -42,6 +42,7 @@
 //*************************************************************************************************
 
 #include <blaze/math/views/row/Dense.h>
+#include <blaze/math/traits/SchurTrait.h>
 
 #include <blaze_tensor/math/InitializerList.h>
 #include <blaze_tensor/math/constraints/DenseTensor.h>

--- a/blaze_tensor/math/views/dilatedsubmatrix/Dense.h
+++ b/blaze_tensor/math/views/dilatedsubmatrix/Dense.h
@@ -52,6 +52,7 @@
 #include <blaze/math/constraints/RequiresEvaluation.h>
 #include <blaze/math/constraints/RowMajorMatrix.h>
 #include <blaze/math/constraints/Symmetric.h>
+#include <blaze/math/constraints/Submatrix.h>
 #include <blaze/math/constraints/TransExpr.h>
 #include <blaze/math/constraints/UniTriangular.h>
 #include <blaze/math/dense/InitializerMatrix.h>

--- a/blaze_tensor/math/views/rowslice/Dense.h
+++ b/blaze_tensor/math/views/rowslice/Dense.h
@@ -55,6 +55,7 @@
 #include <blaze/math/shims/Clear.h>
 #include <blaze/math/shims/IsDefault.h>
 #include <blaze/math/shims/Reset.h>
+#include <blaze/math/traits/SchurTrait.h>
 #include <blaze/math/typetraits/HasMutableDataAccess.h>
 #include <blaze/math/typetraits/HasSIMDAdd.h>
 #include <blaze/math/typetraits/HasSIMDDiv.h>

--- a/blaze_tensor/math/views/subtensor/DenseAligned.h
+++ b/blaze_tensor/math/views/subtensor/DenseAligned.h
@@ -63,6 +63,9 @@
 #include <blaze/math/typetraits/HasSIMDAdd.h>
 #include <blaze/math/typetraits/HasSIMDMult.h>
 #include <blaze/math/typetraits/HasSIMDSub.h>
+#include <blaze/math/typetraits/IsDiagonal.h>
+#include <blaze/math/typetraits/IsSIMDCombinable.h>
+#include <blaze/math/typetraits/IsTriangular.h>
 #include <blaze/math/typetraits/RequiresEvaluation.h>
 #include <blaze/math/views/Check.h>
 #include <blaze/system/Blocking.h>

--- a/blazetest/src/mathtest/uniformtensor/ClassTest2.cpp
+++ b/blazetest/src/mathtest/uniformtensor/ClassTest2.cpp
@@ -3566,7 +3566,7 @@ void ClassTest::testTranspose()
                 << "   Result:\n" << mat << "\n"
                 << "   Expected result:\n"
                         "(( 2 2 2 2 2 )\n( 2 2 2 2 2 )\n"
-                        " ( 2 2 2 2 2 )\n( 2 2 2 2 2 )\n";
+                        " ( 2 2 2 2 2 )\n( 2 2 2 2 2 )\n"
                         " ( 2 2 2 2 2 )\n( 2 2 2 2 2 ))\n";
             throw std::runtime_error( oss.str() );
          }
@@ -3651,9 +3651,9 @@ void ClassTest::testTranspose()
                 << "   Result:\n" << mat << "\n"
                 << "   Expected result:\n"
                         "(( 2 2 2 )\n( 2 2 2 )\n"
-                        " ( 2 2 2 )\n( 2 2 2 )\n";
-                        " ( 2 2 2 )\n( 2 2 2 )\n";
-                        " ( 2 2 2 )\n( 2 2 2 )\n";
+                        " ( 2 2 2 )\n( 2 2 2 )\n"
+                        " ( 2 2 2 )\n( 2 2 2 )\n"
+                        " ( 2 2 2 )\n( 2 2 2 )\n"
                         " ( 2 2 2 )\n( 2 2 2 ))\n";
             throw std::runtime_error( oss.str() );
          }
@@ -3698,9 +3698,9 @@ void ClassTest::testTranspose()
                 << "   Result:\n" << mat << "\n"
                 << "   Expected result:\n"
                         "(( 2 2 )\n( 2 2 )\n( 2 2 )\n"
-                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n";
-                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n";
-                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n";
+                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n"
+                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n"
+                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n"
                         " ( 2 2 )\n( 2 2 )\n( 2 2 ))\n";
             throw std::runtime_error( oss.str() );
          }
@@ -3815,7 +3815,7 @@ void ClassTest::testTranspose()
                 << "   Result:\n" << mat << "\n"
                 << "   Expected result:\n"
                         "(( 2 2 2 2 2 )\n( 2 2 2 2 2 )\n"
-                        " ( 2 2 2 2 2 )\n( 2 2 2 2 2 )\n";
+                        " ( 2 2 2 2 2 )\n( 2 2 2 2 2 )\n"
                         " ( 2 2 2 2 2 )\n( 2 2 2 2 2 ))\n";
             throw std::runtime_error( oss.str() );
          }
@@ -3900,9 +3900,9 @@ void ClassTest::testTranspose()
                 << "   Result:\n" << mat << "\n"
                 << "   Expected result:\n"
                         "(( 2 2 2 )\n( 2 2 2 )\n"
-                        " ( 2 2 2 )\n( 2 2 2 )\n";
-                        " ( 2 2 2 )\n( 2 2 2 )\n";
-                        " ( 2 2 2 )\n( 2 2 2 )\n";
+                        " ( 2 2 2 )\n( 2 2 2 )\n"
+                        " ( 2 2 2 )\n( 2 2 2 )\n"
+                        " ( 2 2 2 )\n( 2 2 2 )\n"
                         " ( 2 2 2 )\n( 2 2 2 ))\n";
             throw std::runtime_error( oss.str() );
          }
@@ -3947,9 +3947,9 @@ void ClassTest::testTranspose()
                 << "   Result:\n" << mat << "\n"
                 << "   Expected result:\n"
                         "(( 2 2 )\n( 2 2 )\n( 2 2 )\n"
-                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n";
-                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n";
-                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n";
+                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n"
+                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n"
+                        " ( 2 2 )\n( 2 2 )\n( 2 2 )\n"
                         " ( 2 2 )\n( 2 2 )\n( 2 2 ))\n";
             throw std::runtime_error( oss.str() );
          }


### PR DESCRIPTION
This pull request primarily fixes the vectorized compute kernels of the 'DTensDVecMultExpr' class template. Additionally, it adds several missing include directives and deals with "Unused parameter" warnings.