### PR TITLE
Replace all CRTP-based downcasts via 'operator~()' by 'operator*()'

### DIFF
--- a/blaze_tensor/math/Array.h
+++ b/blaze_tensor/math/Array.h
@@ -105,7 +105,7 @@ bool isUniform( const Array<MT>& m );
 template< typename MT > // Type of the tensor
 inline bool isUniform( const Array<MT>& t )
 {
-   return isUniform<relaxed>( ~t );
+   return isUniform<relaxed>( *t );
 }
 //*************************************************************************************************
 
@@ -136,7 +136,7 @@ inline std::ostream& operator<<( std::ostream& os, const Array<MT>& m );
 template< typename MT >
 inline std::ostream& operator<<( std::ostream& os, const Array<MT>& m )
 {
-   CompositeType_t<MT> tmp( ~m );
+   CompositeType_t<MT> tmp( *m );
 
    ArrayForEachGrouped(
       tmp.dimensions(),

--- a/blaze_tensor/math/InitializerList.h
+++ b/blaze_tensor/math/InitializerList.h
@@ -318,8 +318,8 @@ struct nested_initializer_list< 1, Type > : initializer_list< Type >
    void transfer_data( C& rhs )
    {
       std::fill(
-         std::copy( this->type::begin(), this->type::end(), ( ~rhs ).begin() ),
-         ( ~rhs ).end(),
+         std::copy( this->type::begin(), this->type::end(), ( *rhs ).begin() ),
+         ( *rhs ).end(),
          Type() );
    }
 };
@@ -348,8 +348,8 @@ struct nested_initializer_list< 2, Type >
       size_t i( 0UL );
       for( const auto& rowList : *this ) {
          std::fill(
-            std::copy( rowList.begin(), rowList.end(), ( ~rhs ).begin( i ) ),
-            ( ~rhs ).end( i ),
+            std::copy( rowList.begin(), rowList.end(), ( *rhs ).begin( i ) ),
+            ( *rhs ).end( i ),
             Type() );
          ++i;
       }
@@ -384,8 +384,8 @@ struct nested_initializer_list< 3, Type >
          for (const auto& rowList : page) {
             std::fill(
                std::copy(
-                  rowList.begin(), rowList.end(), ( ~rhs ).begin( i, k ) ),
-               ( ~rhs ).end( i, k ),
+                  rowList.begin(), rowList.end(), ( *rhs ).begin( i, k ) ),
+               ( *rhs ).end( i, k ),
                Type() );
             ++i;
          }
@@ -426,8 +426,8 @@ struct nested_initializer_list< 4, Type >
             for( const auto& row_list : page_list ) {
                std::fill( std::copy( row_list.begin(),
                              row_list.end(),
-                             ( ~rhs ).begin( i, l, k ) ),
-                  ( ~rhs ).end( i, l, k ),
+                             ( *rhs ).begin( i, l, k ) ),
+                  ( *rhs ).end( i, l, k ),
                   Type() );
                ++i;
             }

--- a/blaze_tensor/math/Tensor.h
+++ b/blaze_tensor/math/Tensor.h
@@ -103,7 +103,7 @@ bool isUniform( const Tensor<MT>& m );
 template< typename MT > // Type of the tensor
 inline bool isUniform( const Tensor<MT>& t )
 {
-   return isUniform<relaxed>( ~t );
+   return isUniform<relaxed>( *t );
 }
 //*************************************************************************************************
 
@@ -134,7 +134,7 @@ inline std::ostream& operator<<( std::ostream& os, const Tensor<MT>& m );
 template< typename MT >
 inline std::ostream& operator<<( std::ostream& os, const Tensor<MT>& m )
 {
-   CompositeType_t<MT> tmp( ~m );
+   CompositeType_t<MT> tmp( *m );
 
    for (size_t k = 0UL; k < tmp.pages(); ++k) {
       os << "(";

--- a/blaze_tensor/math/dense/CustomArray.h
+++ b/blaze_tensor/math/dense/CustomArray.h
@@ -2035,7 +2035,7 @@ inline CustomArray<N,Type,AF,PF,RT>&
       BLAZE_THROW_INVALID_ARGUMENT( "Array sizes do not match" );
    }
 
-   smpAssign( *this, ~rhs );
+   smpAssign( *this, *rhs );
 
    return *this;
 }
@@ -2090,16 +2090,16 @@ template< typename MT >  // Type of the right-hand side array
 inline CustomArray<N,Type,AF,PF,RT>&
    CustomArray<N,Type,AF,PF,RT>::operator=( const Array<MT>& rhs )
 {
-   if( dims_ != (~rhs).dimensions() ) {
+   if( dims_ != (*rhs).dimensions() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Array sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAssign( *this, tmp );
    }
    else {
-      smpAssign( *this, ~rhs );
+      smpAssign( *this, *rhs );
    }
 
    return *this;
@@ -2126,16 +2126,16 @@ template< typename MT >  // Type of the right-hand side array
 inline CustomArray<N,Type,AF,PF,RT>&
    CustomArray<N,Type,AF,PF,RT>::operator+=( const Array<MT>& rhs )
 {
-   if( dims_ != (~rhs).dimensions() ) {
+   if( dims_ != (*rhs).dimensions() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Array sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAddAssign( *this, tmp );
    }
    else {
-      smpAddAssign( *this, ~rhs );
+      smpAddAssign( *this, *rhs );
    }
 
    return *this;
@@ -2162,16 +2162,16 @@ template< typename MT >  // Type of the right-hand side array
 inline CustomArray<N,Type,AF,PF,RT>&
    CustomArray<N,Type,AF,PF,RT>::operator-=( const Array<MT>& rhs )
 {
-   if( dims_ != (~rhs).dimensions() ) {
+   if( dims_ != (*rhs).dimensions() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Array sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSubAssign( *this, tmp );
    }
    else {
-      smpSubAssign( *this, ~rhs );
+      smpSubAssign( *this, *rhs );
    }
 
    return *this;
@@ -2198,16 +2198,16 @@ template< typename MT >  // Type of the right-hand side array
 inline CustomArray<N,Type,AF,PF,RT>&
    CustomArray<N,Type,AF,PF,RT>::operator%=( const Array<MT>& rhs )
 {
-   if( dims_ != (~rhs).dimensions() ) {
+   if( dims_ != (*rhs).dimensions() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Array sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSchurAssign( *this, tmp );
    }
    else {
-      smpSchurAssign( *this, ~rhs );
+      smpSchurAssign( *this, *rhs );
    }
 
    return *this;
@@ -3102,14 +3102,14 @@ template< typename MT >  // Type of the right-hand side dense array
 inline auto CustomArray<N,Type,AF,PF,RT>::assign( const DenseArray<MT>& rhs )
    /*-> EnableIf_t< !VectorizedAssign_v<MT> >*/
 {
-   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
    const size_t jpos( dims_[0] & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( dims_[0] - ( dims_[0] % 2UL ) ) == jpos, "Invalid end calculation" );
 
    ArrayForEachGrouped(
       dims_, nn_, [&]( size_t i, std::array< size_t, N > const& dims ) {
-         v_[i] = ( ~rhs )( dims );
+         v_[i] = ( *rhs )( dims );
       } );
 }
 //*************************************************************************************************
@@ -3137,7 +3137,7 @@ inline auto CustomArray<N,Type,AF,PF,RT>::assign( const DenseArray<MT>& rhs )
 //{
 //   BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //
-//   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+//   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 //
 //    constexpr bool remainder( !PF || !IsPadded_v<MT> );
 //
@@ -3145,13 +3145,13 @@ inline auto CustomArray<N,Type,AF,PF,RT>::assign( const DenseArray<MT>& rhs )
 //    BLAZE_INTERNAL_ASSERT( !remainder || ( n_ - ( n_ % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 //
 //    if( AF && PF && useStreaming &&
-//        ( m_*n_*o_ > ( cacheSize / ( sizeof(Type) * 3UL ) ) ) && !(~rhs).isAliased( this ) )
+//        ( m_*n_*o_ > ( cacheSize / ( sizeof(Type) * 3UL ) ) ) && !(*rhs).isAliased( this ) )
 //    {
 //       for (size_t k=0UL; k<o_; ++k) {
 //          for (size_t i=0UL; i<m_; ++i) {
 //             size_t j(0UL);
 //             Iterator left(begin(i, k));
-//             ConstIterator_t<MT> right((~rhs).begin(i, k));
+//             ConstIterator_t<MT> right((*rhs).begin(i, k));
 //
 //             for (; j<jpos; j+=SIMDSIZE, left+=SIMDSIZE, right+=SIMDSIZE) {
 //                left.stream(right.load());
@@ -3169,7 +3169,7 @@ inline auto CustomArray<N,Type,AF,PF,RT>::assign( const DenseArray<MT>& rhs )
 //          {
 //             size_t j(0UL);
 //             Iterator left(begin(i, k));
-//             ConstIterator_t<MT> right((~rhs).begin(i, k));
+//             ConstIterator_t<MT> right((*rhs).begin(i, k));
 //
 //             for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
 //                left.store(right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -3210,14 +3210,14 @@ template< typename MT >  // Type of the right-hand side dense array
 inline auto CustomArray<N,Type,AF,PF,RT>::addAssign( const DenseArray<MT>& rhs )
    //-> EnableIf_t< !VectorizedAddAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
    const size_t jpos( dims_[0] & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( dims_[0] - ( dims_[0] % 2UL ) ) == jpos, "Invalid end calculation" );
 
    ArrayForEachGrouped(
       dims_, nn_, [&]( size_t i, std::array< size_t, N > const& dims ) {
-         v_[i] += ( ~rhs )( dims );
+         v_[i] += ( *rhs )( dims );
       } );
 }
 //*************************************************************************************************
@@ -3245,7 +3245,7 @@ inline auto CustomArray<N,Type,AF,PF,RT>::addAssign( const DenseArray<MT>& rhs )
 //{
 //   BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //
-//   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+//   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 //
 //    constexpr bool remainder( !PF || !IsPadded_v<MT> );
 //
@@ -3261,7 +3261,7 @@ inline auto CustomArray<N,Type,AF,PF,RT>::addAssign( const DenseArray<MT>& rhs )
 //
 //          size_t j(jbegin);
 //          Iterator left(begin(i, k) + jbegin);
-//          ConstIterator_t<MT> right((~rhs).begin(i, k) + jbegin);
+//          ConstIterator_t<MT> right((*rhs).begin(i, k) + jbegin);
 //
 //          for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
 //             left.store(left.load() + right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -3301,14 +3301,14 @@ template< typename MT >  // Type of the right-hand side dense array
 inline auto CustomArray<N,Type,AF,PF,RT>::subAssign( const DenseArray<MT>& rhs )
    //-> EnableIf_t< !VectorizedSubAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
    const size_t jpos( dims_[0] & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( dims_[0] - ( dims_[0] % 2UL ) ) == jpos, "Invalid end calculation" );
 
    ArrayForEachGrouped(
       dims_, nn_, [&]( size_t i, std::array< size_t, N > const& dims ) {
-         v_[i] -= ( ~rhs )( dims );
+         v_[i] -= ( *rhs )( dims );
       } );
 }
 //*************************************************************************************************
@@ -3336,7 +3336,7 @@ inline auto CustomArray<N,Type,AF,PF,RT>::subAssign( const DenseArray<MT>& rhs )
 //{
 //   BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //
-//   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+//   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
 //    constexpr bool remainder( !PF || !IsPadded_v<MT> );
 //
@@ -3352,7 +3352,7 @@ inline auto CustomArray<N,Type,AF,PF,RT>::subAssign( const DenseArray<MT>& rhs )
 //
 //          size_t j(jbegin);
 //          Iterator left(begin(i, k) + jbegin);
-//          ConstIterator_t<MT> right((~rhs).begin(i, k) + jbegin);
+//          ConstIterator_t<MT> right((*rhs).begin(i, k) + jbegin);
 //
 //          for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
 //             left.store(left.load() - right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -3392,14 +3392,14 @@ template< typename MT >  // Type of the right-hand side dense array
 inline auto CustomArray<N,Type,AF,PF,RT>::schurAssign( const DenseArray<MT>& rhs )
    //-> EnableIf_t< !VectorizedSchurAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
    const size_t jpos( dims_[0] & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( dims_[0] - ( dims_[0] % 2UL ) ) == jpos, "Invalid end calculation" );
 
    ArrayForEachGrouped(
       dims_, nn_, [&]( size_t i, std::array< size_t, N > const& dims ) {
-         v_[i] *= ( ~rhs )( dims );
+         v_[i] *= ( *rhs )( dims );
       } );
 }
 //*************************************************************************************************
@@ -3427,7 +3427,7 @@ inline auto CustomArray<N,Type,AF,PF,RT>::schurAssign( const DenseArray<MT>& rhs
 //{
 //   BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //
-//   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+//   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
 //    constexpr bool remainder( !PF || !IsPadded_v<MT> );
 //
@@ -3439,7 +3439,7 @@ inline auto CustomArray<N,Type,AF,PF,RT>::schurAssign( const DenseArray<MT>& rhs
 //
 //          size_t j(0UL);
 //          Iterator left(begin(i, k));
-//          ConstIterator_t<MT> right((~rhs).begin(i, k));
+//          ConstIterator_t<MT> right((*rhs).begin(i, k));
 //
 //          for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
 //             left.store(left.load() * right.load()); left += SIMDSIZE; right += SIMDSIZE;

--- a/blaze_tensor/math/dense/CustomTensor.h
+++ b/blaze_tensor/math/dense/CustomTensor.h
@@ -1354,7 +1354,7 @@ inline CustomTensor<Type,AF,PF,RT>&
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   smpAssign( *this, ~rhs );
+   smpAssign( *this, *rhs );
 
    return *this;
 }
@@ -1411,12 +1411,12 @@ template< typename MT >  // Type of the right-hand side tensor
 inline CustomTensor<Type,AF,PF,RT>&
    CustomTensor<Type,AF,PF,RT>::operator=( const Tensor<MT>& rhs )
 {
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAssign( *this, tmp );
    }
    else {
-      smpAssign( *this, ~rhs );
+      smpAssign( *this, *rhs );
    }
 
    return *this;
@@ -1442,16 +1442,16 @@ template< typename MT >  // Type of the right-hand side tensor
 inline CustomTensor<Type,AF,PF,RT>&
    CustomTensor<Type,AF,PF,RT>::operator+=( const Tensor<MT>& rhs )
 {
-   if( (~rhs).rows() != m_ || (~rhs).columns() != n_ || (~rhs).pages() != o_ ) {
+   if( (*rhs).rows() != m_ || (*rhs).columns() != n_ || (*rhs).pages() != o_ ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAddAssign( *this, tmp );
    }
    else {
-      smpAddAssign( *this, ~rhs );
+      smpAddAssign( *this, *rhs );
    }
 
    return *this;
@@ -1477,16 +1477,16 @@ template< typename MT >  // Type of the right-hand side tensor
 inline CustomTensor<Type,AF,PF,RT>&
    CustomTensor<Type,AF,PF,RT>::operator-=( const Tensor<MT>& rhs )
 {
-   if( (~rhs).rows() != m_ || (~rhs).columns() != n_ || (~rhs).pages() != o_ ) {
+   if( (*rhs).rows() != m_ || (*rhs).columns() != n_ || (*rhs).pages() != o_ ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSubAssign( *this, tmp );
    }
    else {
-      smpSubAssign( *this, ~rhs );
+      smpSubAssign( *this, *rhs );
    }
 
    return *this;
@@ -1512,16 +1512,16 @@ template< typename MT >  // Type of the right-hand side tensor
 inline CustomTensor<Type,AF,PF,RT>&
    CustomTensor<Type,AF,PF,RT>::operator%=( const Tensor<MT>& rhs )
 {
-   if( (~rhs).rows() != m_ || (~rhs).columns() != n_ || (~rhs).pages() != o_ ) {
+   if( (*rhs).rows() != m_ || (*rhs).columns() != n_ || (*rhs).pages() != o_ ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSchurAssign( *this, tmp );
    }
    else {
-      smpSchurAssign( *this, ~rhs );
+      smpSchurAssign( *this, *rhs );
    }
 
    return *this;
@@ -2418,9 +2418,9 @@ template< typename MT >  // Type of the right-hand side dense tensor
 inline auto CustomTensor<Type,AF,PF,RT>::assign( const DenseTensor<MT>& rhs )
    -> EnableIf_t< !VectorizedAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( m_ == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( n_ == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( o_ == (~rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( m_ == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( n_ == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( o_ == (*rhs).pages(),   "Invalid number of pages" );
 
    const size_t jpos( n_ & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( n_ - ( n_ % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2429,11 +2429,11 @@ inline auto CustomTensor<Type,AF,PF,RT>::assign( const DenseTensor<MT>& rhs )
       for (size_t i=0UL; i<m_; ++i) {
          size_t row_elements = (k*m_+i)*nn_;
          for (size_t j=0UL; j<jpos; j+=2UL) {
-            v_[row_elements+j] = (~rhs)(k, i, j);
-            v_[row_elements+j+1UL] = (~rhs)(k, i, j+1UL);
+            v_[row_elements+j] = (*rhs)(k, i, j);
+            v_[row_elements+j+1UL] = (*rhs)(k, i, j+1UL);
          }
          if (jpos < n_) {
-            v_[row_elements+jpos] = (~rhs)(k, i, jpos);
+            v_[row_elements+jpos] = (*rhs)(k, i, jpos);
          }
       }
    }
@@ -2462,9 +2462,9 @@ inline auto CustomTensor<Type,AF,PF,RT>::assign( const DenseTensor<MT>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 
-   BLAZE_INTERNAL_ASSERT( m_ == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( n_ == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( o_ == (~rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( m_ == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( n_ == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( o_ == (*rhs).pages(),   "Invalid number of pages" );
 
    constexpr bool remainder( !PF || !IsPadded_v<MT> );
 
@@ -2472,13 +2472,13 @@ inline auto CustomTensor<Type,AF,PF,RT>::assign( const DenseTensor<MT>& rhs )
    BLAZE_INTERNAL_ASSERT( !remainder || ( n_ - ( n_ % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
    if( AF && PF && useStreaming &&
-       ( m_*n_*o_ > ( cacheSize / ( sizeof(Type) * 3UL ) ) ) && !(~rhs).isAliased( this ) )
+       ( m_*n_*o_ > ( cacheSize / ( sizeof(Type) * 3UL ) ) ) && !(*rhs).isAliased( this ) )
    {
       for (size_t k=0UL; k<o_; ++k) {
          for (size_t i=0UL; i<m_; ++i) {
             size_t j(0UL);
             Iterator left(begin(i, k));
-            ConstIterator_t<MT> right((~rhs).begin(i, k));
+            ConstIterator_t<MT> right((*rhs).begin(i, k));
 
             for (; j<jpos; j+=SIMDSIZE, left+=SIMDSIZE, right+=SIMDSIZE) {
                left.stream(right.load());
@@ -2496,7 +2496,7 @@ inline auto CustomTensor<Type,AF,PF,RT>::assign( const DenseTensor<MT>& rhs )
          {
             size_t j(0UL);
             Iterator left(begin(i, k));
-            ConstIterator_t<MT> right((~rhs).begin(i, k));
+            ConstIterator_t<MT> right((*rhs).begin(i, k));
 
             for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
                left.store(right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -2536,9 +2536,9 @@ template< typename MT >  // Type of the right-hand side dense tensor
 inline auto CustomTensor<Type,AF,PF,RT>::addAssign( const DenseTensor<MT>& rhs )
    -> EnableIf_t< !VectorizedAddAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( m_ == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( n_ == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( o_ == (~rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( m_ == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( n_ == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( o_ == (*rhs).pages(),   "Invalid number of pages" );
 
    for (size_t k=0UL; k<o_; ++k) {
       for (size_t i=0UL; i<m_; ++i) {
@@ -2550,11 +2550,11 @@ inline auto CustomTensor<Type,AF,PF,RT>::addAssign( const DenseTensor<MT>& rhs )
          size_t j(jbegin);
 
          for (; (j+2UL) <= jend; j+=2UL) {
-            v_[row_elements+j] += (~rhs)(k, i, j);
-            v_[row_elements+j+1UL] += (~rhs)(k, i, j+1UL);
+            v_[row_elements+j] += (*rhs)(k, i, j);
+            v_[row_elements+j+1UL] += (*rhs)(k, i, j+1UL);
          }
          if (j < jend) {
-            v_[row_elements+j] += (~rhs)(k, i, j);
+            v_[row_elements+j] += (*rhs)(k, i, j);
          }
       }
    }
@@ -2583,9 +2583,9 @@ inline auto CustomTensor<Type,AF,PF,RT>::addAssign( const DenseTensor<MT>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 
-   BLAZE_INTERNAL_ASSERT( m_ == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( n_ == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( o_ == (~rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( m_ == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( n_ == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( o_ == (*rhs).pages(),   "Invalid number of pages" );
 
    constexpr bool remainder( !PF || !IsPadded_v<MT> );
 
@@ -2601,7 +2601,7 @@ inline auto CustomTensor<Type,AF,PF,RT>::addAssign( const DenseTensor<MT>& rhs )
 
          size_t j(jbegin);
          Iterator left(begin(i, k) + jbegin);
-         ConstIterator_t<MT> right((~rhs).begin(i, k) + jbegin);
+         ConstIterator_t<MT> right((*rhs).begin(i, k) + jbegin);
 
          for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
             left.store(left.load() + right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -2640,9 +2640,9 @@ template< typename MT >  // Type of the right-hand side dense tensor
 inline auto CustomTensor<Type,AF,PF,RT>::subAssign( const DenseTensor<MT>& rhs )
    -> EnableIf_t< !VectorizedSubAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( m_ == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( n_ == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( o_ == (~rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( m_ == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( n_ == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( o_ == (*rhs).pages(),   "Invalid number of pages" );
 
    for (size_t k=0UL; k<o_; ++k) {
       for (size_t i=0UL; i<m_; ++i) {
@@ -2654,11 +2654,11 @@ inline auto CustomTensor<Type,AF,PF,RT>::subAssign( const DenseTensor<MT>& rhs )
          size_t j(jbegin);
 
          for (; (j+2UL) <= jend; j+=2UL) {
-            v_[row_elements+j] -= (~rhs)(k, i, j);
-            v_[row_elements+j+1UL] -= (~rhs)(k, i, j+1UL);
+            v_[row_elements+j] -= (*rhs)(k, i, j);
+            v_[row_elements+j+1UL] -= (*rhs)(k, i, j+1UL);
          }
          if (j < jend) {
-            v_[row_elements+j] -= (~rhs)(k, i, j);
+            v_[row_elements+j] -= (*rhs)(k, i, j);
          }
       }
    }
@@ -2687,9 +2687,9 @@ inline auto CustomTensor<Type,AF,PF,RT>::subAssign( const DenseTensor<MT>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 
-   BLAZE_INTERNAL_ASSERT( m_ == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( n_ == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( o_ == (~rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( m_ == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( n_ == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( o_ == (*rhs).pages(),   "Invalid number of pages" );
 
    constexpr bool remainder( !PF || !IsPadded_v<MT> );
 
@@ -2705,7 +2705,7 @@ inline auto CustomTensor<Type,AF,PF,RT>::subAssign( const DenseTensor<MT>& rhs )
 
          size_t j(jbegin);
          Iterator left(begin(i, k) + jbegin);
-         ConstIterator_t<MT> right((~rhs).begin(i, k) + jbegin);
+         ConstIterator_t<MT> right((*rhs).begin(i, k) + jbegin);
 
          for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
             left.store(left.load() - right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -2744,9 +2744,9 @@ template< typename MT >  // Type of the right-hand side dense tensor
 inline auto CustomTensor<Type,AF,PF,RT>::schurAssign( const DenseTensor<MT>& rhs )
    -> EnableIf_t< !VectorizedSchurAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( m_ == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( n_ == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( o_ == (~rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( m_ == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( n_ == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( o_ == (*rhs).pages(),   "Invalid number of pages" );
 
    const size_t jpos( n_ & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( n_ - ( n_ % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2755,11 +2755,11 @@ inline auto CustomTensor<Type,AF,PF,RT>::schurAssign( const DenseTensor<MT>& rhs
       for (size_t i=0UL; i<m_; ++i) {
          size_t row_elements = (k*m_+i)*nn_;
          for (size_t j=0UL; j<jpos; j+=2UL) {
-            v_[row_elements+j] *= (~rhs)(k, i, j);
-            v_[row_elements+j+1UL] *= (~rhs)(k, i, j+1UL);
+            v_[row_elements+j] *= (*rhs)(k, i, j);
+            v_[row_elements+j+1UL] *= (*rhs)(k, i, j+1UL);
          }
          if (jpos < n_) {
-            v_[row_elements+jpos] *= (~rhs)(k, i, jpos);
+            v_[row_elements+jpos] *= (*rhs)(k, i, jpos);
          }
       }
    }
@@ -2788,9 +2788,9 @@ inline auto CustomTensor<Type,AF,PF,RT>::schurAssign( const DenseTensor<MT>& rhs
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 
-   BLAZE_INTERNAL_ASSERT( m_ == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( n_ == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( o_ == (~rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( m_ == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( n_ == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( o_ == (*rhs).pages(),   "Invalid number of pages" );
 
    constexpr bool remainder( !PF || !IsPadded_v<MT> );
 
@@ -2802,7 +2802,7 @@ inline auto CustomTensor<Type,AF,PF,RT>::schurAssign( const DenseTensor<MT>& rhs
 
          size_t j(0UL);
          Iterator left(begin(i, k));
-         ConstIterator_t<MT> right((~rhs).begin(i, k));
+         ConstIterator_t<MT> right((*rhs).begin(i, k));
 
          for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
             left.store(left.load() * right.load()); left += SIMDSIZE; right += SIMDSIZE;

--- a/blaze_tensor/math/dense/DenseTensor.h
+++ b/blaze_tensor/math/dense/DenseTensor.h
@@ -132,7 +132,7 @@ inline auto operator==( const DenseTensor<T1>& tens, T2 scalar )
    using CT1 = CompositeType_t<T1>;
 
    // Evaluation of the dense tensor operand
-   CT1 A( ~tens );
+   CT1 A( *tens );
 
    // In order to compare the tensor and the scalar value, the data values of the lower-order
    // data type are converted to the higher-order data type within the equal function.
@@ -234,18 +234,18 @@ inline auto operator*=( DenseTensor<TT>& tens, ST scalar )
    -> EnableIf_t< IsNumeric_v<ST>, TT& >
 {
    //if( IsRestricted_v<TT> ) {
-   //   if( !tryMult( ~tens, 0UL, 0UL, 0UL, (~tens).pages(), (~tens).rows(), (~tens).columns(), scalar ) ) {
+   //   if( !tryMult( *tens, 0UL, 0UL, 0UL, (*tens).pages(), (*tens).rows(), (*tens).columns(), scalar ) ) {
    //      BLAZE_THROW_INVALID_ARGUMENT( "Invalid scaling of restricted tensor" );
    //   }
    //}
 
-   decltype(auto) left( derestrict( ~tens ) );
+   decltype(auto) left( derestrict( *tens ) );
 
    smpAssign( left, left * scalar );
 
-   BLAZE_INTERNAL_ASSERT( isIntact( ~tens ), "Invariant violation detected" );
+   BLAZE_INTERNAL_ASSERT( isIntact( *tens ), "Invariant violation detected" );
 
-   return ~tens;
+   return *tens;
 }
 //*************************************************************************************************
 
@@ -268,7 +268,7 @@ template< typename TT    // Type of the left-hand side dense tensor
 inline auto operator*=( DenseTensor<TT>&& tens, ST scalar )
    -> EnableIf_t< IsNumeric_v<ST>, TT& >
 {
-   return operator*=( ~tens, scalar );
+   return operator*=( *tens, scalar );
 }
 //*************************************************************************************************
 
@@ -298,18 +298,18 @@ inline auto operator/=( DenseTensor<TT>& tens, ST scalar )
    BLAZE_USER_ASSERT( !isZero( scalar ), "Division by zero detected" );
 
    //if( IsRestricted_v<TT> ) {
-   //   if( !tryDiv( ~tens, 0UL, 0UL, 0UL, (~tens).pages(), (~tens).rows(), (~tens).columns(), scalar ) ) {
+   //   if( !tryDiv( *tens, 0UL, 0UL, 0UL, (*tens).pages(), (*tens).rows(), (*tens).columns(), scalar ) ) {
    //      BLAZE_THROW_INVALID_ARGUMENT( "Invalid scaling of restricted tensor" );
    //   }
    //}
 
-   decltype(auto) left( derestrict( ~tens ) );
+   decltype(auto) left( derestrict( *tens ) );
 
    smpAssign( left, left / scalar );
 
-   BLAZE_INTERNAL_ASSERT( isIntact( ~tens ), "Invariant violation detected" );
+   BLAZE_INTERNAL_ASSERT( isIntact( *tens ), "Invariant violation detected" );
 
-   return ~tens;
+   return *tens;
 }
 //*************************************************************************************************
 
@@ -334,7 +334,7 @@ template< typename TT    // Type of the left-hand side dense tensor
 inline auto operator/=( DenseTensor<TT>&& tens, ST scalar )
    -> EnableIf_t< IsNumeric_v<ST>, TT& >
 {
-   return operator/=( ~tens, scalar );
+   return operator/=( *tens, scalar );
 }
 //*************************************************************************************************
 
@@ -417,7 +417,7 @@ bool isnan( const DenseTensor<TT>& dm )
 {
    using CT = CompositeType_t<TT>;
 
-   CT A( ~dm );  // Evaluation of the dense tensor operand
+   CT A( *dm );  // Evaluation of the dense tensor operand
 
    for (size_t k=0UL; k<A.pages(); ++k) {
       for (size_t i=0UL; i<A.rows(); ++i) {
@@ -445,8 +445,8 @@ bool isnan( const DenseTensor<TT>& dm )
 template< typename MT > // Type of the dense tensor
 auto softmax( const DenseTensor<MT>& dm )
 {
-   auto tmp( evaluate( exp( ~dm ) ) );
-   const auto scalar( sum( ~tmp ) );
+   auto tmp( evaluate( exp( *dm ) ) );
+   const auto scalar( sum( *tmp ) );
    tmp /= scalar;
    return tmp;
 }
@@ -466,16 +466,16 @@ bool isUniform_backend( const DenseTensor<MT>& dm )
 {
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( MT );
 
-   BLAZE_INTERNAL_ASSERT( (~dm).pages()   != 0UL, "Invalid number of pages detected"    );
-   BLAZE_INTERNAL_ASSERT( (~dm).rows()    != 0UL, "Invalid number of rows detected"    );
-   BLAZE_INTERNAL_ASSERT( (~dm).columns() != 0UL, "Invalid number of columns detected" );
+   BLAZE_INTERNAL_ASSERT( (*dm).pages()   != 0UL, "Invalid number of pages detected"    );
+   BLAZE_INTERNAL_ASSERT( (*dm).rows()    != 0UL, "Invalid number of rows detected"    );
+   BLAZE_INTERNAL_ASSERT( (*dm).columns() != 0UL, "Invalid number of columns detected" );
 
-   const auto& cmp( (~dm)(0UL,0UL,0UL) );
+   const auto& cmp( (*dm)(0UL,0UL,0UL) );
 
-   for( size_t k=0UL; k<(~dm).pages(); ++k ) {
-      for( size_t i=0UL; i<(~dm).rows(); ++i ) {
-         for( size_t j=0UL; j<(~dm).columns(); ++j ) {
-            if( !equal<RF>( (~dm)(k,i,j), cmp ) )
+   for( size_t k=0UL; k<(*dm).pages(); ++k ) {
+      for( size_t i=0UL; i<(*dm).rows(); ++i ) {
+         for( size_t j=0UL; j<(*dm).columns(); ++j ) {
+            if( !equal<RF>( (*dm)(k,i,j), cmp ) )
                return false;
          }
       }
@@ -525,14 +525,14 @@ template< RelaxationFlag RF // Relaxation flag
 bool isUniform( const DenseTensor<MT>& dm )
 {
    if( IsUniform_v<MT> ||
-       (~dm).pages() == 0UL || (~dm).rows() == 0UL || (~dm).columns() == 0UL ||
-       ( (~dm).pages() == 1UL && (~dm).rows() == 1UL && (~dm).columns() == 1UL ) )
+       (*dm).pages() == 0UL || (*dm).rows() == 0UL || (*dm).columns() == 0UL ||
+       ( (*dm).pages() == 1UL && (*dm).rows() == 1UL && (*dm).columns() == 1UL ) )
       return true;
 
    if( IsUniTriangular_v<MT> )
       return false;
 
-   CompositeType_t<MT> A( ~dm );  // Evaluation of the dense tensor operand
+   CompositeType_t<MT> A( *dm );  // Evaluation of the dense tensor operand
 
    return isUniform_backend<RF>( A );
 }

--- a/blaze_tensor/math/dense/DynamicArray.h
+++ b/blaze_tensor/math/dense/DynamicArray.h
@@ -717,14 +717,14 @@ template< size_t N         // The dimensionality of the array
         , typename Type >  // Data type of the array
 template< typename MT >    // Type of the foreign array
 inline DynamicArray<N, Type>::DynamicArray( const Array<MT>& rhs )
-   : DynamicArray( (~rhs).dimensions() )
+   : DynamicArray( (*rhs).dimensions() )
 {
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAssign( *this, tmp );
    }
    else {
-      smpAssign( *this, ~rhs );
+      smpAssign( *this, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
@@ -745,12 +745,12 @@ inline DynamicArray<N, Type>::DynamicArray( const Vector<MT, TF>& rhs )
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<1, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
 
@@ -771,13 +771,13 @@ inline DynamicArray<N, Type>::DynamicArray( const Matrix<MT,SO>& rhs )
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<2, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
@@ -799,14 +799,14 @@ inline DynamicArray<N, Type>::DynamicArray( const Tensor<MT>& rhs )
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<2, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
@@ -1426,7 +1426,7 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator=( const DynamicArr
 
    resize( rhs.dimensions(), false );
 
-   smpAssign( *this, ~rhs );
+   smpAssign( *this, *rhs );
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
 
@@ -1475,13 +1475,13 @@ template< size_t N         // The dimensionality of the array
 template< typename MT >  // Type of the right-hand side array
 inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator=( const Array<MT>& rhs )
 {
-   if( (~rhs).canAlias( this ) ) {
-      DynamicArray tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      DynamicArray tmp( *rhs );
       swap( tmp );
    }
    else {
-      resize( (~rhs).dimensions(), false );
-      smpAssign( *this, ~rhs );
+      resize( (*rhs).dimensions(), false );
+      smpAssign( *this, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
@@ -1506,16 +1506,16 @@ template< size_t N         // The dimensionality of the array
 template< typename MT >   // Type of the right-hand side array
 inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator+=( const Array<MT>& rhs )
 {
-   if( (~rhs).dimensions() != dims_ ) {
+   if( (*rhs).dimensions() != dims_ ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Array sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAddAssign( *this, tmp );
    }
    else {
-      smpAddAssign( *this, ~rhs );
+      smpAddAssign( *this, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
@@ -1540,16 +1540,16 @@ template< size_t N         // The dimensionality of the array
 template< typename MT >   // Type of the right-hand side array
 inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator-=( const Array<MT>& rhs )
 {
-   if( (~rhs).dimensions() != dims_ ) {
+   if( (*rhs).dimensions() != dims_ ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Array sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSubAssign( *this, tmp );
    }
    else {
-      smpSubAssign( *this, ~rhs );
+      smpSubAssign( *this, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
@@ -1574,16 +1574,16 @@ template< size_t N         // The dimensionality of the array
 template< typename MT >  // Type of the right-hand side array
 inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator%=( const Array<MT>& rhs )
 {
-   if( (~rhs).dimensions() != dims_ ) {
+   if( (*rhs).dimensions() != dims_ ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Array sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSchurAssign( *this, tmp );
    }
    else {
-      smpSchurAssign( *this, ~rhs );
+      smpSchurAssign( *this, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
@@ -1607,12 +1607,12 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator=( const Vector<MT,
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<1, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
 
@@ -1637,12 +1637,12 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator+=( const Vector<MT
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<1, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAddAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpAddAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
 
@@ -1667,12 +1667,12 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator-=( const Vector<MT
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<1, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSubAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpSubAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
 
@@ -1697,12 +1697,12 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator%=( const Vector<MT
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<1, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSchurAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpSchurAssign( *this, custom_array( tmp.data(), tmp.size(), tmp.spacing() ) );
    }
 
@@ -1727,13 +1727,13 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator=( const Matrix<MT,
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<2, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
@@ -1759,13 +1759,13 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator+=( const Matrix<MT
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<2, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAddAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpAddAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
@@ -1791,13 +1791,13 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator-=( const Matrix<MT
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<2, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSubAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpSubAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
@@ -1823,13 +1823,13 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator%=( const Matrix<MT
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<2, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSchurAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpSchurAssign( *this,
          custom_array( tmp.data(), tmp.rows(), tmp.columns(), tmp.spacing() ) );
    }
@@ -1855,14 +1855,14 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator=( const Tensor<MT>
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<3, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
@@ -1889,14 +1889,14 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator+=( const Tensor<MT
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<3, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpAddAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpAddAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
@@ -1923,14 +1923,14 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator-=( const Tensor<MT
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<3, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSubAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpSubAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
@@ -1957,14 +1957,14 @@ inline DynamicArray<N, Type>& DynamicArray<N, Type>::operator%=( const Tensor<MT
    using ET = ElementType_t<MT>;
    using custom_array = CustomArray<3, ET, unaligned, padded>;
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       smpSchurAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
    }
    else {
-      auto const& tmp = ~rhs;
+      auto const& tmp = *rhs;
       smpSchurAssign( *this,
          custom_array( tmp.data(), tmp.pages(), tmp.rows(), tmp.columns(),
             tmp.spacing() ) );
@@ -3196,14 +3196,14 @@ template< typename MT >  // Type of the right-hand side dense array
 inline auto DynamicArray<N, Type>::assign( const DenseArray<MT>& rhs )
    //-> EnableIf_t< !VectorizedAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
    const size_t jpos( dims_[0] & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( dims_[0] - ( dims_[0] % 2UL ) ) == jpos, "Invalid end calculation" );
 
    ArrayForEachGrouped(
       dims_, nn_, [&]( size_t i, std::array< size_t, N > const& dims ) {
-         v_[i] = ( ~rhs )( dims );
+         v_[i] = ( *rhs )( dims );
       } );
 }
 //*************************************************************************************************
@@ -3228,7 +3228,7 @@ inline auto DynamicArray<N, Type>::assign( const DenseArray<MT>& rhs )
 //{
 //   BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //
-//   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+//   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 //
 //   constexpr bool remainder( !IsPadded_v<MT> );
 //
@@ -3236,13 +3236,13 @@ inline auto DynamicArray<N, Type>::assign( const DenseArray<MT>& rhs )
 //   BLAZE_INTERNAL_ASSERT( !remainder || ( dims_[0] - ( dims_[0] % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
 //    if( useStreaming &&
-//        ( o_*m_*n_ > ( cacheSize / ( sizeof(Type) * 3UL ) ) ) && !(~rhs).isAliased( this ) )
+//        ( o_*m_*n_ > ( cacheSize / ( sizeof(Type) * 3UL ) ) ) && !(*rhs).isAliased( this ) )
 //    {
 //       for (size_t k=0UL; k<o_; ++k) {
 //          for (size_t i=0UL; i<m_; ++i) {
 //             size_t j(0UL);
 //             Iterator left(begin(i, k));
-//             ConstIterator_t<MT> right((~rhs).begin(i, k));
+//             ConstIterator_t<MT> right((*rhs).begin(i, k));
 //
 //             for (; j<jpos; j+=SIMDSIZE, left+=SIMDSIZE, right+=SIMDSIZE) {
 //                left.stream(right.load());
@@ -3259,7 +3259,7 @@ inline auto DynamicArray<N, Type>::assign( const DenseArray<MT>& rhs )
 //          for (size_t i=0UL; i<m_; ++i) {
 //             size_t j(0UL);
 //             Iterator left(begin(i, k));
-//             ConstIterator_t<MT> right((~rhs).begin(i, k));
+//             ConstIterator_t<MT> right((*rhs).begin(i, k));
 //
 //             for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
 //                left.store(right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -3297,14 +3297,14 @@ template< typename MT >  // Type of the right-hand side dense array
 inline auto DynamicArray<N, Type>::addAssign( const DenseArray<MT>& rhs )
    //-> EnableIf_t< !VectorizedAddAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
    const size_t jpos( dims_[0] & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( dims_[0] - ( dims_[0] % 2UL ) ) == jpos, "Invalid end calculation" );
 
    ArrayForEachGrouped(
       dims_, nn_, [&]( size_t i, std::array< size_t, N > const& dims ) {
-         v_[i] += ( ~rhs )( dims );
+         v_[i] += ( *rhs )( dims );
       } );
 }
 //*************************************************************************************************
@@ -3329,7 +3329,7 @@ inline auto DynamicArray<N, Type>::addAssign( const DenseArray<MT>& rhs )
 //{
 //   BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //
-//   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+//   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 //
 //   constexpr bool remainder( !IsPadded_v<MT> );
 //
@@ -3344,7 +3344,7 @@ inline auto DynamicArray<N, Type>::addAssign( const DenseArray<MT>& rhs )
 //
 //         size_t j(jbegin);
 //         Iterator left(begin(i, k) + jbegin);
-//         ConstIterator_t<MT> right((~rhs).begin(i, k) + jbegin);
+//         ConstIterator_t<MT> right((*rhs).begin(i, k) + jbegin);
 //
 //         for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
 //            left.store(left.load() + right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -3381,14 +3381,14 @@ template< typename MT >  // Type of the right-hand side dense array
 inline auto DynamicArray<N, Type>::subAssign( const DenseArray<MT>& rhs )
    //-> EnableIf_t< !VectorizedSubAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
    const size_t jpos( dims_[0] & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( dims_[0] - ( dims_[0] % 2UL ) ) == jpos, "Invalid end calculation" );
 
    ArrayForEachGrouped(
       dims_, nn_, [&]( size_t i, std::array< size_t, N > const& dims ) {
-         v_[i] -= ( ~rhs )( dims );
+         v_[i] -= ( *rhs )( dims );
       } );
 }
 //*************************************************************************************************
@@ -3413,7 +3413,7 @@ inline auto DynamicArray<N, Type>::subAssign( const DenseArray<MT>& rhs )
 //{
 //   BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //
-//   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+//   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 //
 //   constexpr bool remainder( !IsPadded_v<MT> );
 //
@@ -3429,7 +3429,7 @@ inline auto DynamicArray<N, Type>::subAssign( const DenseArray<MT>& rhs )
 //
 //         size_t j(jbegin);
 //         Iterator left(begin(i, k) + jbegin);
-//         ConstIterator_t<MT> right((~rhs).begin(i, k) + jbegin);
+//         ConstIterator_t<MT> right((*rhs).begin(i, k) + jbegin);
 //
 //         for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
 //            left.store(left.load() - right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -3466,14 +3466,14 @@ template< typename MT >  // Type of the right-hand side dense array
 inline auto DynamicArray<N, Type>::schurAssign( const DenseArray<MT>& rhs )
    //-> EnableIf_t< !VectorizedSchurAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 
    const size_t jpos( dims_[0] & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( dims_[0] - ( dims_[0] % 2UL ) ) == jpos, "Invalid end calculation" );
 
    ArrayForEachGrouped(
       dims_, nn_, [&]( size_t i, std::array< size_t, N > const& dims ) {
-         v_[i] *= ( ~rhs )( dims );
+         v_[i] *= ( *rhs )( dims );
       } );
 }
 //*************************************************************************************************
@@ -3498,7 +3498,7 @@ inline auto DynamicArray<N, Type>::schurAssign( const DenseArray<MT>& rhs )
 //{
 //   BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //
-//   BLAZE_INTERNAL_ASSERT( dims_ == (~rhs).dimensions()   , "Invalid array access index"    );
+//   BLAZE_INTERNAL_ASSERT( dims_ == (*rhs).dimensions()   , "Invalid array access index"    );
 //
 //   constexpr bool remainder( !IsPadded_v<MT> );
 //
@@ -3510,7 +3510,7 @@ inline auto DynamicArray<N, Type>::schurAssign( const DenseArray<MT>& rhs )
 //
 //         size_t j(0UL);
 //         Iterator left(begin(i, k));
-//         ConstIterator_t<MT> right((~rhs).begin(i, k));
+//         ConstIterator_t<MT> right((*rhs).begin(i, k));
 //
 //         for (; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL) {
 //            left.store(left.load() * right.load()); left += SIMDSIZE; right += SIMDSIZE;

--- a/blaze_tensor/math/dense/StaticTensor.h
+++ b/blaze_tensor/math/dense/StaticTensor.h
@@ -881,7 +881,7 @@ inline StaticTensor<Type,O,M,N>::StaticTensor( const Tensor<MT>& m )
 
    BLAZE_STATIC_ASSERT( IsVectorizable_v<Type> || NN == N );
 
-   if( (~m).pages() != O || (~m).rows() != M || (~m).columns() != N ) {
+   if( (*m).pages() != O || (*m).rows() != M || (*m).columns() != N ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid setup of static tensor" );
    }
 
@@ -893,7 +893,7 @@ inline StaticTensor<Type,O,M,N>::StaticTensor( const Tensor<MT>& m )
       }
    }
 
-   assign( *this, ~m );
+   assign( *this, *m );
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
 }
@@ -1404,7 +1404,7 @@ inline StaticTensor<Type,O,M,N>& StaticTensor<Type,O,M,N>::operator=( const Stat
 {
    using blaze::assign;
 
-   assign( *this, ~rhs );
+   assign( *this, *rhs );
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
 
@@ -1429,7 +1429,7 @@ inline StaticTensor<Type,O,M,N>&
 {
    using blaze::assign;
 
-   assign( *this, ~rhs );
+   assign( *this, *rhs );
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
 
@@ -1462,25 +1462,25 @@ inline StaticTensor<Type,O,M,N>& StaticTensor<Type,O,M,N>::operator=( const Tens
 //    using CT = decltype( ctrans( *this ) );
 //    using IT = decltype( inv( *this ) );
 
-   if( (~rhs).pages() != O || (~rhs).rows() != M || (~rhs).columns() != N ) {
+   if( (*rhs).pages() != O || (*rhs).rows() != M || (*rhs).columns() != N ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to static tensor" );
    }
 
-//    if( IsSame_v<MT,TT> && (~rhs).isAliased( this ) ) {
+//    if( IsSame_v<MT,TT> && (*rhs).isAliased( this ) ) {
 //       transpose( typename IsSquare<This>::Type() );
 //    }
-//    else if( IsSame_v<MT,CT> && (~rhs).isAliased( this ) ) {
+//    else if( IsSame_v<MT,CT> && (*rhs).isAliased( this ) ) {
 //       ctranspose( typename IsSquare<This>::Type() );
 //    }
 //   else
-   if( /*!IsSame_v<MT,IT> &&*/ (~rhs).canAlias( this ) ) {
-      StaticTensor tmp( ~rhs );
+   if( /*!IsSame_v<MT,IT> &&*/ (*rhs).canAlias( this ) ) {
+      StaticTensor tmp( *rhs );
       assign( *this, tmp );
    }
    else {
 //       if( IsSparseTensor_v<MT> )
 //          reset();
-      assign( *this, ~rhs );
+      assign( *this, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
@@ -1509,16 +1509,16 @@ inline StaticTensor<Type,O,M,N>& StaticTensor<Type,O,M,N>::operator+=( const Ten
 {
    using blaze::addAssign;
 
-   if( (~rhs).pages() != O || (~rhs).rows() != M || (~rhs).columns() != N ) {
+   if( (*rhs).pages() != O || (*rhs).rows() != M || (*rhs).columns() != N ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       addAssign( *this, tmp );
    }
    else {
-      addAssign( *this, ~rhs );
+      addAssign( *this, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
@@ -1547,16 +1547,16 @@ inline StaticTensor<Type,O,M,N>& StaticTensor<Type,O,M,N>::operator-=( const Ten
 {
    using blaze::subAssign;
 
-   if( (~rhs).pages() != O || (~rhs).rows() != M || (~rhs).columns() != N ) {
+   if( (*rhs).pages() != O || (*rhs).rows() != M || (*rhs).columns() != N ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       subAssign( *this, tmp );
    }
    else {
-      subAssign( *this, ~rhs );
+      subAssign( *this, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
@@ -1585,16 +1585,16 @@ inline StaticTensor<Type,O,M,N>& StaticTensor<Type,O,M,N>::operator%=( const Ten
 {
    using blaze::schurAssign;
 
-   if( (~rhs).pages() != O || (~rhs).rows() != M || (~rhs).columns() != N ) {
+   if( (*rhs).pages() != O || (*rhs).rows() != M || (*rhs).columns() != N ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      const ResultType_t<MT> tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      const ResultType_t<MT> tmp( *rhs );
       schurAssign( *this, tmp );
    }
    else {
-      schurAssign( *this, ~rhs );
+      schurAssign( *this, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact(), "Invariant violation detected" );
@@ -2643,12 +2643,12 @@ template< typename MT >  // Type of the right-hand side dense tensor
 inline auto StaticTensor<Type,O,M,N>::assign( const DenseTensor<MT>& rhs )
    -> EnableIf_t< !VectorizedAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( (~rhs).pages() == O && (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+   BLAZE_INTERNAL_ASSERT( (*rhs).pages() == O && (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 
    for( size_t k=0UL; k<O; ++k )
       for( size_t i=0UL; i<M; ++i ) {
          for( size_t j=0UL; j<N; ++j ) {
-            v_[(k*M+i)*NN+j] = (~rhs)(k,i,j);
+            v_[(k*M+i)*NN+j] = (*rhs)(k,i,j);
          }
       }
 }
@@ -2676,7 +2676,7 @@ inline auto StaticTensor<Type,O,M,N>::assign( const DenseTensor<MT>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 
-   BLAZE_INTERNAL_ASSERT( (~rhs).pages() == O && (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+   BLAZE_INTERNAL_ASSERT( (*rhs).pages() == O && (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 
    constexpr bool remainder = !IsPadded_v<MT>;
 
@@ -2689,10 +2689,10 @@ inline auto StaticTensor<Type,O,M,N>::assign( const DenseTensor<MT>& rhs )
          size_t j( 0UL );
 
          for( ; j<jpos; j+=SIMDSIZE ) {
-            store( k, i, j, (~rhs).load(k,i,j) );
+            store( k, i, j, (*rhs).load(k,i,j) );
          }
          for( ; remainder && j<N; ++j ) {
-            v_[(k*M+i)*NN+j] = (~rhs)(k,i,j);
+            v_[(k*M+i)*NN+j] = (*rhs)(k,i,j);
          }
       }
 }
@@ -2717,11 +2717,11 @@ inline auto StaticTensor<Type,O,M,N>::assign( const DenseTensor<MT>& rhs )
 // template< typename MT >  // Type of the right-hand side sparse tensor
 // inline void StaticTensor<Type,O,M,N>::assign( const SparseTensor<MT>& rhs )
 // {
-//    BLAZE_INTERNAL_ASSERT( (~rhs).pages() == O && (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+//    BLAZE_INTERNAL_ASSERT( (*rhs).pages() == O && (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 //
 //    for( size_t k=0UL; k<O; ++k )
 //       for( size_t i=0UL; i<M; ++i )
-//          for( ConstIterator_t<MT> element=(~rhs).begin(i); element!=(~rhs).end(i); ++element )
+//          for( ConstIterator_t<MT> element=(*rhs).begin(i); element!=(*rhs).end(i); ++element )
 //             v_[(k*M+i)*NN+element->index()] = element->value();
 // }
 //*************************************************************************************************
@@ -2747,10 +2747,10 @@ inline auto StaticTensor<Type,O,M,N>::assign( const DenseTensor<MT>& rhs )
 // {
 //    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_TENSOR_TYPE( MT );
 //
-//    BLAZE_INTERNAL_ASSERT( (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+//    BLAZE_INTERNAL_ASSERT( (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 //
 //    for( size_t j=0UL; j<N; ++j )
-//       for( ConstIterator_t<MT> element=(~rhs).begin(j); element!=(~rhs).end(j); ++element )
+//       for( ConstIterator_t<MT> element=(*rhs).begin(j); element!=(*rhs).end(j); ++element )
 //          v_[element->index()*NN+j] = element->value();
 // }
 //*************************************************************************************************
@@ -2775,14 +2775,14 @@ template< typename MT >  // Type of the right-hand side dense tensor
 inline auto StaticTensor<Type,O,M,N>::addAssign( const DenseTensor<MT>& rhs )
    -> EnableIf_t< !VectorizedAddAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( (~rhs).pages() == O && (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+   BLAZE_INTERNAL_ASSERT( (*rhs).pages() == O && (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 
    for( size_t k=0UL; k<O; ++k )
       for( size_t i=0UL; i<M; ++i )
       {
 //          if( IsDiagonal_v<MT> )
 //          {
-//             v_[(k*M+i)*NN+i] += (~rhs)(i,i,i);
+//             v_[(k*M+i)*NN+i] += (*rhs)(i,i,i);
 //          }
 //          else
          {
@@ -2791,7 +2791,7 @@ inline auto StaticTensor<Type,O,M,N>::addAssign( const DenseTensor<MT>& rhs )
             BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
             for( size_t j=jbegin; j<jend; ++j ) {
-               v_[(k*M+i)*NN+j] += (~rhs)(k,i,j);
+               v_[(k*M+i)*NN+j] += (*rhs)(k,i,j);
             }
          }
       }
@@ -2821,7 +2821,7 @@ inline auto StaticTensor<Type,O,M,N>::addAssign( const DenseTensor<MT>& rhs )
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //    BLAZE_CONSTRAINT_MUST_NOT_BE_DIAGONAL_TENSOR_TYPE( MT );
 
-   BLAZE_INTERNAL_ASSERT( (~rhs).pages() == O && (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+   BLAZE_INTERNAL_ASSERT( (*rhs).pages() == O && (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 
    constexpr bool remainder = !IsPadded_v<MT>;
 
@@ -2838,10 +2838,10 @@ inline auto StaticTensor<Type,O,M,N>::addAssign( const DenseTensor<MT>& rhs )
          size_t j( jbegin );
 
          for( ; j<jpos; j+=SIMDSIZE ) {
-            store( k, i, j, load(k,i,j) + (~rhs).load(k,i,j) );
+            store( k, i, j, load(k,i,j) + (*rhs).load(k,i,j) );
          }
          for( ; remainder && j<jend; ++j ) {
-            v_[(k*M+i)*NN+j] += (~rhs)(k,i,j);
+            v_[(k*M+i)*NN+j] += (*rhs)(k,i,j);
          }
       }
 }
@@ -2866,11 +2866,11 @@ inline auto StaticTensor<Type,O,M,N>::addAssign( const DenseTensor<MT>& rhs )
 // template< typename MT >  // Type of the right-hand side sparse tensor
 // inline void StaticTensor<Type,O,M,N>::addAssign( const SparseTensor<MT>& rhs )
 // {
-//    BLAZE_INTERNAL_ASSERT( (~rhs).pages() == O && (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+//    BLAZE_INTERNAL_ASSERT( (*rhs).pages() == O && (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 //
 //    for( size_t k=0UL; k<O; ++k )
 //       for( size_t i=0UL; i<M; ++i )
-//          for( ConstIterator_t<MT> element=(~rhs).begin(i, k); element!=(~rhs).end(i, k); ++element )
+//          for( ConstIterator_t<MT> element=(*rhs).begin(i, k); element!=(*rhs).end(i, k); ++element )
 //             v_[(k*M+i)*NN+element->index()] += element->value();
 // }
 //*************************************************************************************************
@@ -2896,10 +2896,10 @@ inline auto StaticTensor<Type,O,M,N>::addAssign( const DenseTensor<MT>& rhs )
 // {
 //    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_TENSOR_TYPE( MT );
 //
-//    BLAZE_INTERNAL_ASSERT( (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+//    BLAZE_INTERNAL_ASSERT( (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 //
 //    for( size_t j=0UL; j<N; ++j )
-//       for( ConstIterator_t<MT> element=(~rhs).begin(j); element!=(~rhs).end(j); ++element )
+//       for( ConstIterator_t<MT> element=(*rhs).begin(j); element!=(*rhs).end(j); ++element )
 //          v_[element->index()*NN+j] += element->value();
 // }
 //*************************************************************************************************
@@ -2924,14 +2924,14 @@ template< typename MT >  // Type of the right-hand side dense tensor
 inline auto StaticTensor<Type,O,M,N>::subAssign( const DenseTensor<MT>& rhs )
    -> EnableIf_t< !VectorizedSubAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( (~rhs).pages() == O && (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+   BLAZE_INTERNAL_ASSERT( (*rhs).pages() == O && (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 
    for( size_t k=0UL; k<O; ++k )
       for( size_t i=0UL; i<M; ++i )
       {
 //          if( IsDiagonal_v<MT> )
 //          {
-//             v_[i*NN+i] -= (~rhs)(i,i);
+//             v_[i*NN+i] -= (*rhs)(i,i);
 //          }
 //          else
          {
@@ -2940,7 +2940,7 @@ inline auto StaticTensor<Type,O,M,N>::subAssign( const DenseTensor<MT>& rhs )
             BLAZE_INTERNAL_ASSERT( jbegin <= jend, "Invalid loop indices detected" );
 
             for( size_t j=jbegin; j<jend; ++j ) {
-               v_[(k*M+i)*NN+j] -= (~rhs)(k,i,j);
+               v_[(k*M+i)*NN+j] -= (*rhs)(k,i,j);
             }
          }
       }
@@ -2970,7 +2970,7 @@ inline auto StaticTensor<Type,O,M,N>::subAssign( const DenseTensor<MT>& rhs )
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 //    BLAZE_CONSTRAINT_MUST_NOT_BE_DIAGONAL_TENSOR_TYPE( MT );
 
-   BLAZE_INTERNAL_ASSERT( (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+   BLAZE_INTERNAL_ASSERT( (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 
    constexpr bool remainder = !IsPadded_v<MT>;
 
@@ -2987,10 +2987,10 @@ inline auto StaticTensor<Type,O,M,N>::subAssign( const DenseTensor<MT>& rhs )
          size_t j( jbegin );
 
          for( ; j<jpos; j+=SIMDSIZE ) {
-            store( k, i, j, load(k,i,j) - (~rhs).load(k,i,j) );
+            store( k, i, j, load(k,i,j) - (*rhs).load(k,i,j) );
          }
          for( ; remainder && j<jend; ++j ) {
-            v_[(k*M+i)*NN+j] -= (~rhs)(k,i,j);
+            v_[(k*M+i)*NN+j] -= (*rhs)(k,i,j);
          }
       }
 }
@@ -3015,10 +3015,10 @@ inline auto StaticTensor<Type,O,M,N>::subAssign( const DenseTensor<MT>& rhs )
 // template< typename MT >  // Type of the right-hand side sparse tensor
 // inline void StaticTensor<Type,O,M,N>::subAssign( const SparseTensor<MT>& rhs )
 // {
-//    BLAZE_INTERNAL_ASSERT( (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+//    BLAZE_INTERNAL_ASSERT( (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 //
 //    for( size_t i=0UL; i<M; ++i )
-//       for( ConstIterator_t<MT> element=(~rhs).begin(i); element!=(~rhs).end(i); ++element )
+//       for( ConstIterator_t<MT> element=(*rhs).begin(i); element!=(*rhs).end(i); ++element )
 //          v_[i*NN+element->index()] -= element->value();
 // }
 //*************************************************************************************************
@@ -3044,10 +3044,10 @@ inline auto StaticTensor<Type,O,M,N>::subAssign( const DenseTensor<MT>& rhs )
 // {
 //    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_TENSOR_TYPE( MT );
 //
-//    BLAZE_INTERNAL_ASSERT( (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+//    BLAZE_INTERNAL_ASSERT( (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 //
 //    for( size_t j=0UL; j<N; ++j )
-//       for( ConstIterator_t<MT> element=(~rhs).begin(j); element!=(~rhs).end(j); ++element )
+//       for( ConstIterator_t<MT> element=(*rhs).begin(j); element!=(*rhs).end(j); ++element )
 //          v_[element->index()*NN+j] -= element->value();
 // }
 //*************************************************************************************************
@@ -3072,12 +3072,12 @@ template< typename MT >  // Type of the right-hand side dense tensor
 inline auto StaticTensor<Type,O,M,N>::schurAssign( const DenseTensor<MT>& rhs )
    -> EnableIf_t< !VectorizedSchurAssign_v<MT> >
 {
-   BLAZE_INTERNAL_ASSERT( (~rhs).pages() == O && (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+   BLAZE_INTERNAL_ASSERT( (*rhs).pages() == O && (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 
    for( size_t k=0UL; k<O; ++k )
       for( size_t i=0UL; i<M; ++i ) {
          for( size_t j=0UL; j<N; ++j ) {
-            v_[(k*M+i)*NN+j] *= (~rhs)(k,i,j);
+            v_[(k*M+i)*NN+j] *= (*rhs)(k,i,j);
          }
       }
 }
@@ -3105,7 +3105,7 @@ inline auto StaticTensor<Type,O,M,N>::schurAssign( const DenseTensor<MT>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( Type );
 
-   BLAZE_INTERNAL_ASSERT( (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+   BLAZE_INTERNAL_ASSERT( (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 
    constexpr bool remainder = !IsPadded_v<MT>;
 
@@ -3118,10 +3118,10 @@ inline auto StaticTensor<Type,O,M,N>::schurAssign( const DenseTensor<MT>& rhs )
          size_t j( 0UL );
 
          for( ; j<jpos; j+=SIMDSIZE ) {
-            store( k, i, j, load(k,i,j) * (~rhs).load(k,i,j) );
+            store( k, i, j, load(k,i,j) * (*rhs).load(k,i,j) );
          }
          for( ; remainder && j<N; ++j ) {
-            v_[(k*M+i)*NN+j] *= (~rhs)(k,i,j);
+            v_[(k*M+i)*NN+j] *= (*rhs)(k,i,j);
          }
       }
 }
@@ -3146,14 +3146,14 @@ inline auto StaticTensor<Type,O,M,N>::schurAssign( const DenseTensor<MT>& rhs )
 // template< typename MT >  // Type of the right-hand side sparse tensor
 // inline void StaticTensor<Type,O,M,N>::schurAssign( const SparseTensor<MT>& rhs )
 // {
-//    BLAZE_INTERNAL_ASSERT( (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+//    BLAZE_INTERNAL_ASSERT( (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 //
 //    const StaticTensor tmp( serial( *this ) );
 //
 //    reset();
 //
 //    for( size_t i=0UL; i<M; ++i )
-//       for( ConstIterator_t<MT> element=(~rhs).begin(i); element!=(~rhs).end(i); ++element )
+//       for( ConstIterator_t<MT> element=(*rhs).begin(i); element!=(*rhs).end(i); ++element )
 //          v_[i*NN+element->index()] = tmp.v_[i*NN+element->index()] * element->value();
 // }
 //*************************************************************************************************
@@ -3179,14 +3179,14 @@ inline auto StaticTensor<Type,O,M,N>::schurAssign( const DenseTensor<MT>& rhs )
 // {
 //    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_TENSOR_TYPE( MT );
 //
-//    BLAZE_INTERNAL_ASSERT( (~rhs).rows() == M && (~rhs).columns() == N, "Invalid tensor size" );
+//    BLAZE_INTERNAL_ASSERT( (*rhs).rows() == M && (*rhs).columns() == N, "Invalid tensor size" );
 //
 //    const StaticTensor tmp( serial( *this ) );
 //
 //    reset();
 //
 //    for( size_t j=0UL; j<N; ++j )
-//       for( ConstIterator_t<MT> element=(~rhs).begin(j); element!=(~rhs).end(j); ++element )
+//       for( ConstIterator_t<MT> element=(*rhs).begin(j); element!=(*rhs).end(j); ++element )
 //          v_[element->index()*NN+j] = tmp.v_[element->index()*NN+j] * element->value();
 // }
 //*************************************************************************************************

--- a/blaze_tensor/math/dense/Transposition.h
+++ b/blaze_tensor/math/dense/Transposition.h
@@ -161,7 +161,7 @@ inline void transposeGeneral021( DenseTensor<TT>& dt )
 
    constexpr size_t block( BLOCK_SIZE );
 
-   TT& t( ~dt );
+   TT& t( *dt );
 
    for( size_t kk = 0UL; kk < t.pages(); kk += block )
    {
@@ -206,7 +206,7 @@ inline void transposeGeneral102( DenseTensor<TT>& dt )
 
    constexpr size_t block( BLOCK_SIZE );
 
-   TT& t( ~dt );
+   TT& t( *dt );
 
    for( size_t jj = 0UL; jj < t.columns(); jj += block )
    {
@@ -251,7 +251,7 @@ inline void transposeGeneral120( DenseTensor<TT>& dt )
 
    constexpr size_t block( BLOCK_SIZE );
 
-   TT& t( ~dt );
+   TT& t( *dt );
 
    for( size_t kk = 0UL; kk < t.pages(); kk += block )
    {
@@ -315,7 +315,7 @@ inline void transposeGeneral201( DenseTensor<TT>& dt )
 
    constexpr size_t block( BLOCK_SIZE );
 
-   TT& t( ~dt );
+   TT& t( *dt );
 
    for( size_t ii = 0UL; ii < t.rows(); ii += block )
    {
@@ -379,7 +379,7 @@ inline void transposeGeneral210( DenseTensor<TT>& dt )
 
    constexpr size_t block( BLOCK_SIZE );
 
-   TT& t( ~dt );
+   TT& t( *dt );
 
    for( size_t ii = 0UL; ii < t.rows(); ii += block )
    {

--- a/blaze_tensor/math/dense/UniformTensor.h
+++ b/blaze_tensor/math/dense/UniformTensor.h
@@ -453,17 +453,17 @@ template< typename Type > // Data type of the tensor
 template< typename MT    // Type of the foreign tensor
          >     // Storage order of the foreign tensor
 inline UniformTensor<Type>::UniformTensor( const Tensor<MT>& m )
-   : o_    ( (~m).pages()   )  // The current number of pages of the tensor
-   , m_    ( (~m).rows()    )  // The current number of rows of the tensor
-   , n_    ( (~m).columns() )  // The current number of columns of the tensor
+   : o_    ( (*m).pages()   )  // The current number of pages of the tensor
+   , m_    ( (*m).rows()    )  // The current number of rows of the tensor
+   , n_    ( (*m).columns() )  // The current number of columns of the tensor
    , value_()                  // The value of all elements of the uniform vector
 {
-   if( !IsUniform_v<MT> && !isUniform( ~m ) ) {
+   if( !IsUniform_v<MT> && !isUniform( *m ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid setup of uniform tensor" );
    }
 
    if( o_ > 0UL && m_ > 0UL && n_ > 0UL ) {
-      value_ = (~m)(0UL,0UL,0UL);
+      value_ = (*m)(0UL,0UL,0UL);
    }
 }
 //*************************************************************************************************
@@ -714,21 +714,21 @@ template< typename Type > // Data type of the tensor
 template< typename MT >   // Type of the right-hand side tensor
 inline UniformTensor<Type>& UniformTensor<Type>::operator=( const Tensor<MT>& rhs )
 {
-   if( !IsUniform_v<MT> && !isUniform( ~rhs ) ) {
+   if( !IsUniform_v<MT> && !isUniform( *rhs ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment of uniform tensor" );
    }
 
-   if( (~rhs).canAlias( this ) ) {
-      UniformTensor tmp( ~rhs );
+   if( (*rhs).canAlias( this ) ) {
+      UniformTensor tmp( *rhs );
       swap( tmp );
    }
    else {
-      o_ = (~rhs).pages();
-      m_ = (~rhs).rows();
-      n_ = (~rhs).columns();
+      o_ = (*rhs).pages();
+      m_ = (*rhs).rows();
+      n_ = (*rhs).columns();
 
       if( o_ > 0UL && m_ > 0UL && n_ > 0UL ) {
-         value_ = (~rhs)(0UL,0UL,0UL);
+         value_ = (*rhs)(0UL,0UL,0UL);
       }
    }
 
@@ -751,16 +751,16 @@ template< typename Type > // Data type of the tensor
 template< typename MT >   // Type of the right-hand side tensor
 inline UniformTensor<Type>& UniformTensor<Type>::operator+=( const Tensor<MT>& rhs )
 {
-   if( (~rhs).pages() != o_ || (~rhs).rows() != m_ || (~rhs).columns() != n_ ) {
+   if( (*rhs).pages() != o_ || (*rhs).rows() != m_ || (*rhs).columns() != n_ ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !IsUniform_v<MT> && !isUniform( ~rhs ) ) {
+   if( !IsUniform_v<MT> && !isUniform( *rhs ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid addition assignment to uniform tensor" );
    }
 
    if( o_ > 0UL && m_ > 0UL && n_ > 0UL ) {
-      value_ += (~rhs)(0UL,0UL,0UL);
+      value_ += (*rhs)(0UL,0UL,0UL);
    }
 
    return *this;
@@ -782,16 +782,16 @@ template< typename Type > // Data type of the tensor
 template< typename MT >   // Type of the right-hand side tensor
 inline UniformTensor<Type>& UniformTensor<Type>::operator-=( const Tensor<MT>& rhs )
 {
-   if( (~rhs).pages() != o_ || (~rhs).rows() != m_ || (~rhs).columns() != n_ ) {
+   if( (*rhs).pages() != o_ || (*rhs).rows() != m_ || (*rhs).columns() != n_ ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !IsUniform_v<MT> && !isUniform( ~rhs ) ) {
+   if( !IsUniform_v<MT> && !isUniform( *rhs ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid subtraction assignment to uniform tensor" );
    }
 
    if( o_ > 0UL && m_ > 0UL && n_ > 0UL ) {
-      value_ -= (~rhs)(0UL,0UL,0UL);
+      value_ -= (*rhs)(0UL,0UL,0UL);
    }
 
    return *this;
@@ -813,16 +813,16 @@ template< typename Type > // Data type of the tensor
 template< typename MT >   // Type of the right-hand side tensor
 inline UniformTensor<Type>& UniformTensor<Type>::operator%=( const Tensor<MT>& rhs )
 {
-   if( (~rhs).pages() != o_ || (~rhs).rows() != m_ || (~rhs).columns() != n_ ) {
+   if( (*rhs).pages() != o_ || (*rhs).rows() != m_ || (*rhs).columns() != n_ ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !IsUniform_v<MT> && !isUniform( ~rhs ) ) {
+   if( !IsUniform_v<MT> && !isUniform( *rhs ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid Schur product assignment to uniform tensor" );
    }
 
    if( o_ > 0UL && m_ > 0UL && n_ > 0UL ) {
-      value_ *= (~rhs)(0UL,0UL,0UL);
+      value_ *= (*rhs)(0UL,0UL,0UL);
    }
 
    return *this;
@@ -844,18 +844,18 @@ inline UniformTensor<Type>& UniformTensor<Type>::operator%=( const Tensor<MT>& r
 // template< typename MT >   // Type of the right-hand side tensor
 // inline UniformTensor<Type>& UniformTensor<Type>::operator*=( const Tensor<MT>& rhs )
 // {
-//    if( (~rhs).rows() != n_ ) {
+//    if( (*rhs).rows() != n_ ) {
 //       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
 //    }
 //
-//    if( !IsUniform_v<MT> && !isUniform( ~rhs ) ) {
+//    if( !IsUniform_v<MT> && !isUniform( *rhs ) ) {
 //       BLAZE_THROW_INVALID_ARGUMENT( "Invalid multiplication assignment to uniform tensor" );
 //    }
 //
-//    n_ = (~rhs).columns();
+//    n_ = (*rhs).columns();
 //
 //    if( m_ > 0UL && n_ > 0UL ) {
-//       value_ = ( value_ * (~rhs)(0UL,0UL) ) * Type( (~rhs).rows() );
+//       value_ = ( value_ * (*rhs)(0UL,0UL) ) * Type( (*rhs).rows() );
 //    }
 //
 //    return *this;

--- a/blaze_tensor/math/expressions/Array.h
+++ b/blaze_tensor/math/expressions/Array.h
@@ -90,21 +90,53 @@ struct Array
    //**********************************************************************************************
 
    //**Non-const conversion operator***************************************************************
-   /*!\brief Conversion operator for non-constant arrays.
+   /*!\brief CRTP-based conversion operation for non-constant arrays.
    //
-   // \return Reference of the actual type of the array.
+   // \return Mutable reference of the actual type of the array.
+   //
+   // This operator performs the CRTP-based type-safe downcast to the actual type \a VT of the
+   // array. It will return a mutable reference to the actual type \a VT.
    */
-   BLAZE_ALWAYS_INLINE constexpr ArrayType& operator~() noexcept {
+   [[deprecated]] BLAZE_ALWAYS_INLINE constexpr ArrayType& operator~() noexcept {
       return *static_cast<ArrayType*>( this );
    }
    //**********************************************************************************************
 
    //**Const conversion operator*******************************************************************
-   /*!\brief Conversion operator for constant arrays.
+   /*!\brief CRTP-based conversion operation for constant arrays.
    //
    // \return Constant reference of the actual type of the array.
+   //
+   // This operator performs the CRTP-based type-safe downcast to the actual type \a VT of the
+   // array. It will return a constant reference to the actual type \a VT.
    */
-   BLAZE_ALWAYS_INLINE constexpr const ArrayType& operator~() const noexcept {
+   [[deprecated]] BLAZE_ALWAYS_INLINE constexpr const ArrayType& operator~() const noexcept {
+      return *static_cast<const ArrayType*>( this );
+   }
+   //**********************************************************************************************
+
+   //**Non-const conversion operator***************************************************************
+   /*!\brief CRTP-based conversion operation for non-constant arrays.
+   //
+   // \return Mutable reference of the actual type of the array.
+   //
+   // This operator performs the CRTP-based type-safe downcast to the actual type \a VT of the
+   // array. It will return a mutable reference to the actual type \a VT.
+   */
+   BLAZE_ALWAYS_INLINE constexpr ArrayType& operator*() noexcept {
+      return *static_cast<ArrayType*>( this );
+   }
+   //**********************************************************************************************
+
+   //**Const conversion operator*******************************************************************
+   /*!\brief CRTP-based conversion operation for constant arrays.
+   //
+   // \return Constant reference of the actual type of the array.
+   //
+   // This operator performs the CRTP-based type-safe downcast to the actual type \a VT of the
+   // array. It will return a constant reference to the actual type \a VT.
+   */
+   BLAZE_ALWAYS_INLINE constexpr const ArrayType& operator*() const noexcept {
       return *static_cast<const ArrayType*>( this );
    }
    //**********************************************************************************************
@@ -134,9 +166,9 @@ template< typename TT1  // Type of the left-hand side array
         , typename TT2 > // Type of the right-hand side array
 inline TT1& operator*=( Array<TT1>& lhs, const Array<TT2>& rhs )
 {
-   ResultType_t<TT1> tmp( (~lhs) * (~rhs) );
-   (~lhs) = std::move( tmp );
-   return (~lhs);
+   ResultType_t<TT1> tmp( (*lhs) * (*rhs) );
+   (*lhs) = std::move( tmp );
+   return (*lhs);
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -160,7 +192,7 @@ template< typename TT1  // Type of the left-hand side array
         , typename TT2 > // Type of the right-hand side array
 inline TT1& operator*=( Array<TT1>&& lhs, const Array<TT2>& rhs )
 {
-   return (~lhs) *= (~rhs);
+   return (*lhs) *= (*rhs);
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -190,7 +222,7 @@ template< typename MT    // Type of the array
 BLAZE_ALWAYS_INLINE bool trySet( const Array<MT>& arr, std::array< size_t, N > const& dims, const ET& value )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& arrdims = ( ~arr ).dimensions();
+   auto const& arrdims = ( *arr ).dimensions();
    ArrayDimForEach( arrdims, [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -227,7 +259,7 @@ template< typename MT    // Type of the array
 BLAZE_ALWAYS_INLINE bool tryAdd( const Array<MT>& arr, std::array< size_t, N > const& dims, const ET& value )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& arrdims = ( ~arr ).dimensions();
+   auto const& arrdims = ( *arr ).dimensions();
    ArrayDimForEach( arrdims, [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -264,7 +296,7 @@ template< typename MT    // Type of the array
 BLAZE_ALWAYS_INLINE bool trySub( const Array<MT>& arr, std::array< size_t, N > const& dims, const ET& value )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& arrdims = ( ~arr ).dimensions();
+   auto const& arrdims = ( *arr ).dimensions();
    ArrayDimForEach( arrdims, [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -301,7 +333,7 @@ template< typename MT    // Type of the array
 BLAZE_ALWAYS_INLINE bool tryMult( const Array<MT>& arr, std::array< size_t, N > const& dims, const ET& value )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& arrdims = ( ~arr ).dimensions();
+   auto const& arrdims = ( *arr ).dimensions();
    ArrayDimForEach( arrdims, [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -341,12 +373,12 @@ template< typename MT    // Type of the array
 BLAZE_ALWAYS_INLINE bool
    tryMult( const Array<MT>& arr, std::array< size_t, N > const& sizes, std::array< size_t, N > const& indices, const ET& value )
 {
-//    BLAZE_INTERNAL_ASSERT( row <= (~tens).rows(), "Invalid row access index" );
-//    BLAZE_INTERNAL_ASSERT( column <= (~tens).columns(), "Invalid column access index" );
-//    BLAZE_INTERNAL_ASSERT( page <= (~tens).pages(), "Invalid page access index" );
-//    BLAZE_INTERNAL_ASSERT( row + m <= (~tens).rows(), "Invalid number of rows" );
-//    BLAZE_INTERNAL_ASSERT( column + n <= (~tens).columns(), "Invalid number of columns" );
-//    BLAZE_INTERNAL_ASSERT( page + o <= (~tens).pages(), "Invalid number of pages" );
+//    BLAZE_INTERNAL_ASSERT( row <= (*tens).rows(), "Invalid row access index" );
+//    BLAZE_INTERNAL_ASSERT( column <= (*tens).columns(), "Invalid column access index" );
+//    BLAZE_INTERNAL_ASSERT( page <= (*tens).pages(), "Invalid page access index" );
+//    BLAZE_INTERNAL_ASSERT( row + m <= (*tens).rows(), "Invalid number of rows" );
+//    BLAZE_INTERNAL_ASSERT( column + n <= (*tens).columns(), "Invalid number of columns" );
+//    BLAZE_INTERNAL_ASSERT( page + o <= (*tens).pages(), "Invalid number of pages" );
 //
 //    MAYBE_UNUSED( tens, page, row, column, o, m, n, value );
 
@@ -379,7 +411,7 @@ template< typename MT    // Type of the array
 BLAZE_ALWAYS_INLINE bool tryDiv( const Array<MT>& arr, std::array< size_t, N > const& dims, const ET& value )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& arrdims = ( ~arr ).dimensions();
+   auto const& arrdims = ( *arr ).dimensions();
    ArrayDimForEach( arrdims, [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -460,8 +492,8 @@ BLAZE_ALWAYS_INLINE bool tryAssign( const Array<MT>& lhs, const Array<VT>& rhs,
                                     std::array< size_t, N > const& dims )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& rhsdims = ( ~rhs ).dimensions();
-   ArrayDimForEach( ( ~lhs ).dimensions(), [&]( size_t i, size_t dim ) {
+   auto const& rhsdims = ( *rhs ).dimensions();
+   ArrayDimForEach( ( *lhs ).dimensions(), [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( rhsdims[i] != dim, "Invalid array access index" );
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -498,8 +530,8 @@ BLAZE_ALWAYS_INLINE bool tryAddAssign( const Array<TT1>& lhs, const Array<TT2>& 
                                        std::array< size_t, N > const& dims )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& rhsdims = ( ~rhs ).dimensions();
-   ArrayDimForEach( ( ~lhs ).dimensions(), [&]( size_t i, size_t dim ) {
+   auto const& rhsdims = ( *rhs ).dimensions();
+   ArrayDimForEach( ( *lhs ).dimensions(), [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( rhsdims[i] != dim, "Invalid array access index" );
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -536,8 +568,8 @@ BLAZE_ALWAYS_INLINE bool trySubAssign( const Array<TT1>& lhs, const Array<TT2>& 
                                        std::array< size_t, N > const& dims )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& rhsdims = ( ~rhs ).dimensions();
-   ArrayDimForEach( ( ~lhs ).dimensions(), [&]( size_t i, size_t dim ) {
+   auto const& rhsdims = ( *rhs ).dimensions();
+   ArrayDimForEach( ( *lhs ).dimensions(), [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( rhsdims[i] != dim, "Invalid array access index" );
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -575,8 +607,8 @@ BLAZE_ALWAYS_INLINE bool tryMultAssign( const Array<TT1>& lhs, const Array<TT2>&
                                          std::array< size_t, N > const& dims )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& rhsdims = ( ~rhs ).dimensions();
-   ArrayDimForEach( ( ~lhs ).dimensions(), [&]( size_t i, size_t dim ) {
+   auto const& rhsdims = ( *rhs ).dimensions();
+   ArrayDimForEach( ( *lhs ).dimensions(), [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( rhsdims[i] != dim, "Invalid array access index" );
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -613,8 +645,8 @@ BLAZE_ALWAYS_INLINE bool trySchurAssign( const Array<TT1>& lhs, const Array<TT2>
                                          std::array< size_t, N > const& dims )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& rhsdims = ( ~rhs ).dimensions();
-   ArrayDimForEach( ( ~lhs ).dimensions(), [&]( size_t i, size_t dim ) {
+   auto const& rhsdims = ( *rhs ).dimensions();
+   ArrayDimForEach( ( *lhs ).dimensions(), [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( rhsdims[i] != dim, "Invalid array access index" );
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -651,8 +683,8 @@ BLAZE_ALWAYS_INLINE bool tryDivAssign( const Array<TT1>& lhs, const Array<TT2>& 
                                        std::array< size_t, N > const& dims )
 {
 #if defined(BLAZE_INTERNAL_ASSERTION)
-   auto const& rhsdims = ( ~rhs ).dimensions();
-   ArrayDimForEach( ( ~lhs ).dimensions(), [&]( size_t i, size_t dim ) {
+   auto const& rhsdims = ( *rhs ).dimensions();
+   ArrayDimForEach( ( *lhs ).dimensions(), [&]( size_t i, size_t dim ) {
       BLAZE_INTERNAL_ASSERT( rhsdims[i] != dim, "Invalid array access index" );
       BLAZE_INTERNAL_ASSERT( dims[i] < dim, "Invalid array access index" );
    } );
@@ -776,7 +808,7 @@ BLAZE_ALWAYS_INLINE bool isSame( const Array<TT1>& a, const Array<TT2>& b ) noex
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE typename MT::Iterator begin( Array<MT>& array, size_t i, size_t k )
 {
-   return (~array).begin(i, k);
+   return (*array).begin(i, k);
 }
 //*************************************************************************************************
 
@@ -797,7 +829,7 @@ BLAZE_ALWAYS_INLINE typename MT::Iterator begin( Array<MT>& array, size_t i, siz
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE typename MT::ConstIterator begin( const Array<MT>& array, size_t i, size_t k )
 {
-   return (~array).begin(i, k);
+   return (*array).begin(i, k);
 }
 //*************************************************************************************************
 
@@ -818,7 +850,7 @@ BLAZE_ALWAYS_INLINE typename MT::ConstIterator begin( const Array<MT>& array, si
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE typename MT::ConstIterator cbegin( const Array<MT>& array, size_t i, size_t k )
 {
-   return (~array).cbegin(i, k);
+   return (*array).cbegin(i, k);
 }
 //*************************************************************************************************
 
@@ -839,7 +871,7 @@ BLAZE_ALWAYS_INLINE typename MT::ConstIterator cbegin( const Array<MT>& array, s
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE typename MT::Iterator end( Array<MT>& array, size_t i, size_t k )
 {
-   return (~array).end(i, k);
+   return (*array).end(i, k);
 }
 //*************************************************************************************************
 
@@ -860,7 +892,7 @@ BLAZE_ALWAYS_INLINE typename MT::Iterator end( Array<MT>& array, size_t i, size_
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE typename MT::ConstIterator end( const Array<MT>& array, size_t i, size_t k )
 {
-   return (~array).end(i, k);
+   return (*array).end(i, k);
 }
 //*************************************************************************************************
 
@@ -881,7 +913,7 @@ BLAZE_ALWAYS_INLINE typename MT::ConstIterator end( const Array<MT>& array, size
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE typename MT::ConstIterator cend( const Array<MT>& array, size_t i, size_t k )
 {
-   return (~array).cend(i, k);
+   return (*array).cend(i, k);
 }
 //*************************************************************************************************
 
@@ -896,7 +928,7 @@ BLAZE_ALWAYS_INLINE typename MT::ConstIterator cend( const Array<MT>& array, siz
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE constexpr size_t rows( const Array<MT>& array ) noexcept
 {
-   return (~array).rows();
+   return (*array).rows();
 }
 //*************************************************************************************************
 
@@ -911,7 +943,7 @@ BLAZE_ALWAYS_INLINE constexpr size_t rows( const Array<MT>& array ) noexcept
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE constexpr size_t columns( const Array<MT>& array ) noexcept
 {
-   return (~array).columns();
+   return (*array).columns();
 }
 //*************************************************************************************************
 
@@ -926,7 +958,7 @@ BLAZE_ALWAYS_INLINE constexpr size_t columns( const Array<MT>& array ) noexcept
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE constexpr size_t pages( const Array<MT>& array ) noexcept
 {
-   return (~array).pages();
+   return (*array).pages();
 }
 //*************************************************************************************************
 
@@ -941,7 +973,7 @@ BLAZE_ALWAYS_INLINE constexpr size_t pages( const Array<MT>& array ) noexcept
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE constexpr size_t quats( const Array<MT>& array ) noexcept
 {
-   return (~array).quats();
+   return (*array).quats();
 }
 //*************************************************************************************************
 
@@ -956,7 +988,7 @@ BLAZE_ALWAYS_INLINE constexpr size_t quats( const Array<MT>& array ) noexcept
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE constexpr size_t size( const Array<MT>& array ) noexcept
 {
-   return (~array).rows() * (~array).columns() * (~array).pages();
+   return (*array).rows() * (*array).columns() * (*array).pages();
 }
 //*************************************************************************************************
 
@@ -971,7 +1003,7 @@ BLAZE_ALWAYS_INLINE constexpr size_t size( const Array<MT>& array ) noexcept
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE size_t capacity( const Array<MT>& array ) noexcept
 {
-   return (~array).capacity();
+   return (*array).capacity();
 }
 //*************************************************************************************************
 
@@ -992,7 +1024,7 @@ BLAZE_ALWAYS_INLINE size_t capacity( const Array<MT>& array ) noexcept
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE size_t capacity( const Array<MT>& array, size_t i, size_t k ) noexcept
 {
-   return (~array).capacity( i, k );
+   return (*array).capacity( i, k );
 }
 //*************************************************************************************************
 
@@ -1007,7 +1039,7 @@ BLAZE_ALWAYS_INLINE size_t capacity( const Array<MT>& array, size_t i, size_t k 
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE size_t nonZeros( const Array<MT>& array )
 {
-   return (~array).nonZeros();
+   return (*array).nonZeros();
 }
 //*************************************************************************************************
 
@@ -1028,7 +1060,7 @@ BLAZE_ALWAYS_INLINE size_t nonZeros( const Array<MT>& array )
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE size_t nonZeros( const Array<MT>& array, size_t i, size_t k )
 {
-   return (~array).nonZeros( i, k );
+   return (*array).nonZeros( i, k );
 }
 //*************************************************************************************************
 
@@ -1056,7 +1088,7 @@ BLAZE_ALWAYS_INLINE EnableIf_t< !IsResizable_v<MT> >
 {
    MAYBE_UNUSED( preserve );
 
-   if( (~array).rows() != m || (~array).columns() != n || (~array).pages() != o) {
+   if( (*array).rows() != m || (*array).columns() != n || (*array).pages() != o) {
       BLAZE_THROW_INVALID_ARGUMENT( "Array cannot be resized" );
    }
 }
@@ -1081,7 +1113,7 @@ template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE EnableIf_t< IsResizable_v<MT> && !IsSquare_v<MT> >
    resize_backend( Array<MT>& array, size_t o, size_t m, size_t n, bool preserve )
 {
-   (~array).resize( o, m, n, preserve );
+   (*array).resize( o, m, n, preserve );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1109,7 +1141,7 @@ BLAZE_ALWAYS_INLINE EnableIf_t< IsResizable_v<MT> && !IsSquare_v<MT> >
 //       BLAZE_THROW_INVALID_ARGUMENT( "Invalid resize arguments for square array" );
 //    }
 //
-//    (~array).resize( m, preserve );
+//    (*array).resize( m, preserve );
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1191,7 +1223,7 @@ template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE EnableIf_t< IsShrinkable_v<MT> >
    shrinkToFit_backend( Array<MT>& array )
 {
-   (~array).shrinkToFit();
+   (*array).shrinkToFit();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1239,7 +1271,7 @@ BLAZE_ALWAYS_INLINE void shrinkToFit( Array<MT>& array )
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE void transpose( Array<MT>& array )
 {
-   (~array).transpose( );
+   (*array).transpose( );
 }
 //*************************************************************************************************
 
@@ -1265,7 +1297,7 @@ template< typename MT   // Type of the array
         , typename T >  // Type of the index initializer
 BLAZE_ALWAYS_INLINE void transpose( Array<MT>& array, const T* indices, size_t n )
 {
-   (~array).transpose( indices, n );
+   (*array).transpose( indices, n );
 }
 //*************************************************************************************************
 
@@ -1291,7 +1323,7 @@ template< typename MT   // Type of the array
         , typename T >  // Type of the index initializer
 BLAZE_ALWAYS_INLINE void transpose( Array<MT>& array, std::initializer_list<T> indices )
 {
-   (~array).transpose( indices.begin(), indices.size() );
+   (*array).transpose( indices.begin(), indices.size() );
 }
 //*************************************************************************************************
 
@@ -1316,7 +1348,7 @@ BLAZE_ALWAYS_INLINE void transpose( Array<MT>& array, std::initializer_list<T> i
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE void ctranspose( Array<MT>& array )
 {
-   (~array).ctranspose();
+   (*array).ctranspose();
 }
 //*************************************************************************************************
 
@@ -1342,7 +1374,7 @@ template< typename MT   // Type of the array
         , typename T >  // Type of the index initializer
 BLAZE_ALWAYS_INLINE void ctranspose( Array<MT>& array, const T* indices, size_t n )
 {
-   (~array).ctranspose( indices, n );
+   (*array).ctranspose( indices, n );
 }
 //*************************************************************************************************
 
@@ -1368,7 +1400,7 @@ template< typename MT   // Type of the array
         , typename T >  // Type of the index initializer
 BLAZE_ALWAYS_INLINE void ctranspose( Array<MT>& array, std::initializer_list<T> indices )
 {
-   (~array).ctranspose( indices.begin(), indices.size() );
+   (*array).ctranspose( indices.begin(), indices.size() );
 }
 //*************************************************************************************************
 
@@ -1428,7 +1460,7 @@ BLAZE_ALWAYS_INLINE void ctranspose( Array<MT>& array, std::initializer_list<T> 
 template< typename MT > // Type of the array
 inline const typename MT::ResultType evaluate( const Array<MT>& array )
 {
-   const typename MT::ResultType tmp( ~array );
+   const typename MT::ResultType tmp( *array );
    return tmp;
 }
 //*************************************************************************************************
@@ -1447,7 +1479,7 @@ inline const typename MT::ResultType evaluate( const Array<MT>& array )
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE constexpr bool isEmpty( const Array<MT>& array ) noexcept
 {
-   return size( ~array ) == 0UL;
+   return size( *array ) == 0UL;
 }
 //*************************************************************************************************
 
@@ -1465,7 +1497,7 @@ BLAZE_ALWAYS_INLINE constexpr bool isEmpty( const Array<MT>& array ) noexcept
 template< typename MT > // Type of the array
 BLAZE_ALWAYS_INLINE bool isSquare( const Array<MT>& array ) noexcept
 {
-   return ( IsSquare_v<MT> || ( (~array).rows() == (~array).columns() && (~array).rows() == (~array).pages() ) );
+   return ( IsSquare_v<MT> || ( (*array).rows() == (*array).columns() && (*array).rows() == (*array).pages() ) );
 }
 //*************************************************************************************************
 
@@ -1526,7 +1558,7 @@ BLAZE_ALWAYS_INLINE void assign_backend( Array<TT1>& lhs, const Array<TT2>& rhs 
 {
    BLAZE_FUNCTION_TRACE;
 
-   (~lhs).assign( ~rhs );
+   (*lhs).assign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1553,11 +1585,11 @@ BLAZE_ALWAYS_INLINE void assign( Array<TT1>& lhs, const Array<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   assign_backend( ~lhs, ~rhs );
+   assign_backend( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1579,7 +1611,7 @@ BLAZE_ALWAYS_INLINE void addAssign_backend( Array<TT1>& lhs, const Array<TT2>& r
 {
    BLAZE_FUNCTION_TRACE;
 
-   (~lhs).addAssign( ~rhs );
+   (*lhs).addAssign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1606,11 +1638,11 @@ BLAZE_ALWAYS_INLINE void addAssign( Array<TT1>& lhs, const Array<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   addAssign_backend( ~lhs, ~rhs );
+   addAssign_backend( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1632,7 +1664,7 @@ BLAZE_ALWAYS_INLINE void subAssign_backend( Array<TT1>& lhs, const Array<TT2>& r
 {
    BLAZE_FUNCTION_TRACE;
 
-   (~lhs).subAssign( ~rhs );
+   (*lhs).subAssign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1659,11 +1691,11 @@ BLAZE_ALWAYS_INLINE void subAssign( Array<TT1>& lhs, const Array<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   subAssign_backend( ~lhs, ~rhs );
+   subAssign_backend( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1685,7 +1717,7 @@ BLAZE_ALWAYS_INLINE void schurAssign_backend( Array<TT1>& lhs, const Array<TT2>&
 {
    BLAZE_FUNCTION_TRACE;
 
-   (~lhs).schurAssign( ~rhs );
+   (*lhs).schurAssign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1712,11 +1744,11 @@ BLAZE_ALWAYS_INLINE void schurAssign( Array<TT1>& lhs, const Array<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   schurAssign_backend( ~lhs, ~rhs );
+   schurAssign_backend( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1743,9 +1775,9 @@ BLAZE_ALWAYS_INLINE void multAssign( Array<TT1>& lhs, const Array<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).rows(), "Invalid array sizes" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).rows(), "Invalid array sizes" );
 
-   (~lhs).multAssign( ~rhs );
+   (*lhs).multAssign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1770,7 +1802,7 @@ BLAZE_ALWAYS_INLINE void multAssign( Array<TT1>& lhs, const Array<TT2>& rhs )
 template< typename TT > // Type of the array
 BLAZE_ALWAYS_INLINE TT& derestrict( Array<TT>& array )
 {
-   return ~array;
+   return *array;
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1793,7 +1825,7 @@ BLAZE_ALWAYS_INLINE TT& derestrict( Array<TT>& array )
 template< typename TT > // Type of the array
 inline decltype(auto) unview( Array<TT>& array )
 {
-   return ~array;
+   return *array;
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1816,7 +1848,7 @@ inline decltype(auto) unview( Array<TT>& array )
 template< typename TT > // Type of the array
 inline decltype(auto) unview( const Array<TT>& array )
 {
-   return ~array;
+   return *array;
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DArrDArrEqualExpr.h
+++ b/blaze_tensor/math/expressions/DArrDArrEqualExpr.h
@@ -114,20 +114,20 @@ inline bool //EnableIf_t< !DArrDArrEqualExprHelper<MT1,MT2>::value, bool >
    using CT2 = CompositeType_t<MT2>;
 
    // Early exit in case the array sizes don't match
-   if( ( ~lhs ).dimensions() != ( ~rhs ).dimensions() ) {
+   if( ( *lhs ).dimensions() != ( *rhs ).dimensions() ) {
       return false;
    }
 
    constexpr size_t N = MT1::num_dimensions;
 
    // Evaluation of the two dense array operands
-   CT1 A( ~lhs );
-   CT2 B( ~rhs );
+   CT1 A( *lhs );
+   CT2 B( *rhs );
 
    // In order to compare the two arrays, the data values of the lower-order data
    // type are converted to the higher-order data type within the equal function.
    return ArrayForEachGroupedAllOf(
-      ( ~lhs ).dimensions(), [&]( std::array< size_t, N > const& dims ) {
+      ( *lhs ).dimensions(), [&]( std::array< size_t, N > const& dims ) {
          return equal( A( dims ), B( dims ) );
       } );
 }
@@ -160,15 +160,15 @@ inline bool //EnableIf_t< !DArrDArrEqualExprHelper<MT1,MT2>::value, bool >
 //    using XT2 = RemoveReference_t<CT2>;
 //
 //    // Early exit in case the array sizes don't match
-//    auto const& rhsdims = ( ~rhs ).dimensions();
-//    if( ArrayDimAnyOf( ( ~lhs ).dimensions(),
+//    auto const& rhsdims = ( *rhs ).dimensions();
+//    if( ArrayDimAnyOf( ( *lhs ).dimensions(),
 //           [&]( size_t i, size_t dim ) { return dim != rhsdims[i]; } ) ) {
 //       return false;
 //    }
 //
 //    // Evaluation of the two dense array operands
-//    CT1 A( ~lhs );
-//    CT2 B( ~rhs );
+//    CT1 A( *lhs );
+//    CT2 B( *rhs );
 //
 //    constexpr size_t SIMDSIZE = SIMDTrait< ElementType_t<MT1> >::size;
 //    constexpr bool remainder( !IsPadded_v<XT1> || !IsPadded_v<XT2> );

--- a/blaze_tensor/math/expressions/DArrDArrMapExpr.h
+++ b/blaze_tensor/math/expressions/DArrDArrMapExpr.h
@@ -631,7 +631,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense array operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense array operand
@@ -639,7 +639,7 @@ class DArrDArrMapExpr
       BLAZE_INTERNAL_ASSERT( A.dimensions() == rhs.lhs_.dimensions(), "Invalid number of elements" );
       BLAZE_INTERNAL_ASSERT( B.dimensions() == rhs.rhs_.dimensions(), "Invalid number of elements" );
 
-      assign( ~lhs, map( A, B, rhs.op_ ) );
+      assign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -664,7 +664,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense array operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense array operand
@@ -672,7 +672,7 @@ class DArrDArrMapExpr
       BLAZE_INTERNAL_ASSERT( A.dimensions() == rhs.lhs_.dimensions(), "Invalid number of elements" );
       BLAZE_INTERNAL_ASSERT( B.dimensions() == rhs.rhs_.dimensions(), "Invalid number of elements" );
 
-      addAssign( ~lhs, map( A, B, rhs.op_ ) );
+      addAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -697,7 +697,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense array operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense array operand
@@ -705,7 +705,7 @@ class DArrDArrMapExpr
       BLAZE_INTERNAL_ASSERT( A.dimensions() == rhs.lhs_.dimensions(), "Invalid number of elements" );
       BLAZE_INTERNAL_ASSERT( B.dimensions() == rhs.rhs_.dimensions(), "Invalid number of elements" );
 
-      subAssign( ~lhs, map( A, B, rhs.op_ ) );
+      subAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -730,7 +730,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense array operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense array operand
@@ -738,7 +738,7 @@ class DArrDArrMapExpr
       BLAZE_INTERNAL_ASSERT( A.dimensions() == rhs.lhs_.dimensions(), "Invalid number of elements" );
       BLAZE_INTERNAL_ASSERT( B.dimensions() == rhs.rhs_.dimensions(), "Invalid number of elements" );
 
-      schurAssign( ~lhs, map( A, B, rhs.op_ ) );
+      schurAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -763,7 +763,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense array operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense array operand
@@ -771,7 +771,7 @@ class DArrDArrMapExpr
       BLAZE_INTERNAL_ASSERT( A.dimensions() == rhs.lhs_.dimensions(), "Invalid number of elements" );
       BLAZE_INTERNAL_ASSERT( B.dimensions() == rhs.rhs_.dimensions(), "Invalid number of elements" );
 
-      smpAssign( ~lhs, map( A, B, rhs.op_ ) );
+      smpAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -797,7 +797,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense array operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense array operand
@@ -805,7 +805,7 @@ class DArrDArrMapExpr
       BLAZE_INTERNAL_ASSERT( A.dimensions() == rhs.lhs_.dimensions(), "Invalid number of elements" );
       BLAZE_INTERNAL_ASSERT( B.dimensions() == rhs.rhs_.dimensions(), "Invalid number of elements" );
 
-      smpAddAssign( ~lhs, map( A, B, rhs.op_ ) );
+      smpAddAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -831,7 +831,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense array operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense array operand
@@ -839,7 +839,7 @@ class DArrDArrMapExpr
       BLAZE_INTERNAL_ASSERT( A.dimensions() == rhs.lhs_.dimensions(), "Invalid number of elements" );
       BLAZE_INTERNAL_ASSERT( B.dimensions() == rhs.rhs_.dimensions(), "Invalid number of elements" );
 
-      smpSubAssign( ~lhs, map( A, B, rhs.op_ ) );
+      smpSubAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -865,7 +865,7 @@ class DArrDArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense array operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense array operand
@@ -873,7 +873,7 @@ class DArrDArrMapExpr
       BLAZE_INTERNAL_ASSERT( A.dimensions() == rhs.lhs_.dimensions(), "Invalid number of elements" );
       BLAZE_INTERNAL_ASSERT( B.dimensions() == rhs.rhs_.dimensions(), "Invalid number of elements" );
 
-      smpSchurAssign( ~lhs, map( A, B, rhs.op_ ) );
+      smpSchurAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -925,12 +925,12 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   if( (~lhs).dimensions() != (~rhs).dimensions() ) {
+   if( (*lhs).dimensions() != (*rhs).dimensions() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Array sizes do not match" );
    }
 
    using ReturnType = const DArrDArrMapExpr<MT1,MT2,OP>;
-   return ReturnType( ~lhs, ~rhs, op );
+   return ReturnType( *lhs, *rhs, op );
 }
 //*************************************************************************************************
 
@@ -960,7 +960,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Min() );
+   return map( *lhs, *rhs, Min() );
 }
 //*************************************************************************************************
 
@@ -990,7 +990,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Max() );
+   return map( *lhs, *rhs, Max() );
 }
 //*************************************************************************************************
 
@@ -1020,7 +1020,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Hypot() );
+   return map( *lhs, *rhs, Hypot() );
 }
 //*************************************************************************************************
 
@@ -1050,7 +1050,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Pow() );
+   return map( *lhs, *rhs, Pow() );
 }
 //*************************************************************************************************
 
@@ -1080,7 +1080,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Atan2() );
+   return map( *lhs, *rhs, Atan2() );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DArrMapExpr.h
+++ b/blaze_tensor/math/expressions/DArrMapExpr.h
@@ -600,10 +600,10 @@ class DArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
-      assign( ~lhs, rhs.dm_ );
-      assign( ~lhs, rhs.op_( ~lhs ) );
+      assign( *lhs, rhs.dm_ );
+      assign( *lhs, rhs.op_( *lhs ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -633,10 +633,10 @@ class DArrMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( serial( rhs.dm_ ) );
-      assign( ~lhs, map( tmp, rhs.op_ ) );
+      assign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -664,10 +664,10 @@ class DArrMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( serial( rhs.dm_ ) );
-      addAssign( ~lhs, map( tmp, rhs.op_ ) );
+      addAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -695,10 +695,10 @@ class DArrMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( serial( rhs.dm_ ) );
-      subAssign( ~lhs, map( tmp, rhs.op_ ) );
+      subAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -726,10 +726,10 @@ class DArrMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( serial( rhs.dm_ ) );
-      schurAssign( ~lhs, map( tmp, rhs.op_ ) );
+      schurAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -756,10 +756,10 @@ class DArrMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
-      smpAssign( ~lhs, rhs.dm_ );
-      smpAssign( ~lhs, rhs.op_( ~lhs ) );
+      smpAssign( *lhs, rhs.dm_ );
+      smpAssign( *lhs, rhs.op_( *lhs ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -789,10 +789,10 @@ class DArrMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( rhs.dm_ );
-      smpAssign( ~lhs, map( tmp, rhs.op_ ) );
+      smpAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -820,10 +820,10 @@ class DArrMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( rhs.dm_ );
-      smpAddAssign( ~lhs, map( tmp, rhs.op_ ) );
+      smpAddAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -851,10 +851,10 @@ class DArrMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( rhs.dm_ );
-      smpSubAssign( ~lhs, map( tmp, rhs.op_ ) );
+      smpSubAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -882,10 +882,10 @@ class DArrMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( rhs.dm_ );
-      smpSchurAssign( ~lhs, map( tmp, rhs.op_ ) );
+      smpSchurAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -932,7 +932,7 @@ inline decltype(auto) map( const DenseArray<MT>& dm, OP op )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,OP>;
-   return ReturnType( ~dm, op );
+   return ReturnType( *dm, op );
 }
 //*************************************************************************************************
 
@@ -962,7 +962,7 @@ inline decltype(auto) forEach( const DenseArray<MT>& dm, OP op )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,OP>;
-   return ReturnType( ~dm, op );
+   return ReturnType( *dm, op );
 }
 //*************************************************************************************************
 
@@ -990,7 +990,7 @@ inline decltype(auto) abs( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Abs>;
-   return ReturnType( ~dm, Abs() );
+   return ReturnType( *dm, Abs() );
 }
 //*************************************************************************************************
 
@@ -1018,7 +1018,7 @@ inline decltype(auto) sign( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Sign>;
-   return ReturnType( ~dm, Sign() );
+   return ReturnType( *dm, Sign() );
 }
 //*************************************************************************************************
 
@@ -1046,7 +1046,7 @@ inline decltype(auto) floor( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Floor>;
-   return ReturnType( ~dm, Floor() );
+   return ReturnType( *dm, Floor() );
 }
 //*************************************************************************************************
 
@@ -1074,7 +1074,7 @@ inline decltype(auto) ceil( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Ceil>;
-   return ReturnType( ~dm, Ceil() );
+   return ReturnType( *dm, Ceil() );
 }
 //*************************************************************************************************
 
@@ -1102,7 +1102,7 @@ inline decltype(auto) trunc( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Trunc>;
-   return ReturnType( ~dm, Trunc() );
+   return ReturnType( *dm, Trunc() );
 }
 //*************************************************************************************************
 
@@ -1130,7 +1130,7 @@ inline decltype(auto) round( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Round>;
-   return ReturnType( ~dm, Round() );
+   return ReturnType( *dm, Round() );
 }
 //*************************************************************************************************
 
@@ -1158,7 +1158,7 @@ inline decltype(auto) conj( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Conj>;
-   return ReturnType( ~dm, Conj() );
+   return ReturnType( *dm, Conj() );
 }
 //*************************************************************************************************
 
@@ -1195,7 +1195,7 @@ inline decltype(auto) ctrans( const DenseArray<MT>& dm, RTAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( conj( ~dm ), args... );
+   return trans( conj( *dm ), args... );
 }
 //*************************************************************************************************
 
@@ -1223,7 +1223,7 @@ inline decltype(auto) real( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Real>;
-   return ReturnType( ~dm, Real() );
+   return ReturnType( *dm, Real() );
 }
 //*************************************************************************************************
 
@@ -1251,7 +1251,7 @@ inline decltype(auto) imag( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Imag>;
-   return ReturnType( ~dm, Imag() );
+   return ReturnType( *dm, Imag() );
 }
 //*************************************************************************************************
 
@@ -1282,7 +1282,7 @@ inline decltype(auto) sqrt( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Sqrt>;
-   return ReturnType( ~dm, Sqrt() );
+   return ReturnType( *dm, Sqrt() );
 }
 //*************************************************************************************************
 
@@ -1313,7 +1313,7 @@ inline decltype(auto) invsqrt( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,InvSqrt>;
-   return ReturnType( ~dm, InvSqrt() );
+   return ReturnType( *dm, InvSqrt() );
 }
 //*************************************************************************************************
 
@@ -1344,7 +1344,7 @@ inline decltype(auto) cbrt( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Cbrt>;
-   return ReturnType( ~dm, Cbrt() );
+   return ReturnType( *dm, Cbrt() );
 }
 //*************************************************************************************************
 
@@ -1375,7 +1375,7 @@ inline decltype(auto) invcbrt( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,InvCbrt>;
-   return ReturnType( ~dm, InvCbrt() );
+   return ReturnType( *dm, InvCbrt() );
 }
 //*************************************************************************************************
 
@@ -1405,7 +1405,7 @@ inline decltype(auto) clamp( const DenseArray<MT>& dm, const DT& min, const DT& 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~dm, bind2nd( bind3rd( Clamp(), max ), min ) );
+   return map( *dm, bind2nd( bind3rd( Clamp(), max ), min ) );
 }
 //*************************************************************************************************
 
@@ -1436,7 +1436,7 @@ inline decltype(auto) pow( const DenseArray<MT>& dm, ST exp )
    BLAZE_FUNCTION_TRACE;
 
    using ScalarType = MultTrait_t< UnderlyingBuiltin_t<MT>, ST >;
-   return map( ~dm, blaze::bind2nd( Pow(), ScalarType( exp ) ) );
+   return map( *dm, blaze::bind2nd( Pow(), ScalarType( exp ) ) );
 }
 //*************************************************************************************************
 
@@ -1464,7 +1464,7 @@ inline decltype(auto) exp( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Exp>;
-   return ReturnType( ~dm, Exp() );
+   return ReturnType( *dm, Exp() );
 }
 //*************************************************************************************************
 
@@ -1492,7 +1492,7 @@ inline decltype(auto) exp2( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Exp2>;
-   return ReturnType( ~dm, Exp2() );
+   return ReturnType( *dm, Exp2() );
 }
 //*************************************************************************************************
 
@@ -1520,7 +1520,7 @@ inline decltype(auto) exp10( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Exp10>;
-   return ReturnType( ~dm, Exp10() );
+   return ReturnType( *dm, Exp10() );
 }
 //*************************************************************************************************
 
@@ -1551,7 +1551,7 @@ inline decltype(auto) log( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Log>;
-   return ReturnType( ~dm, Log() );
+   return ReturnType( *dm, Log() );
 }
 //*************************************************************************************************
 
@@ -1582,7 +1582,7 @@ inline decltype(auto) log2( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Log2>;
-   return ReturnType( ~dm, Log2() );
+   return ReturnType( *dm, Log2() );
 }
 //*************************************************************************************************
 
@@ -1613,7 +1613,7 @@ inline decltype(auto) log10( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Log10>;
-   return ReturnType( ~dm, Log10() );
+   return ReturnType( *dm, Log10() );
 }
 //*************************************************************************************************
 
@@ -1641,7 +1641,7 @@ inline decltype(auto) sin( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Sin>;
-   return ReturnType( ~dm, Sin() );
+   return ReturnType( *dm, Sin() );
 }
 //*************************************************************************************************
 
@@ -1672,7 +1672,7 @@ inline decltype(auto) asin( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Asin>;
-   return ReturnType( ~dm, Asin() );
+   return ReturnType( *dm, Asin() );
 }
 //*************************************************************************************************
 
@@ -1700,7 +1700,7 @@ inline decltype(auto) sinh( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Sinh>;
-   return ReturnType( ~dm, Sinh() );
+   return ReturnType( *dm, Sinh() );
 }
 //*************************************************************************************************
 
@@ -1728,7 +1728,7 @@ inline decltype(auto) asinh( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Asinh>;
-   return ReturnType( ~dm, Asinh() );
+   return ReturnType( *dm, Asinh() );
 }
 //*************************************************************************************************
 
@@ -1756,7 +1756,7 @@ inline decltype(auto) cos( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Cos>;
-   return ReturnType( ~dm, Cos() );
+   return ReturnType( *dm, Cos() );
 }
 //*************************************************************************************************
 
@@ -1787,7 +1787,7 @@ inline decltype(auto) acos( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Acos>;
-   return ReturnType( ~dm, Acos() );
+   return ReturnType( *dm, Acos() );
 }
 //*************************************************************************************************
 
@@ -1815,7 +1815,7 @@ inline decltype(auto) cosh( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Cosh>;
-   return ReturnType( ~dm, Cosh() );
+   return ReturnType( *dm, Cosh() );
 }
 //*************************************************************************************************
 
@@ -1846,7 +1846,7 @@ inline decltype(auto) acosh( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Acosh>;
-   return ReturnType( ~dm, Acosh() );
+   return ReturnType( *dm, Acosh() );
 }
 //*************************************************************************************************
 
@@ -1874,7 +1874,7 @@ inline decltype(auto) tan( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Tan>;
-   return ReturnType( ~dm, Tan() );
+   return ReturnType( *dm, Tan() );
 }
 //*************************************************************************************************
 
@@ -1902,7 +1902,7 @@ inline decltype(auto) atan( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Atan>;
-   return ReturnType( ~dm, Atan() );
+   return ReturnType( *dm, Atan() );
 }
 //*************************************************************************************************
 
@@ -1933,7 +1933,7 @@ inline decltype(auto) tanh( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Tanh>;
-   return ReturnType( ~dm, Tanh() );
+   return ReturnType( *dm, Tanh() );
 }
 //*************************************************************************************************
 
@@ -1964,7 +1964,7 @@ inline decltype(auto) atanh( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Atanh>;
-   return ReturnType( ~dm, Atanh() );
+   return ReturnType( *dm, Atanh() );
 }
 //*************************************************************************************************
 
@@ -1992,7 +1992,7 @@ inline decltype(auto) erf( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Erf>;
-   return ReturnType( ~dm, Erf() );
+   return ReturnType( *dm, Erf() );
 }
 //*************************************************************************************************
 
@@ -2020,7 +2020,7 @@ inline decltype(auto) erfc( const DenseArray<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DArrMapExpr<MT,Erfc>;
-   return ReturnType( ~dm, Erfc() );
+   return ReturnType( *dm, Erfc() );
 }
 //*************************************************************************************************
 
@@ -2220,7 +2220,7 @@ inline decltype(auto) conj( const DQuatTransExpr<DArrMapExpr<MT,Conj>, CTAs... >
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DQuatTransExpr<MT,CTAs...>;
-   return ReturnType( dm.operand().operand(), (~dm).idces() );
+   return ReturnType( dm.operand().operand(), (*dm).idces() );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DArrNormExpr.h
+++ b/blaze_tensor/math/expressions/DArrNormExpr.h
@@ -165,22 +165,22 @@ decltype(auto) norm_backend( const DenseArray<MT>& dm, Abs abs, Power power, Roo
    using ET = ElementType_t<MT>;
    using RT = decltype( evaluate( root( std::declval<ET>() ) ) );
 
-   if( ArrayDimAnyOf( ( ~dm ).dimensions(),
+   if( ArrayDimAnyOf( ( *dm ).dimensions(),
           []( size_t i, size_t dim ) { return dim == 0; } ) ) {
       return RT{};
    }
 
-   CT tmp( ~dm );
+   CT tmp( *dm );
 
-   BLAZE_INTERNAL_ASSERT( tmp.dimensions() == (~dm).dimensions(), "Invalid number of elements" );
+   BLAZE_INTERNAL_ASSERT( tmp.dimensions() == (*dm).dimensions(), "Invalid number of elements" );
 
-   using AT = RemoveCV_t<RemoveReference_t< decltype( ~dm ) > >;
+   using AT = RemoveCV_t<RemoveReference_t< decltype( *dm ) > >;
    constexpr size_t N = AT::num_dimensions;
 
    std::array< size_t, N > dims{};
    ET norm( power( abs( tmp( dims ) ) ) );
 
-   ArrayForEachGrouped( ( ~dm ).dimensions(),
+   ArrayForEachGrouped( ( *dm ).dimensions(),
       [&]( std::array< size_t, N > const& ds ) {
          norm += power( abs( tmp( ds ) ) );
       } );
@@ -211,7 +211,7 @@ decltype(auto) norm( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, SqrAbs(), Noop(), Sqrt() );
+   return norm_backend( *dm, SqrAbs(), Noop(), Sqrt() );
 }
 //*************************************************************************************************
 
@@ -236,7 +236,7 @@ decltype(auto) sqrNorm( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, SqrAbs(), Noop(), Noop() );
+   return norm_backend( *dm, SqrAbs(), Noop(), Noop() );
 }
 //*************************************************************************************************
 
@@ -261,7 +261,7 @@ decltype(auto) l1Norm( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, Abs(), Noop(), Noop() );
+   return norm_backend( *dm, Abs(), Noop(), Noop() );
 }
 //*************************************************************************************************
 
@@ -286,7 +286,7 @@ decltype(auto) l2Norm( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, SqrAbs(), Noop(), Sqrt() );
+   return norm_backend( *dm, SqrAbs(), Noop(), Sqrt() );
 }
 //*************************************************************************************************
 
@@ -311,7 +311,7 @@ decltype(auto) l3Norm( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, Abs(), Pow3(), Cbrt() );
+   return norm_backend( *dm, Abs(), Pow3(), Cbrt() );
 }
 //*************************************************************************************************
 
@@ -336,7 +336,7 @@ decltype(auto) l4Norm( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, SqrAbs(), Pow2(), Qdrt() );
+   return norm_backend( *dm, SqrAbs(), Pow2(), Qdrt() );
 }
 //*************************************************************************************************
 
@@ -371,7 +371,7 @@ decltype(auto) lpNorm( const DenseArray<MT>& dm, ST p )
 
    using ScalarType = MultTrait_t< UnderlyingBuiltin_t<MT>, decltype( inv( p ) ) >;
    using UnaryPow = Bind2nd<Pow,ScalarType>;
-   return norm_backend( ~dm, Abs(), UnaryPow( Pow(), p ), UnaryPow( Pow(), inv( p ) ) );
+   return norm_backend( *dm, Abs(), UnaryPow( Pow(), p ), UnaryPow( Pow(), inv( p ) ) );
 }
 //*************************************************************************************************
 
@@ -404,7 +404,7 @@ inline decltype(auto) lpNorm( const DenseArray<MT>& dm )
    using Norms = TypeList< L1Norm, L2Norm, L3Norm, L4Norm, LpNorm<P> >;
    using Norm  = typename TypeAt< Norms, min( P-1UL, 4UL ) >::Type;
 
-   return Norm()( ~dm );
+   return Norm()( *dm );
 }
 //*************************************************************************************************
 
@@ -429,7 +429,7 @@ decltype(auto) maxNorm( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return max( abs( ~dm ) );
+   return max( abs( *dm ) );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DArrReduceExpr.h
+++ b/blaze_tensor/math/expressions/DArrReduceExpr.h
@@ -603,10 +603,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense array operand
-      assign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      assign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -631,10 +631,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense array operand
-      addAssign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      addAssign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -660,10 +660,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense array operand
-      subAssign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      subAssign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -689,10 +689,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense array operand
-      multAssign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      multAssign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -717,10 +717,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense array operand
-      divAssign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      divAssign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -745,10 +745,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense array operand
-      smpAssign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      smpAssign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -774,10 +774,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense array operand
-      smpAddAssign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      smpAddAssign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -803,10 +803,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense array operand
-      smpSubAssign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      smpSubAssign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -832,10 +832,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense array operand
-      smpMultAssign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      smpMultAssign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -861,10 +861,10 @@ class ReducedArray
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense array operand
-      smpDivAssign( ~lhs, reduce<R>( tmp, rhs.op_ ) );
+      smpDivAssign( *lhs, reduce<R>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -943,26 +943,26 @@ inline ElementType_t<MT> darrayreduce( const DenseArray<MT>& dm, OP op )
    using ET = ElementType_t<MT>;
 
    constexpr size_t N =
-      RemoveCV_t< RemoveReference_t< decltype( ~dm ) > >::num_dimensions;
+      RemoveCV_t< RemoveReference_t< decltype( *dm ) > >::num_dimensions;
 
    std::array< size_t, N > dims{};
 
-   if( ArrayDimAnyOf( ( ~dm ).dimensions(),
+   if( ArrayDimAnyOf( ( *dm ).dimensions(),
           []( size_t, size_t dim ) { return dim == 0; } ) )
       return ET{};
 
-   if( ArrayDimAllOf( ( ~dm ).dimensions(),
+   if( ArrayDimAllOf( ( *dm ).dimensions(),
           []( size_t, size_t dim ) { return dim == 1; } ) )
-      return ( ~dm )( dims );
+      return ( *dm )( dims );
 
-   CT tmp( ~dm );
+   CT tmp( *dm );
 
-   BLAZE_INTERNAL_ASSERT( tmp.dimensions() == (~dm).dimensions(), "Invalid number of elements" );
+   BLAZE_INTERNAL_ASSERT( tmp.dimensions() == (*dm).dimensions(), "Invalid number of elements" );
 
-   ET redux = ( ~dm )( dims );   // start with first element
+   ET redux = ( *dm )( dims );   // start with first element
 
    std::array< size_t, N > starts_with{1};
-   ArrayForEachGroupedStartsWith( ( ~dm ).dimensions(),
+   ArrayForEachGroupedStartsWith( ( *dm ).dimensions(),
       [&]( std::array< size_t, N > const& ds ) {
          redux = op( redux, tmp( ds ) );
       },
@@ -1009,7 +1009,7 @@ inline decltype(auto) reduce( const DenseArray<MT>& dm, OP op )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return darrayreduce( ~dm, op );
+   return darrayreduce( *dm, op );
 }
 //*************************************************************************************************
 
@@ -1028,7 +1028,7 @@ template< size_t RF      // Reduction flag
         , typename OP >  // Type of the reduction operation
 inline const ReducedArray<MT,OP,RF> reduce_backend( const DenseArray<MT>& dm, OP op )
 {
-   return ReducedArray<MT,OP,RF>( ~dm, op );
+   return ReducedArray<MT,OP,RF>( *dm, op );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1087,7 +1087,7 @@ inline decltype(auto) reduce( const DenseArray<MT>& dm, OP op )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce_backend<RF>( ~dm, op );
+   return reduce_backend<RF>( *dm, op );
 }
 //*************************************************************************************************
 
@@ -1114,7 +1114,7 @@ inline decltype(auto) sum( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce( ~dm, Add() );
+   return reduce( *dm, Add() );
 }
 //*************************************************************************************************
 
@@ -1158,7 +1158,7 @@ inline decltype(auto) sum( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce<RF>( ~dm, Add() );
+   return reduce<RF>( *dm, Add() );
 }
 //*************************************************************************************************
 
@@ -1185,7 +1185,7 @@ inline decltype(auto) prod( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce( ~dm, Mult() );
+   return reduce( *dm, Mult() );
 }
 //*************************************************************************************************
 
@@ -1229,7 +1229,7 @@ inline decltype(auto) prod( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce<RF>( ~dm, Mult() );
+   return reduce<RF>( *dm, Mult() );
 }
 //*************************************************************************************************
 
@@ -1257,7 +1257,7 @@ inline decltype(auto) min( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce( ~dm, Min() );
+   return reduce( *dm, Min() );
 }
 //*************************************************************************************************
 
@@ -1298,7 +1298,7 @@ inline decltype(auto) min( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce<RF>( ~dm, Min() );
+   return reduce<RF>( *dm, Min() );
 }
 //*************************************************************************************************
 
@@ -1326,7 +1326,7 @@ inline decltype(auto) max( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce( ~dm, Max() );
+   return reduce( *dm, Max() );
 }
 //*************************************************************************************************
 
@@ -1367,7 +1367,7 @@ inline decltype(auto) max( const DenseArray<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce<RF>( ~dm, Max() );
+   return reduce<RF>( *dm, Max() );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DArrScalarDivExpr.h
+++ b/blaze_tensor/math/expressions/DArrScalarDivExpr.h
@@ -597,10 +597,10 @@ class DArrScalarDivExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
-      assign( ~lhs, rhs.array_ );
-      assign( ~lhs, (~lhs) / rhs.scalar_ );
+      assign( *lhs, rhs.array_ );
+      assign( *lhs, (*lhs) / rhs.scalar_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -628,10 +628,10 @@ class DArrScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( serial( rhs ) );
-      addAssign( ~lhs, tmp );
+      addAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -663,10 +663,10 @@ class DArrScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( serial( rhs ) );
-      subAssign( ~lhs, tmp );
+      subAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -698,10 +698,10 @@ class DArrScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -726,10 +726,10 @@ class DArrScalarDivExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
-      smpAssign( ~lhs, rhs.array_ );
-      smpAssign( ~lhs, (~lhs) / rhs.scalar_ );
+      smpAssign( *lhs, rhs.array_ );
+      smpAssign( *lhs, (*lhs) / rhs.scalar_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -757,10 +757,10 @@ class DArrScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( rhs );
-      smpAddAssign( ~lhs, tmp );
+      smpAddAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -788,10 +788,10 @@ class DArrScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( rhs );
-      smpSubAssign( ~lhs, tmp );
+      smpSubAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -819,10 +819,10 @@ class DArrScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -913,10 +913,10 @@ inline decltype(auto) operator/( const DenseArray<MT>& mat, ST scalar )
    using ScalarType = RightOperand_t<ReturnType>;
 
    if( IsMultExpr_v<ReturnType> ) {
-      return ReturnType( ~mat, ScalarType(1)/ScalarType(scalar) );
+      return ReturnType( *mat, ScalarType(1)/ScalarType(scalar) );
    }
    else {
-      return ReturnType( ~mat, scalar );
+      return ReturnType( *mat, scalar );
    }
 }
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DArrScalarMultExpr.h
+++ b/blaze_tensor/math/expressions/DArrScalarMultExpr.h
@@ -597,10 +597,10 @@ class DArrScalarMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
-      assign( ~lhs, rhs.array_ );
-      assign( ~lhs, (~lhs) * rhs.scalar_ );
+      assign( *lhs, rhs.array_ );
+      assign( *lhs, (*lhs) * rhs.scalar_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -628,10 +628,10 @@ class DArrScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( serial( rhs ) );
-      addAssign( ~lhs, tmp );
+      addAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -659,10 +659,10 @@ class DArrScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( serial( rhs ) );
-      subAssign( ~lhs, tmp );
+      subAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -690,10 +690,10 @@ class DArrScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -718,10 +718,10 @@ class DArrScalarMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
-      smpAssign( ~lhs, rhs.array_ );
-      smpAssign( ~lhs, (~lhs) * rhs.scalar_ );
+      smpAssign( *lhs, rhs.array_ );
+      smpAssign( *lhs, (*lhs) * rhs.scalar_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -749,10 +749,10 @@ class DArrScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( rhs );
-      smpAddAssign( ~lhs, tmp );
+      smpAddAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -780,10 +780,10 @@ class DArrScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( rhs );
-      smpSubAssign( ~lhs, tmp );
+      smpSubAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -811,10 +811,10 @@ class DArrScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_ARRAY_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( ( ~lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
+      BLAZE_INTERNAL_ASSERT( ( *lhs ).dimensions() == rhs.dimensions(), "Invalid number of elements" );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -862,7 +862,7 @@ inline decltype(auto) operator-( const DenseArray<MT>& dm )
 
    using ScalarType = UnderlyingBuiltin_t<MT>;
    using ReturnType = const DArrScalarMultExpr<MT,ScalarType>;
-   return ReturnType( ~dm, ScalarType(-1) );
+   return ReturnType( *dm, ScalarType(-1) );
 }
 //*************************************************************************************************
 
@@ -905,7 +905,7 @@ inline decltype(auto) operator*( const DenseArray<MT>& mat, ST scalar )
 
    using ScalarType = MultTrait_t< UnderlyingBuiltin_t<MT>, ST >;
    using ReturnType = const DArrScalarMultExpr<MT,ScalarType>;
-   return ReturnType( ~mat, scalar );
+   return ReturnType( *mat, scalar );
 }
 //*************************************************************************************************
 
@@ -940,7 +940,7 @@ inline decltype(auto) operator*( ST scalar, const DenseArray<MT>& mat )
 
    using ScalarType = MultTrait_t< ST, UnderlyingBuiltin_t<MT> >;
    using ReturnType = const DArrScalarMultExpr<MT,ScalarType>;
-   return ReturnType( ~mat, scalar );
+   return ReturnType( *mat, scalar );
 }
 //*************************************************************************************************
 
@@ -1089,7 +1089,7 @@ inline decltype(auto) operator/( const DArrScalarMultExpr<MT,ST1>& mat, ST2 scal
 // {
 //    BLAZE_FUNCTION_TRACE;
 //
-//    return ( mat.leftOperand() * (~vec) ) * mat.rightOperand();
+//    return ( mat.leftOperand() * (*vec) ) * mat.rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1117,7 +1117,7 @@ inline decltype(auto) operator/( const DArrScalarMultExpr<MT,ST1>& mat, ST2 scal
 // {
 //    BLAZE_FUNCTION_TRACE;
 //
-//    return ( (~vec) * mat.leftOperand() ) * mat.rightOperand();
+//    return ( (*vec) * mat.leftOperand() ) * mat.rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1207,7 +1207,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return ( lhs.leftOperand() * (~rhs) ) * lhs.rightOperand();
+   return ( lhs.leftOperand() * (*rhs) ) * lhs.rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1235,7 +1235,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return ( (~lhs) * rhs.leftOperand() ) * rhs.rightOperand();
+   return ( (*lhs) * rhs.leftOperand() ) * rhs.rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DMatExpandExpr.h
+++ b/blaze_tensor/math/expressions/DMatExpandExpr.h
@@ -381,13 +381,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      assign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      assign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -414,13 +414,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      addAssign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      addAssign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -447,13 +447,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      subAssign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      subAssign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -480,13 +480,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      schurAssign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      schurAssign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -513,13 +513,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      multAssign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      multAssign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -546,13 +546,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpAssign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      smpAssign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -579,13 +579,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpAddAssign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      smpAddAssign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -612,13 +612,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpSubAssign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      smpSubAssign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -645,13 +645,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpSchurAssign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      smpSchurAssign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -678,13 +678,13 @@ class DMatExpandExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpMultAssign( ~lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
+      smpMultAssign( *lhs, expand<CEAs...>( tmp, rhs.expansion() ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -751,7 +751,7 @@ inline decltype(auto) expand( const DenseMatrix<MT, SO>& dm, size_t expansion )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DMatExpandExpr<MT>;
-   return ReturnType( ~dm, expansion );
+   return ReturnType( *dm, expansion );
 }
 //*************************************************************************************************
 
@@ -802,7 +802,7 @@ inline decltype(auto) expand( const DenseMatrix<MT, SO>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DMatExpandExpr<MT,E>;
-   return ReturnType( ~dm );
+   return ReturnType( *dm );
 }
 //*************************************************************************************************
 
@@ -829,7 +829,7 @@ inline decltype(auto) expand( const DenseMatrix<MT, SO>& dm, size_t expansion )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DMatExpandExpr<MT,E>;
-   return ReturnType( ~dm );
+   return ReturnType( *dm );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DMatRavelExpr.h
+++ b/blaze_tensor/math/expressions/DMatRavelExpr.h
@@ -613,11 +613,11 @@ class DMatRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      assign( ~lhs, ravel( tmp ) );
+      assign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -645,11 +645,11 @@ class DMatRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      subAssign( ~lhs, ravel( tmp ) );
+      subAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -677,11 +677,11 @@ class DMatRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      schurAssign( ~lhs, ravel( tmp ) );
+      schurAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -709,11 +709,11 @@ class DMatRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      multAssign( ~lhs, ravel( tmp ) );
+      multAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -741,11 +741,11 @@ class DMatRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpAssign( ~lhs, ravel( tmp ) );
+      smpAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -773,11 +773,11 @@ class DMatRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpAddAssign( ~lhs, ravel( tmp ) );
+      smpAddAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -805,11 +805,11 @@ class DMatRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpSubAssign( ~lhs, ravel( tmp ) );
+      smpSubAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -837,11 +837,11 @@ class DMatRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpSchurAssign( ~lhs, ravel( tmp ) );
+      smpSchurAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -869,11 +869,11 @@ class DMatRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpMultAssign( ~lhs, ravel( tmp ) );
+      smpMultAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -935,7 +935,7 @@ inline decltype(auto) ravel( const DenseMatrix<MT, SO>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DMatRavelExpr<MT>;
-   return ReturnType( ~dm );
+   return ReturnType( *dm );
 }
 //*************************************************************************************************
 
@@ -960,7 +960,7 @@ inline decltype(auto) subvector( const DMatRavelExpr<MT>& matrix, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subvector<AF,CSAs...>( evaluate( ~matrix ), args... );
+   return subvector<AF,CSAs...>( evaluate( *matrix ), args... );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DQuatTransExpr.h
+++ b/blaze_tensor/math/expressions/DQuatTransExpr.h
@@ -654,12 +654,12 @@ inline void reset(size_t i, size_t l, size_t k)
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DQuatTransposer<MT2> tmp( ~lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
+      DQuatTransposer<MT2> tmp( *lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
       assign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -694,11 +694,11 @@ inline void reset(size_t i, size_t l, size_t k)
 //       BLAZE_CONSTRAINT_MATRICES_MUST_HAVE_SAME_STORAGE_ORDER( MT2, TmpType );
 //       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( TmpType );
 //
-//       BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-//       BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+//       BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+//       BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 //
 //       const TmpType tmp( serial( rhs ) );
-//       assign( ~lhs, tmp );
+//       assign( *lhs, tmp );
 //    }
    /*! \endcond */
    //**********************************************************************************************
@@ -723,12 +723,12 @@ inline void reset(size_t i, size_t l, size_t k)
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DQuatTransposer<MT2> tmp( ~lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
+      DQuatTransposer<MT2> tmp( *lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
       addAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -758,12 +758,12 @@ inline void reset(size_t i, size_t l, size_t k)
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DQuatTransposer<MT2> tmp( ~lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
+      DQuatTransposer<MT2> tmp( *lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
       subAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -793,12 +793,12 @@ inline void reset(size_t i, size_t l, size_t k)
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DQuatTransposer<MT2> tmp( ~lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
+      DQuatTransposer<MT2> tmp( *lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
       schurAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -836,12 +836,12 @@ inline void reset(size_t i, size_t l, size_t k)
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DQuatTransposer<MT2> tmp( ~lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
+      DQuatTransposer<MT2> tmp( *lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
       smpAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -876,11 +876,11 @@ inline void reset(size_t i, size_t l, size_t k)
 //       BLAZE_CONSTRAINT_MATRICES_MUST_HAVE_SAME_STORAGE_ORDER( MT2, TmpType );
 //       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( TmpType );
 //
-//       BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-//       BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+//       BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+//       BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 //
 //       const TmpType tmp( rhs );
-//       smpAssign( ~lhs, tmp );
+//       smpAssign( *lhs, tmp );
 //    }
    /*! \endcond */
    //**********************************************************************************************
@@ -905,12 +905,12 @@ inline void reset(size_t i, size_t l, size_t k)
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DQuatTransposer<MT2> tmp( ~lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
+      DQuatTransposer<MT2> tmp( *lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
       smpAddAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -940,12 +940,12 @@ inline void reset(size_t i, size_t l, size_t k)
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DQuatTransposer<MT2> tmp( ~lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
+      DQuatTransposer<MT2> tmp( *lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
       smpSubAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -976,12 +976,12 @@ inline void reset(size_t i, size_t l, size_t k)
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).quats()   == rhs.quats()  , "Invalid number of quats"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DQuatTransposer<MT2> tmp( ~lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
+      DQuatTransposer<MT2> tmp( *lhs, rhs.quats(), rhs.pages(), rhs.rows(), rhs.columns() );
       smpSchurAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -1044,7 +1044,7 @@ inline decltype(auto) trans( const DenseArray<MT>& dm, RTAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DQuatTransExpr<MT, P, O, M, N>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -1076,7 +1076,7 @@ inline decltype(auto) trans( DenseArray<MT>& dm, RTAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DQuatTransExpr<MT, P, O, M, N>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -1108,7 +1108,7 @@ inline decltype(auto) trans( DenseArray<MT>&& dm, RTAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DQuatTransExpr<MT, P, O, M, N>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -1136,7 +1136,7 @@ inline decltype(auto) trans( const DenseArray<MT>& dm, RTAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DQuatTransExpr<MT>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -1164,7 +1164,7 @@ inline decltype(auto) trans( DenseArray<MT>& dm, RTAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DQuatTransExpr<MT>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -1192,7 +1192,7 @@ inline decltype(auto) trans( DenseArray<MT>&& dm, RTAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DQuatTransExpr<MT>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -1221,7 +1221,7 @@ inline decltype(auto) trans( const DenseArray<MT>& dm, const T* indices, size_t 
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DQuatTransExpr<MT>;
-   return ReturnType( ~dm, indices, n, args... );
+   return ReturnType( *dm, indices, n, args... );
 }
 //*************************************************************************************************
 
@@ -1250,7 +1250,7 @@ inline decltype(auto) trans( DenseArray<MT>& dm, const T* indices, size_t n, RTA
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DQuatTransExpr<MT>;
-   return ReturnType( ~dm, indices, n, args... );
+   return ReturnType( *dm, indices, n, args... );
 }
 //*************************************************************************************************
 
@@ -1279,7 +1279,7 @@ inline decltype(auto) trans( DenseArray<MT>&& dm, const T* indices, size_t n, RT
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DQuatTransExpr<MT>;
-   return ReturnType( ~dm, indices, n, args... );
+   return ReturnType( *dm, indices, n, args... );
 }
 //*************************************************************************************************
 
@@ -1307,7 +1307,7 @@ inline decltype(auto) trans( const DenseArray<MT>& dm, std::index_sequence<Is...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans<Is...>( ~dm, args... );
+   return trans<Is...>( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -1335,7 +1335,7 @@ inline decltype(auto) trans( DenseArray<MT>& dm, std::index_sequence<Is...> indi
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans<Is...>( ~dm, args... );
+   return trans<Is...>( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -1363,7 +1363,7 @@ inline decltype(auto) trans( DenseArray<MT>&& dm, std::index_sequence<Is...> ind
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans<Is...>( ~dm, args... );
+   return trans<Is...>( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -1391,7 +1391,7 @@ inline decltype(auto) trans( const DenseArray<MT>& dm, std::initializer_list<T> 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( ~dm, indices.begin(), indices.size(), args... );
+   return trans( *dm, indices.begin(), indices.size(), args... );
 }
 //*************************************************************************************************
 
@@ -1419,7 +1419,7 @@ inline decltype(auto) trans( DenseArray<MT>& dm, std::initializer_list<T> indice
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( ~dm, indices.begin(), indices.size(), args... );
+   return trans( *dm, indices.begin(), indices.size(), args... );
 }
 //*************************************************************************************************
 
@@ -1447,7 +1447,7 @@ inline decltype(auto) trans( DenseArray<MT>&& dm, std::initializer_list<T> indic
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( ~dm, indices.begin(), indices.size(), args... );
+   return trans( *dm, indices.begin(), indices.size(), args... );
 }
 //*************************************************************************************************
 
@@ -1491,7 +1491,7 @@ inline decltype(auto) trans( const DQuatTransExpr<MT, CTAs...>& dm, RTAs... args
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DQuatTransExpr<MT, P, O, M, N>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1523,7 +1523,7 @@ inline decltype(auto) trans( const DQuatTransExpr<MT, CTAs...>& dm, RTAs... args
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DQuatTransExpr<MT, CTAs...>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DQuatTransposer.h
+++ b/blaze_tensor/math/expressions/DQuatTransposer.h
@@ -595,7 +595,7 @@ class DQuatTransposer
             , typename... RTAs >  // Runtime arguments
    inline void assign( const Array<MT2>& rhs, RTAs... args )
    {
-      dm_.assign( trans( ~rhs, args... ) );
+      dm_.assign( trans( *rhs, args... ) );
    }
    //**********************************************************************************************
 
@@ -614,7 +614,7 @@ class DQuatTransposer
             , typename... RTAs >  // Runtime arguments
    inline void addAssign( const Array<MT2>& rhs, RTAs... args )
    {
-      dm_.addAssign( trans( ~rhs, args... ) );
+      dm_.addAssign( trans( *rhs, args... ) );
    }
    //**********************************************************************************************
 
@@ -633,7 +633,7 @@ class DQuatTransposer
             , typename... RTAs >  // Runtime arguments
    inline void subAssign( const Array<MT2>& rhs, RTAs... args )
    {
-      dm_.subAssign( trans( ~rhs, args... ) );
+      dm_.subAssign( trans( *rhs, args... ) );
    }
    //**********************************************************************************************
 
@@ -652,7 +652,7 @@ class DQuatTransposer
             , typename... RTAs >  // Runtime arguments
    inline void schurAssign( const Array<MT2>& rhs, RTAs... args )
    {
-      dm_.schurAssign( trans( ~rhs, args... ) );
+      dm_.schurAssign( trans( *rhs, args... ) );
    }
    //**********************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensDMatSchurExpr.h
+++ b/blaze_tensor/math/expressions/DTensDMatSchurExpr.h
@@ -669,17 +669,17 @@ class DTensDMatSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns");
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"  );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns");
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"  );
 
-      //if( !IsOperation_v<TT> && isSame( ~lhs, rhs.lhs_ ) ) {
-      //   schurAssign( ~lhs, rhs.rhs_ );
+      //if( !IsOperation_v<TT> && isSame( *lhs, rhs.lhs_ ) ) {
+      //   schurAssign( *lhs, rhs.rhs_ );
       //}
       //else {
          CT1 A( serial( rhs.lhs_ ) );
          CT2 B( serial( rhs.rhs_ ) );
-         assign( ~lhs, A % B );
+         assign( *lhs, A % B );
       //}
    }
    /*! \endcond */
@@ -705,23 +705,23 @@ class DTensDMatSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
 
-      if( !IsOperation_v<TT> && isSame( ~lhs, rhs.lhs_ ) ) {
-         schurAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<TT> && isSame( *lhs, rhs.lhs_ ) ) {
+         schurAssign( *lhs, rhs.rhs_ );
       }
-      else if( !IsOperation_v<MT> && isSame( ~lhs, rhs.rhs_ ) ) {
-         schurAssign( ~lhs, rhs.lhs_ );
+      else if( !IsOperation_v<MT> && isSame( *lhs, rhs.rhs_ ) ) {
+         schurAssign( *lhs, rhs.lhs_ );
       }
       else if( !RequiresEvaluation_v<MT> ) {
-         assign     ( ~lhs, rhs.rhs_ );
-         schurAssign( ~lhs, rhs.lhs_ );
+         assign     ( *lhs, rhs.rhs_ );
+         schurAssign( *lhs, rhs.lhs_ );
       }
       else {
-         assign     ( ~lhs, rhs.lhs_ );
-         schurAssign( ~lhs, rhs.rhs_ );
+         assign     ( *lhs, rhs.lhs_ );
+         schurAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -750,12 +750,12 @@ class DTensDMatSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns");
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"  );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns");
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"  );
 
       const ResultType tmp( serial( rhs ) );
-      addAssign( ~lhs, tmp );
+      addAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -787,12 +787,12 @@ class DTensDMatSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns");
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"  );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns");
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"  );
 
       const ResultType tmp( serial( rhs ) );
-      subAssign( ~lhs, tmp );
+      subAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -821,12 +821,12 @@ class DTensDMatSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns");
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"  );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns");
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"  );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -852,17 +852,17 @@ class DTensDMatSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT> ) {
-         schurAssign( ~lhs, rhs.rhs_ );
-         schurAssign( ~lhs, rhs.lhs_ );
+         schurAssign( *lhs, rhs.rhs_ );
+         schurAssign( *lhs, rhs.lhs_ );
       }
       else {
-         schurAssign( ~lhs, rhs.lhs_ );
-         schurAssign( ~lhs, rhs.rhs_ );
+         schurAssign( *lhs, rhs.lhs_ );
+         schurAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -889,17 +889,17 @@ class DTensDMatSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
 
-      //if( !IsOperation_v<TT> && isSame( ~lhs, rhs.lhs_ ) ) {
-      //   smpSchurAssign( ~lhs, rhs.rhs_ );
+      //if( !IsOperation_v<TT> && isSame( *lhs, rhs.lhs_ ) ) {
+      //   smpSchurAssign( *lhs, rhs.rhs_ );
       //}
       //else {
          CT1 A( rhs.lhs_ );
          CT2 B( rhs.rhs_ );
-         smpAssign( ~lhs, A % B );
+         smpAssign( *lhs, A % B );
       //}
    }
    /*! \endcond */
@@ -926,23 +926,23 @@ class DTensDMatSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
 
-      if( !IsOperation_v<TT> && isSame( ~lhs, rhs.lhs_ ) ) {
-         smpSchurAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<TT> && isSame( *lhs, rhs.lhs_ ) ) {
+         smpSchurAssign( *lhs, rhs.rhs_ );
       }
-      else if( !IsOperation_v<MT> && isSame( ~lhs, rhs.rhs_ ) ) {
-         smpSchurAssign( ~lhs, rhs.lhs_ );
+      else if( !IsOperation_v<MT> && isSame( *lhs, rhs.rhs_ ) ) {
+         smpSchurAssign( *lhs, rhs.lhs_ );
       }
       else if( !RequiresEvaluation_v<MT> ) {
-         smpAssign     ( ~lhs, rhs.rhs_ );
-         smpSchurAssign( ~lhs, rhs.lhs_ );
+         smpAssign     ( *lhs, rhs.rhs_ );
+         smpSchurAssign( *lhs, rhs.lhs_ );
       }
       else {
-         smpAssign     ( ~lhs, rhs.lhs_ );
-         smpSchurAssign( ~lhs, rhs.rhs_ );
+         smpAssign     ( *lhs, rhs.lhs_ );
+         smpSchurAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -971,12 +971,12 @@ class DTensDMatSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
 
       const ResultType tmp( rhs );
-      smpAddAssign( ~lhs, tmp );
+      smpAddAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1005,12 +1005,12 @@ class DTensDMatSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
 
       const ResultType tmp( rhs );
-      smpSubAssign( ~lhs, tmp );
+      smpSubAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1039,12 +1039,12 @@ class DTensDMatSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1070,17 +1070,17 @@ class DTensDMatSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT> ) {
-         smpSchurAssign( ~lhs, rhs.rhs_ );
-         smpSchurAssign( ~lhs, rhs.lhs_ );
+         smpSchurAssign( *lhs, rhs.rhs_ );
+         smpSchurAssign( *lhs, rhs.lhs_ );
       }
       else {
-         smpSchurAssign( ~lhs, rhs.lhs_ );
-         smpSchurAssign( ~lhs, rhs.rhs_ );
+         smpSchurAssign( *lhs, rhs.lhs_ );
+         smpSchurAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -1128,10 +1128,10 @@ inline const DTensDMatSchurExpr<TT,MT,SO>
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
 
-   return DTensDMatSchurExpr<TT,MT,SO>( ~lhs, ~rhs );
+   return DTensDMatSchurExpr<TT,MT,SO>( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1161,11 +1161,11 @@ inline const DTensDMatSchurExpr<TT,MT,SO>
 //
 //    MAYBE_UNUSED( rhs );
 //
-//    BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-//    BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-//    BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages()  , "Invalid number of pages" );
+//    BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+//    BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+//    BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages()  , "Invalid number of pages" );
 //
-//    return IdentityTensor< MultTrait_t< ElementType_t<TT>, ElementType_t<MT> > >( (~lhs).rows() );
+//    return IdentityTensor< MultTrait_t< ElementType_t<TT>, ElementType_t<MT> > >( (*lhs).rows() );
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1204,11 +1204,11 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   if( (~lhs).rows() != (~rhs).rows() || (~lhs).columns() != (~rhs).columns() ) {
+   if( (*lhs).rows() != (*rhs).rows() || (*lhs).columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor and matrix sizes do not match" );
    }
 
-   return dtensdmatschur( ~lhs, ~rhs );
+   return dtensdmatschur( *lhs, *rhs );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensDTensAddExpr.h
+++ b/blaze_tensor/math/expressions/DTensDTensAddExpr.h
@@ -625,23 +625,23 @@ class DTensDTensAddExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      if( !IsOperation_v<MT1> && isSame( ~lhs, rhs.lhs_ ) ) {
-         addAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<MT1> && isSame( *lhs, rhs.lhs_ ) ) {
+         addAssign( *lhs, rhs.rhs_ );
       }
-      else if( !IsOperation_v<MT2> && isSame( ~lhs, rhs.rhs_ ) ) {
-         addAssign( ~lhs, rhs.lhs_ );
+      else if( !IsOperation_v<MT2> && isSame( *lhs, rhs.rhs_ ) ) {
+         addAssign( *lhs, rhs.lhs_ );
       }
       else if( !RequiresEvaluation_v<MT2> ) {
-         assign   ( ~lhs, rhs.rhs_ );
-         addAssign( ~lhs, rhs.lhs_ );
+         assign   ( *lhs, rhs.rhs_ );
+         addAssign( *lhs, rhs.lhs_ );
       }
       else {
-         assign   ( ~lhs, rhs.lhs_ );
-         addAssign( ~lhs, rhs.rhs_ );
+         assign   ( *lhs, rhs.lhs_ );
+         addAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -667,17 +667,17 @@ class DTensDTensAddExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         addAssign( ~lhs, rhs.rhs_ );
-         addAssign( ~lhs, rhs.lhs_ );
+         addAssign( *lhs, rhs.rhs_ );
+         addAssign( *lhs, rhs.lhs_ );
       }
       else {
-         addAssign( ~lhs, rhs.lhs_ );
-         addAssign( ~lhs, rhs.rhs_ );
+         addAssign( *lhs, rhs.lhs_ );
+         addAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -703,17 +703,17 @@ class DTensDTensAddExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         subAssign( ~lhs, rhs.rhs_ );
-         subAssign( ~lhs, rhs.lhs_ );
+         subAssign( *lhs, rhs.rhs_ );
+         subAssign( *lhs, rhs.lhs_ );
       }
       else {
-         subAssign( ~lhs, rhs.lhs_ );
-         subAssign( ~lhs, rhs.rhs_ );
+         subAssign( *lhs, rhs.lhs_ );
+         subAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -742,12 +742,12 @@ class DTensDTensAddExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -772,23 +772,23 @@ class DTensDTensAddExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      if( !IsOperation_v<MT1> && isSame( ~lhs, rhs.lhs_ ) ) {
-         smpAddAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<MT1> && isSame( *lhs, rhs.lhs_ ) ) {
+         smpAddAssign( *lhs, rhs.rhs_ );
       }
-      else if( !IsOperation_v<MT2> && isSame( ~lhs, rhs.rhs_ ) ) {
-         smpAddAssign( ~lhs, rhs.lhs_ );
+      else if( !IsOperation_v<MT2> && isSame( *lhs, rhs.rhs_ ) ) {
+         smpAddAssign( *lhs, rhs.lhs_ );
       }
       else if( !RequiresEvaluation_v<MT2> ) {
-         smpAssign   ( ~lhs, rhs.rhs_ );
-         smpAddAssign( ~lhs, rhs.lhs_ );
+         smpAssign   ( *lhs, rhs.rhs_ );
+         smpAddAssign( *lhs, rhs.lhs_ );
       }
       else {
-         smpAssign   ( ~lhs, rhs.lhs_ );
-         smpAddAssign( ~lhs, rhs.rhs_ );
+         smpAssign   ( *lhs, rhs.lhs_ );
+         smpAddAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -814,17 +814,17 @@ class DTensDTensAddExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         smpAddAssign( ~lhs, rhs.rhs_ );
-         smpAddAssign( ~lhs, rhs.lhs_ );
+         smpAddAssign( *lhs, rhs.rhs_ );
+         smpAddAssign( *lhs, rhs.lhs_ );
       }
       else {
-         smpAddAssign( ~lhs, rhs.lhs_ );
-         smpAddAssign( ~lhs, rhs.rhs_ );
+         smpAddAssign( *lhs, rhs.lhs_ );
+         smpAddAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -850,17 +850,17 @@ class DTensDTensAddExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         smpSubAssign( ~lhs, rhs.rhs_ );
-         smpSubAssign( ~lhs, rhs.lhs_ );
+         smpSubAssign( *lhs, rhs.rhs_ );
+         smpSubAssign( *lhs, rhs.lhs_ );
       }
       else {
-         smpSubAssign( ~lhs, rhs.lhs_ );
-         smpSubAssign( ~lhs, rhs.rhs_ );
+         smpSubAssign( *lhs, rhs.lhs_ );
+         smpSubAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -889,12 +889,12 @@ class DTensDTensAddExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -952,12 +952,12 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   if( (~lhs).rows() != (~rhs).rows() || (~lhs).columns() != (~rhs).columns() || (~lhs).pages() != (~rhs).pages() ) {
+   if( (*lhs).rows() != (*rhs).rows() || (*lhs).columns() != (*rhs).columns() || (*lhs).pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "tensor sizes do not match" );
    }
 
    using ReturnType = const DTensDTensAddExpr<MT1,MT2>;
-   return ReturnType( ~lhs, ~rhs );
+   return ReturnType( *lhs, *rhs );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensDTensEqualExpr.h
+++ b/blaze_tensor/math/expressions/DTensDTensEqualExpr.h
@@ -113,12 +113,12 @@ inline EnableIf_t< !DTensDTensEqualExprHelper<MT1,MT2>::value, bool >
    using CT2 = CompositeType_t<MT2>;
 
    // Early exit in case the tensor sizes don't match
-   if( (~lhs).rows() != (~rhs).rows() || (~lhs).columns() != (~rhs).columns() || (~lhs).pages() != (~rhs).pages() )
+   if( (*lhs).rows() != (*rhs).rows() || (*lhs).columns() != (*rhs).columns() || (*lhs).pages() != (*rhs).pages() )
       return false;
 
    // Evaluation of the two dense tensor operands
-   CT1 A( ~lhs );
-   CT2 B( ~rhs );
+   CT1 A( *lhs );
+   CT2 B( *rhs );
 
    // In order to compare the two matrices, the data values of the lower-order data
    // type are converted to the higher-order data type within the equal function.
@@ -161,12 +161,12 @@ inline EnableIf_t< DTensDTensEqualExprHelper<MT1,MT2>::value, bool >
    using XT2 = RemoveReference_t<CT2>;
 
    // Early exit in case the tensor sizes don't match
-   if( (~lhs).rows() != (~rhs).rows() || (~lhs).columns() != (~rhs).columns() || (~lhs).pages() != (~rhs).pages() )
+   if( (*lhs).rows() != (*rhs).rows() || (*lhs).columns() != (*rhs).columns() || (*lhs).pages() != (*rhs).pages() )
       return false;
 
    // Evaluation of the two dense tensor operands
-   CT1 A( ~lhs );
-   CT2 B( ~rhs );
+   CT1 A( *lhs );
+   CT2 B( *rhs );
 
    constexpr size_t SIMDSIZE = SIMDTrait< ElementType_t<MT1> >::size;
    constexpr bool remainder( !IsPadded_v<XT1> || !IsPadded_v<XT2> );

--- a/blaze_tensor/math/expressions/DTensDTensMapExpr.h
+++ b/blaze_tensor/math/expressions/DTensDTensMapExpr.h
@@ -646,9 +646,9 @@ class DTensDTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense tensor operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense tensor operand
@@ -659,11 +659,11 @@ class DTensDTensMapExpr
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.pages()   == rhs.rhs_.pages()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( B.pages()   == (~lhs).pages()    , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( B.pages()   == (*lhs).pages()    , "Invalid number of columns" );
 
-      assign( ~lhs, map( A, B, rhs.op_ ) );
+      assign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -688,9 +688,9 @@ class DTensDTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense tensor operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense tensor operand
@@ -701,11 +701,11 @@ class DTensDTensMapExpr
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.pages()   == rhs.rhs_.pages()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( B.pages()   == (~lhs).pages()    , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( B.pages()   == (*lhs).pages()    , "Invalid number of columns" );
 
-      addAssign( ~lhs, map( A, B, rhs.op_ ) );
+      addAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -730,9 +730,9 @@ class DTensDTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense tensor operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense tensor operand
@@ -743,11 +743,11 @@ class DTensDTensMapExpr
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.pages()   == rhs.rhs_.pages()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( B.pages()   == (~lhs).pages()    , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( B.pages()   == (*lhs).pages()    , "Invalid number of columns" );
 
-      subAssign( ~lhs, map( A, B, rhs.op_ ) );
+      subAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -772,9 +772,9 @@ class DTensDTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
 
       LT A( serial( rhs.lhs_ ) );  // Evaluation of the left-hand side dense tensor operand
       RT B( serial( rhs.rhs_ ) );  // Evaluation of the right-hand side dense tensor operand
@@ -785,11 +785,11 @@ class DTensDTensMapExpr
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.pages()   == rhs.rhs_.pages()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( B.pages()   == (~lhs).pages()    , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( B.pages()   == (*lhs).pages()    , "Invalid number of columns" );
 
-      schurAssign( ~lhs, map( A, B, rhs.op_ ) );
+      schurAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -814,9 +814,9 @@ class DTensDTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense tensor operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense tensor operand
@@ -827,11 +827,11 @@ class DTensDTensMapExpr
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.pages()   == rhs.rhs_.pages()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( B.pages()   == (~lhs).pages()    , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( B.pages()   == (*lhs).pages()    , "Invalid number of columns" );
 
-      smpAssign( ~lhs, map( A, B, rhs.op_ ) );
+      smpAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -857,9 +857,9 @@ class DTensDTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense tensor operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense tensor operand
@@ -870,11 +870,11 @@ class DTensDTensMapExpr
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.pages()   == rhs.rhs_.pages()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( B.pages()   == (~lhs).pages()    , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( B.pages()   == (*lhs).pages()    , "Invalid number of columns" );
 
-      smpAddAssign( ~lhs, map( A, B, rhs.op_ ) );
+      smpAddAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -900,9 +900,9 @@ class DTensDTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense tensor operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense tensor operand
@@ -913,11 +913,11 @@ class DTensDTensMapExpr
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.pages()   == rhs.rhs_.pages()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( B.pages()   == (~lhs).pages()    , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( B.pages()   == (*lhs).pages()    , "Invalid number of columns" );
 
-      smpSubAssign( ~lhs, map( A, B, rhs.op_ ) );
+      smpSubAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -943,9 +943,9 @@ class DTensDTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages" );
 
       LT A( rhs.lhs_ );  // Evaluation of the left-hand side dense tensor operand
       RT B( rhs.rhs_ );  // Evaluation of the right-hand side dense tensor operand
@@ -956,11 +956,11 @@ class DTensDTensMapExpr
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.pages()   == rhs.rhs_.pages()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( B.pages()   == (~lhs).pages()    , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( B.pages()   == (*lhs).pages()    , "Invalid number of columns" );
 
-      smpSchurAssign( ~lhs, map( A, B, rhs.op_ ) );
+      smpSchurAssign( *lhs, map( A, B, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1012,12 +1012,12 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   if( (~lhs).rows() != (~rhs).rows() || (~lhs).columns() != (~rhs).columns()  || (~lhs).pages() != (~rhs).pages()) {
+   if( (*lhs).rows() != (*rhs).rows() || (*lhs).columns() != (*rhs).columns()  || (*lhs).pages() != (*rhs).pages()) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
    using ReturnType = const DTensDTensMapExpr<MT1,MT2,OP>;
-   return ReturnType( ~lhs, ~rhs, op );
+   return ReturnType( *lhs, *rhs, op );
 }
 //*************************************************************************************************
 
@@ -1047,7 +1047,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Min() );
+   return map( *lhs, *rhs, Min() );
 }
 //*************************************************************************************************
 
@@ -1077,7 +1077,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Max() );
+   return map( *lhs, *rhs, Max() );
 }
 //*************************************************************************************************
 
@@ -1107,7 +1107,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Hypot() );
+   return map( *lhs, *rhs, Hypot() );
 }
 //*************************************************************************************************
 
@@ -1137,7 +1137,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Pow() );
+   return map( *lhs, *rhs, Pow() );
 }
 //*************************************************************************************************
 
@@ -1167,7 +1167,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~lhs, ~rhs, Atan2() );
+   return map( *lhs, *rhs, Atan2() );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensDTensMultExpr.h
+++ b/blaze_tensor/math/expressions/DTensDTensMultExpr.h
@@ -396,15 +396,15 @@ class DTensDTensMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || (~lhs).pages() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || (*lhs).pages() == 0UL ) {
          return;
       }
-      else if( rhs.lhs_.columns() == 0UL || (~rhs).pages() == 0UL ) {
-         reset( ~lhs );
+      else if( rhs.lhs_.columns() == 0UL || (*rhs).pages() == 0UL ) {
+         reset( *lhs );
          return;
       }
 
@@ -417,11 +417,11 @@ class DTensDTensMultExpr
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.pages() == rhs.rhs_.pages(),     "Invalid number of pages" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( B.pages() == (~lhs).pages()  ,     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( B.pages() == (*lhs).pages()  ,     "Invalid number of pages" );
 
-      DTensDTensMultExpr::selectAssignKernel( ~lhs, A, B );
+      DTensDTensMultExpr::selectAssignKernel( *lhs, A, B );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -758,7 +758,7 @@ class DTensDTensMultExpr
       BLAZE_INTERNAL_ASSERT( !remainder || ( N - ( N % SIMDSIZE ) ) == jpos, "Invalid end calculation" );
 
       if( N > SIMDSIZE*3UL ) {
-         reset( ~C );
+         reset( *C );
       }
 
       {
@@ -786,14 +786,14 @@ class DTensDTensMultExpr
                      xmm8 += a1 * B.load(k,j+SIMDSIZE*7UL);
                   }
 
-                  (~C).store( i, j             , xmm1 );
-                  (~C).store( i, j+SIMDSIZE    , xmm2 );
-                  (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
-                  (~C).store( i, j+SIMDSIZE*3UL, xmm4 );
-                  (~C).store( i, j+SIMDSIZE*4UL, xmm5 );
-                  (~C).store( i, j+SIMDSIZE*5UL, xmm6 );
-                  (~C).store( i, j+SIMDSIZE*6UL, xmm7 );
-                  (~C).store( i, j+SIMDSIZE*7UL, xmm8 );
+                  (*C).store( i, j             , xmm1 );
+                  (*C).store( i, j+SIMDSIZE    , xmm2 );
+                  (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
+                  (*C).store( i, j+SIMDSIZE*3UL, xmm4 );
+                  (*C).store( i, j+SIMDSIZE*4UL, xmm5 );
+                  (*C).store( i, j+SIMDSIZE*5UL, xmm6 );
+                  (*C).store( i, j+SIMDSIZE*6UL, xmm7 );
+                  (*C).store( i, j+SIMDSIZE*7UL, xmm8 );
                }
             }
          }
@@ -829,16 +829,16 @@ class DTensDTensMultExpr
                   xmm10 += a2 * b5;
                }
 
-               (~C).store( i    , j             , xmm1  );
-               (~C).store( i    , j+SIMDSIZE    , xmm2  );
-               (~C).store( i    , j+SIMDSIZE*2UL, xmm3  );
-               (~C).store( i    , j+SIMDSIZE*3UL, xmm4  );
-               (~C).store( i    , j+SIMDSIZE*4UL, xmm5  );
-               (~C).store( i+1UL, j             , xmm6  );
-               (~C).store( i+1UL, j+SIMDSIZE    , xmm7  );
-               (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm8  );
-               (~C).store( i+1UL, j+SIMDSIZE*3UL, xmm9  );
-               (~C).store( i+1UL, j+SIMDSIZE*4UL, xmm10 );
+               (*C).store( i    , j             , xmm1  );
+               (*C).store( i    , j+SIMDSIZE    , xmm2  );
+               (*C).store( i    , j+SIMDSIZE*2UL, xmm3  );
+               (*C).store( i    , j+SIMDSIZE*3UL, xmm4  );
+               (*C).store( i    , j+SIMDSIZE*4UL, xmm5  );
+               (*C).store( i+1UL, j             , xmm6  );
+               (*C).store( i+1UL, j+SIMDSIZE    , xmm7  );
+               (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm8  );
+               (*C).store( i+1UL, j+SIMDSIZE*3UL, xmm9  );
+               (*C).store( i+1UL, j+SIMDSIZE*4UL, xmm10 );
             }
 
             if( i < M )
@@ -857,11 +857,11 @@ class DTensDTensMultExpr
                   xmm5 += a1 * B.load(k,j+SIMDSIZE*4UL);
                }
 
-               (~C).store( i, j             , xmm1 );
-               (~C).store( i, j+SIMDSIZE    , xmm2 );
-               (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
-               (~C).store( i, j+SIMDSIZE*3UL, xmm4 );
-               (~C).store( i, j+SIMDSIZE*4UL, xmm5 );
+               (*C).store( i, j             , xmm1 );
+               (*C).store( i, j+SIMDSIZE    , xmm2 );
+               (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
+               (*C).store( i, j+SIMDSIZE*3UL, xmm4 );
+               (*C).store( i, j+SIMDSIZE*4UL, xmm5 );
             }
          }
 
@@ -894,14 +894,14 @@ class DTensDTensMultExpr
                   xmm8 += a2 * b4;
                }
 
-               (~C).store( i    , j             , xmm1 );
-               (~C).store( i    , j+SIMDSIZE    , xmm2 );
-               (~C).store( i    , j+SIMDSIZE*2UL, xmm3 );
-               (~C).store( i    , j+SIMDSIZE*3UL, xmm4 );
-               (~C).store( i+1UL, j             , xmm5 );
-               (~C).store( i+1UL, j+SIMDSIZE    , xmm6 );
-               (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm7 );
-               (~C).store( i+1UL, j+SIMDSIZE*3UL, xmm8 );
+               (*C).store( i    , j             , xmm1 );
+               (*C).store( i    , j+SIMDSIZE    , xmm2 );
+               (*C).store( i    , j+SIMDSIZE*2UL, xmm3 );
+               (*C).store( i    , j+SIMDSIZE*3UL, xmm4 );
+               (*C).store( i+1UL, j             , xmm5 );
+               (*C).store( i+1UL, j+SIMDSIZE    , xmm6 );
+               (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm7 );
+               (*C).store( i+1UL, j+SIMDSIZE*3UL, xmm8 );
             }
 
             if( i < iend )
@@ -919,10 +919,10 @@ class DTensDTensMultExpr
                   xmm4 += a1 * B.load(k,j+SIMDSIZE*3UL);
                }
 
-               (~C).store( i, j             , xmm1 );
-               (~C).store( i, j+SIMDSIZE    , xmm2 );
-               (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
-               (~C).store( i, j+SIMDSIZE*3UL, xmm4 );
+               (*C).store( i, j             , xmm1 );
+               (*C).store( i, j+SIMDSIZE    , xmm2 );
+               (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
+               (*C).store( i, j+SIMDSIZE*3UL, xmm4 );
             }
          }
 
@@ -952,12 +952,12 @@ class DTensDTensMultExpr
                   xmm6 += a2 * b3;
                }
 
-               (~C).store( i    , j             , xmm1 );
-               (~C).store( i    , j+SIMDSIZE    , xmm2 );
-               (~C).store( i    , j+SIMDSIZE*2UL, xmm3 );
-               (~C).store( i+1UL, j             , xmm4 );
-               (~C).store( i+1UL, j+SIMDSIZE    , xmm5 );
-               (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm6 );
+               (*C).store( i    , j             , xmm1 );
+               (*C).store( i    , j+SIMDSIZE    , xmm2 );
+               (*C).store( i    , j+SIMDSIZE*2UL, xmm3 );
+               (*C).store( i+1UL, j             , xmm4 );
+               (*C).store( i+1UL, j+SIMDSIZE    , xmm5 );
+               (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm6 );
             }
 
             if( i < iend )
@@ -974,9 +974,9 @@ class DTensDTensMultExpr
                   xmm3 += a1 * B.load(k,j+SIMDSIZE*2UL);
                }
 
-               (~C).store( i, j             , xmm1 );
-               (~C).store( i, j+SIMDSIZE    , xmm2 );
-               (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
+               (*C).store( i, j             , xmm1 );
+               (*C).store( i, j+SIMDSIZE    , xmm2 );
+               (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
             }
          }
 
@@ -1009,14 +1009,14 @@ class DTensDTensMultExpr
                   xmm8 += a4 * b2;
                }
 
-               (~C).store( i    , j         , xmm1 );
-               (~C).store( i    , j+SIMDSIZE, xmm2 );
-               (~C).store( i+1UL, j         , xmm3 );
-               (~C).store( i+1UL, j+SIMDSIZE, xmm4 );
-               (~C).store( i+2UL, j         , xmm5 );
-               (~C).store( i+2UL, j+SIMDSIZE, xmm6 );
-               (~C).store( i+3UL, j         , xmm7 );
-               (~C).store( i+3UL, j+SIMDSIZE, xmm8 );
+               (*C).store( i    , j         , xmm1 );
+               (*C).store( i    , j+SIMDSIZE, xmm2 );
+               (*C).store( i+1UL, j         , xmm3 );
+               (*C).store( i+1UL, j+SIMDSIZE, xmm4 );
+               (*C).store( i+2UL, j         , xmm5 );
+               (*C).store( i+2UL, j+SIMDSIZE, xmm6 );
+               (*C).store( i+3UL, j         , xmm7 );
+               (*C).store( i+3UL, j+SIMDSIZE, xmm8 );
             }
 
             for( ; (i+3UL) <= iend; i+=3UL )
@@ -1040,12 +1040,12 @@ class DTensDTensMultExpr
                   xmm6 += a3 * b2;
                }
 
-               (~C).store( i    , j         , xmm1 );
-               (~C).store( i    , j+SIMDSIZE, xmm2 );
-               (~C).store( i+1UL, j         , xmm3 );
-               (~C).store( i+1UL, j+SIMDSIZE, xmm4 );
-               (~C).store( i+2UL, j         , xmm5 );
-               (~C).store( i+2UL, j+SIMDSIZE, xmm6 );
+               (*C).store( i    , j         , xmm1 );
+               (*C).store( i    , j+SIMDSIZE, xmm2 );
+               (*C).store( i+1UL, j         , xmm3 );
+               (*C).store( i+1UL, j+SIMDSIZE, xmm4 );
+               (*C).store( i+2UL, j         , xmm5 );
+               (*C).store( i+2UL, j+SIMDSIZE, xmm6 );
             }
 
             for( ; (i+2UL) <= iend; i+=2UL )
@@ -1086,10 +1086,10 @@ class DTensDTensMultExpr
                   xmm4 += a2 * b2;
                }
 
-               (~C).store( i    , j         , xmm1+xmm5 );
-               (~C).store( i    , j+SIMDSIZE, xmm2+xmm6 );
-               (~C).store( i+1UL, j         , xmm3+xmm7 );
-               (~C).store( i+1UL, j+SIMDSIZE, xmm4+xmm8 );
+               (*C).store( i    , j         , xmm1+xmm5 );
+               (*C).store( i    , j+SIMDSIZE, xmm2+xmm6 );
+               (*C).store( i+1UL, j         , xmm3+xmm7 );
+               (*C).store( i+1UL, j+SIMDSIZE, xmm4+xmm8 );
             }
 
             if( i < iend )
@@ -1115,8 +1115,8 @@ class DTensDTensMultExpr
                   xmm2 += a1 * B.load(k,j+SIMDSIZE);
                }
 
-               (~C).store( i, j         , xmm1+xmm3 );
-               (~C).store( i, j+SIMDSIZE, xmm2+xmm4 );
+               (*C).store( i, j         , xmm1+xmm3 );
+               (*C).store( i, j+SIMDSIZE, xmm2+xmm4 );
             }
          }
 
@@ -1154,10 +1154,10 @@ class DTensDTensMultExpr
                   xmm4 += set( A(i+3UL,k) ) * b1;
                }
 
-               (~C).store( i    , j, xmm1+xmm5 );
-               (~C).store( i+1UL, j, xmm2+xmm6 );
-               (~C).store( i+2UL, j, xmm3+xmm7 );
-               (~C).store( i+3UL, j, xmm4+xmm8 );
+               (*C).store( i    , j, xmm1+xmm5 );
+               (*C).store( i+1UL, j, xmm2+xmm6 );
+               (*C).store( i+2UL, j, xmm3+xmm7 );
+               (*C).store( i+3UL, j, xmm4+xmm8 );
             }
 
             for( ; (i+3UL) <= iend; i+=3UL )
@@ -1186,9 +1186,9 @@ class DTensDTensMultExpr
                   xmm3 += set( A(i+2UL,k) ) * b1;
                }
 
-               (~C).store( i    , j, xmm1+xmm4 );
-               (~C).store( i+1UL, j, xmm2+xmm5 );
-               (~C).store( i+2UL, j, xmm3+xmm6 );
+               (*C).store( i    , j, xmm1+xmm4 );
+               (*C).store( i+1UL, j, xmm2+xmm5 );
+               (*C).store( i+2UL, j, xmm3+xmm6 );
             }
 
             for( ; (i+2UL) <= iend; i+=2UL )
@@ -1214,8 +1214,8 @@ class DTensDTensMultExpr
                   xmm2 += set( A(i+1UL,k) ) * b1;
                }
 
-               (~C).store( i    , j, xmm1+xmm3 );
-               (~C).store( i+1UL, j, xmm2+xmm4 );
+               (*C).store( i    , j, xmm1+xmm3 );
+               (*C).store( i+1UL, j, xmm2+xmm4 );
             }
 
             if( i < iend )
@@ -1234,7 +1234,7 @@ class DTensDTensMultExpr
                   xmm1 += set( A(i,k) ) * B.load(k,j);
                }
 
-               (~C).store( i, j, xmm1+xmm2 );
+               (*C).store( i, j, xmm1+xmm2 );
             }
          }
 
@@ -1255,8 +1255,8 @@ class DTensDTensMultExpr
                   value2 += A(i+1UL,k) * B(k,j);
                }
 
-               (~C)(i    ,j) = value1;
-               (~C)(i+1UL,j) = value2;
+               (*C)(i    ,j) = value1;
+               (*C)(i+1UL,j) = value2;
             }
 
             if( i < M )
@@ -1269,7 +1269,7 @@ class DTensDTensMultExpr
                   value += A(i,k) * B(k,j);
                }
 
-               (~C)(i,j) = value;
+               (*C)(i,j) = value;
             }
          }
       }
@@ -1406,10 +1406,10 @@ class DTensDTensMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || rhs.lhs_.columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || rhs.lhs_.columns() == 0UL ) {
          return;
       }
 
@@ -1420,10 +1420,10 @@ class DTensDTensMultExpr
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.lhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
 
-      DTensDTensMultExpr::selectAddAssignKernel( ~lhs, A, B );
+      DTensDTensMultExpr::selectAddAssignKernel( *lhs, A, B );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1726,14 +1726,14 @@ class DTensDTensMultExpr
                                      :( IsStrictlyLower_v<MT4> ? i : i+1UL ) )
                                   :( IsUpper_v<MT5> ? min( j+SIMDSIZE*8UL, K ) : K ) );
 
-               SIMDType xmm1( (~C).load(i,j             ) );
-               SIMDType xmm2( (~C).load(i,j+SIMDSIZE    ) );
-               SIMDType xmm3( (~C).load(i,j+SIMDSIZE*2UL) );
-               SIMDType xmm4( (~C).load(i,j+SIMDSIZE*3UL) );
-               SIMDType xmm5( (~C).load(i,j+SIMDSIZE*4UL) );
-               SIMDType xmm6( (~C).load(i,j+SIMDSIZE*5UL) );
-               SIMDType xmm7( (~C).load(i,j+SIMDSIZE*6UL) );
-               SIMDType xmm8( (~C).load(i,j+SIMDSIZE*7UL) );
+               SIMDType xmm1( (*C).load(i,j             ) );
+               SIMDType xmm2( (*C).load(i,j+SIMDSIZE    ) );
+               SIMDType xmm3( (*C).load(i,j+SIMDSIZE*2UL) );
+               SIMDType xmm4( (*C).load(i,j+SIMDSIZE*3UL) );
+               SIMDType xmm5( (*C).load(i,j+SIMDSIZE*4UL) );
+               SIMDType xmm6( (*C).load(i,j+SIMDSIZE*5UL) );
+               SIMDType xmm7( (*C).load(i,j+SIMDSIZE*6UL) );
+               SIMDType xmm8( (*C).load(i,j+SIMDSIZE*7UL) );
 
                for( size_t k=kbegin; k<kend; ++k ) {
                   const SIMDType a1( set( A(i,k) ) );
@@ -1747,14 +1747,14 @@ class DTensDTensMultExpr
                   xmm8 += a1 * B.load(k,j+SIMDSIZE*7UL);
                }
 
-               (~C).store( i, j             , xmm1 );
-               (~C).store( i, j+SIMDSIZE    , xmm2 );
-               (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
-               (~C).store( i, j+SIMDSIZE*3UL, xmm4 );
-               (~C).store( i, j+SIMDSIZE*4UL, xmm5 );
-               (~C).store( i, j+SIMDSIZE*5UL, xmm6 );
-               (~C).store( i, j+SIMDSIZE*6UL, xmm7 );
-               (~C).store( i, j+SIMDSIZE*7UL, xmm8 );
+               (*C).store( i, j             , xmm1 );
+               (*C).store( i, j+SIMDSIZE    , xmm2 );
+               (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
+               (*C).store( i, j+SIMDSIZE*3UL, xmm4 );
+               (*C).store( i, j+SIMDSIZE*4UL, xmm5 );
+               (*C).store( i, j+SIMDSIZE*5UL, xmm6 );
+               (*C).store( i, j+SIMDSIZE*6UL, xmm7 );
+               (*C).store( i, j+SIMDSIZE*7UL, xmm8 );
             }
          }
       }
@@ -1776,16 +1776,16 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*5UL, K ) : K ) );
 
-            SIMDType xmm1 ( (~C).load(i    ,j             ) );
-            SIMDType xmm2 ( (~C).load(i    ,j+SIMDSIZE    ) );
-            SIMDType xmm3 ( (~C).load(i    ,j+SIMDSIZE*2UL) );
-            SIMDType xmm4 ( (~C).load(i    ,j+SIMDSIZE*3UL) );
-            SIMDType xmm5 ( (~C).load(i    ,j+SIMDSIZE*4UL) );
-            SIMDType xmm6 ( (~C).load(i+1UL,j             ) );
-            SIMDType xmm7 ( (~C).load(i+1UL,j+SIMDSIZE    ) );
-            SIMDType xmm8 ( (~C).load(i+1UL,j+SIMDSIZE*2UL) );
-            SIMDType xmm9 ( (~C).load(i+1UL,j+SIMDSIZE*3UL) );
-            SIMDType xmm10( (~C).load(i+1UL,j+SIMDSIZE*4UL) );
+            SIMDType xmm1 ( (*C).load(i    ,j             ) );
+            SIMDType xmm2 ( (*C).load(i    ,j+SIMDSIZE    ) );
+            SIMDType xmm3 ( (*C).load(i    ,j+SIMDSIZE*2UL) );
+            SIMDType xmm4 ( (*C).load(i    ,j+SIMDSIZE*3UL) );
+            SIMDType xmm5 ( (*C).load(i    ,j+SIMDSIZE*4UL) );
+            SIMDType xmm6 ( (*C).load(i+1UL,j             ) );
+            SIMDType xmm7 ( (*C).load(i+1UL,j+SIMDSIZE    ) );
+            SIMDType xmm8 ( (*C).load(i+1UL,j+SIMDSIZE*2UL) );
+            SIMDType xmm9 ( (*C).load(i+1UL,j+SIMDSIZE*3UL) );
+            SIMDType xmm10( (*C).load(i+1UL,j+SIMDSIZE*4UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -1807,16 +1807,16 @@ class DTensDTensMultExpr
                xmm10 += a2 * b5;
             }
 
-            (~C).store( i    , j             , xmm1  );
-            (~C).store( i    , j+SIMDSIZE    , xmm2  );
-            (~C).store( i    , j+SIMDSIZE*2UL, xmm3  );
-            (~C).store( i    , j+SIMDSIZE*3UL, xmm4  );
-            (~C).store( i    , j+SIMDSIZE*4UL, xmm5  );
-            (~C).store( i+1UL, j             , xmm6  );
-            (~C).store( i+1UL, j+SIMDSIZE    , xmm7  );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm8  );
-            (~C).store( i+1UL, j+SIMDSIZE*3UL, xmm9  );
-            (~C).store( i+1UL, j+SIMDSIZE*4UL, xmm10 );
+            (*C).store( i    , j             , xmm1  );
+            (*C).store( i    , j+SIMDSIZE    , xmm2  );
+            (*C).store( i    , j+SIMDSIZE*2UL, xmm3  );
+            (*C).store( i    , j+SIMDSIZE*3UL, xmm4  );
+            (*C).store( i    , j+SIMDSIZE*4UL, xmm5  );
+            (*C).store( i+1UL, j             , xmm6  );
+            (*C).store( i+1UL, j+SIMDSIZE    , xmm7  );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm8  );
+            (*C).store( i+1UL, j+SIMDSIZE*3UL, xmm9  );
+            (*C).store( i+1UL, j+SIMDSIZE*4UL, xmm10 );
          }
 
          if( i < M )
@@ -1828,11 +1828,11 @@ class DTensDTensMultExpr
                                  :( IsLower_v<MT5> ? j : 0UL ) );
             const size_t kend( ( IsUpper_v<MT5> )?( min( j+SIMDSIZE*5UL, K ) ):( K ) );
 
-            SIMDType xmm1( (~C).load(i,j             ) );
-            SIMDType xmm2( (~C).load(i,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i,j+SIMDSIZE*2UL) );
-            SIMDType xmm4( (~C).load(i,j+SIMDSIZE*3UL) );
-            SIMDType xmm5( (~C).load(i,j+SIMDSIZE*4UL) );
+            SIMDType xmm1( (*C).load(i,j             ) );
+            SIMDType xmm2( (*C).load(i,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i,j+SIMDSIZE*2UL) );
+            SIMDType xmm4( (*C).load(i,j+SIMDSIZE*3UL) );
+            SIMDType xmm5( (*C).load(i,j+SIMDSIZE*4UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i,k) ) );
@@ -1843,11 +1843,11 @@ class DTensDTensMultExpr
                xmm5 += a1 * B.load(k,j+SIMDSIZE*4UL);
             }
 
-            (~C).store( i, j             , xmm1 );
-            (~C).store( i, j+SIMDSIZE    , xmm2 );
-            (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
-            (~C).store( i, j+SIMDSIZE*3UL, xmm4 );
-            (~C).store( i, j+SIMDSIZE*4UL, xmm5 );
+            (*C).store( i, j             , xmm1 );
+            (*C).store( i, j+SIMDSIZE    , xmm2 );
+            (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i, j+SIMDSIZE*3UL, xmm4 );
+            (*C).store( i, j+SIMDSIZE*4UL, xmm5 );
          }
       }
 
@@ -1868,14 +1868,14 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*4UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j             ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i    ,j+SIMDSIZE*2UL) );
-            SIMDType xmm4( (~C).load(i    ,j+SIMDSIZE*3UL) );
-            SIMDType xmm5( (~C).load(i+1UL,j             ) );
-            SIMDType xmm6( (~C).load(i+1UL,j+SIMDSIZE    ) );
-            SIMDType xmm7( (~C).load(i+1UL,j+SIMDSIZE*2UL) );
-            SIMDType xmm8( (~C).load(i+1UL,j+SIMDSIZE*3UL) );
+            SIMDType xmm1( (*C).load(i    ,j             ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i    ,j+SIMDSIZE*2UL) );
+            SIMDType xmm4( (*C).load(i    ,j+SIMDSIZE*3UL) );
+            SIMDType xmm5( (*C).load(i+1UL,j             ) );
+            SIMDType xmm6( (*C).load(i+1UL,j+SIMDSIZE    ) );
+            SIMDType xmm7( (*C).load(i+1UL,j+SIMDSIZE*2UL) );
+            SIMDType xmm8( (*C).load(i+1UL,j+SIMDSIZE*3UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -1894,14 +1894,14 @@ class DTensDTensMultExpr
                xmm8 += a2 * b4;
             }
 
-            (~C).store( i    , j             , xmm1 );
-            (~C).store( i    , j+SIMDSIZE    , xmm2 );
-            (~C).store( i    , j+SIMDSIZE*2UL, xmm3 );
-            (~C).store( i    , j+SIMDSIZE*3UL, xmm4 );
-            (~C).store( i+1UL, j             , xmm5 );
-            (~C).store( i+1UL, j+SIMDSIZE    , xmm6 );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm7 );
-            (~C).store( i+1UL, j+SIMDSIZE*3UL, xmm8 );
+            (*C).store( i    , j             , xmm1 );
+            (*C).store( i    , j+SIMDSIZE    , xmm2 );
+            (*C).store( i    , j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i    , j+SIMDSIZE*3UL, xmm4 );
+            (*C).store( i+1UL, j             , xmm5 );
+            (*C).store( i+1UL, j+SIMDSIZE    , xmm6 );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm7 );
+            (*C).store( i+1UL, j+SIMDSIZE*3UL, xmm8 );
          }
 
          if( i < M )
@@ -1913,10 +1913,10 @@ class DTensDTensMultExpr
                                  :( IsLower_v<MT5> ? j : 0UL ) );
             const size_t kend( ( IsUpper_v<MT5> )?( min( j+SIMDSIZE*4UL, K ) ):( K ) );
 
-            SIMDType xmm1( (~C).load(i,j             ) );
-            SIMDType xmm2( (~C).load(i,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i,j+SIMDSIZE*2UL) );
-            SIMDType xmm4( (~C).load(i,j+SIMDSIZE*3UL) );
+            SIMDType xmm1( (*C).load(i,j             ) );
+            SIMDType xmm2( (*C).load(i,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i,j+SIMDSIZE*2UL) );
+            SIMDType xmm4( (*C).load(i,j+SIMDSIZE*3UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i,k) ) );
@@ -1926,10 +1926,10 @@ class DTensDTensMultExpr
                xmm4 += a1 * B.load(k,j+SIMDSIZE*3UL);
             }
 
-            (~C).store( i, j             , xmm1 );
-            (~C).store( i, j+SIMDSIZE    , xmm2 );
-            (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
-            (~C).store( i, j+SIMDSIZE*3UL, xmm4 );
+            (*C).store( i, j             , xmm1 );
+            (*C).store( i, j+SIMDSIZE    , xmm2 );
+            (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i, j+SIMDSIZE*3UL, xmm4 );
          }
       }
 
@@ -1950,12 +1950,12 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*3UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j             ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i    ,j+SIMDSIZE*2UL) );
-            SIMDType xmm4( (~C).load(i+1UL,j             ) );
-            SIMDType xmm5( (~C).load(i+1UL,j+SIMDSIZE    ) );
-            SIMDType xmm6( (~C).load(i+1UL,j+SIMDSIZE*2UL) );
+            SIMDType xmm1( (*C).load(i    ,j             ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i    ,j+SIMDSIZE*2UL) );
+            SIMDType xmm4( (*C).load(i+1UL,j             ) );
+            SIMDType xmm5( (*C).load(i+1UL,j+SIMDSIZE    ) );
+            SIMDType xmm6( (*C).load(i+1UL,j+SIMDSIZE*2UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -1971,12 +1971,12 @@ class DTensDTensMultExpr
                xmm6 += a2 * b3;
             }
 
-            (~C).store( i    , j             , xmm1 );
-            (~C).store( i    , j+SIMDSIZE    , xmm2 );
-            (~C).store( i    , j+SIMDSIZE*2UL, xmm3 );
-            (~C).store( i+1UL, j             , xmm4 );
-            (~C).store( i+1UL, j+SIMDSIZE    , xmm5 );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm6 );
+            (*C).store( i    , j             , xmm1 );
+            (*C).store( i    , j+SIMDSIZE    , xmm2 );
+            (*C).store( i    , j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i+1UL, j             , xmm4 );
+            (*C).store( i+1UL, j+SIMDSIZE    , xmm5 );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm6 );
          }
 
          if( i < M )
@@ -1988,9 +1988,9 @@ class DTensDTensMultExpr
                                  :( IsLower_v<MT5> ? j : 0UL ) );
             const size_t kend( ( IsUpper_v<MT5> )?( min( j+SIMDSIZE*3UL, K ) ):( K ) );
 
-            SIMDType xmm1( (~C).load(i,j             ) );
-            SIMDType xmm2( (~C).load(i,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i,j+SIMDSIZE*2UL) );
+            SIMDType xmm1( (*C).load(i,j             ) );
+            SIMDType xmm2( (*C).load(i,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i,j+SIMDSIZE*2UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i,k) ) );
@@ -1999,9 +1999,9 @@ class DTensDTensMultExpr
                xmm3 += a1 * B.load(k,j+SIMDSIZE*2UL);
             }
 
-            (~C).store( i, j             , xmm1 );
-            (~C).store( i, j+SIMDSIZE    , xmm2 );
-            (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i, j             , xmm1 );
+            (*C).store( i, j+SIMDSIZE    , xmm2 );
+            (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
          }
       }
 
@@ -2023,14 +2023,14 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+3UL : i+4UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*2UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j         ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE) );
-            SIMDType xmm3( (~C).load(i+1UL,j         ) );
-            SIMDType xmm4( (~C).load(i+1UL,j+SIMDSIZE) );
-            SIMDType xmm5( (~C).load(i+2UL,j         ) );
-            SIMDType xmm6( (~C).load(i+2UL,j+SIMDSIZE) );
-            SIMDType xmm7( (~C).load(i+3UL,j         ) );
-            SIMDType xmm8( (~C).load(i+3UL,j+SIMDSIZE) );
+            SIMDType xmm1( (*C).load(i    ,j         ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE) );
+            SIMDType xmm3( (*C).load(i+1UL,j         ) );
+            SIMDType xmm4( (*C).load(i+1UL,j+SIMDSIZE) );
+            SIMDType xmm5( (*C).load(i+2UL,j         ) );
+            SIMDType xmm6( (*C).load(i+2UL,j+SIMDSIZE) );
+            SIMDType xmm7( (*C).load(i+3UL,j         ) );
+            SIMDType xmm8( (*C).load(i+3UL,j+SIMDSIZE) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -2049,14 +2049,14 @@ class DTensDTensMultExpr
                xmm8 += a4 * b2;
             }
 
-            (~C).store( i    , j         , xmm1 );
-            (~C).store( i    , j+SIMDSIZE, xmm2 );
-            (~C).store( i+1UL, j         , xmm3 );
-            (~C).store( i+1UL, j+SIMDSIZE, xmm4 );
-            (~C).store( i+2UL, j         , xmm5 );
-            (~C).store( i+2UL, j+SIMDSIZE, xmm6 );
-            (~C).store( i+3UL, j         , xmm7 );
-            (~C).store( i+3UL, j+SIMDSIZE, xmm8 );
+            (*C).store( i    , j         , xmm1 );
+            (*C).store( i    , j+SIMDSIZE, xmm2 );
+            (*C).store( i+1UL, j         , xmm3 );
+            (*C).store( i+1UL, j+SIMDSIZE, xmm4 );
+            (*C).store( i+2UL, j         , xmm5 );
+            (*C).store( i+2UL, j+SIMDSIZE, xmm6 );
+            (*C).store( i+3UL, j         , xmm7 );
+            (*C).store( i+3UL, j+SIMDSIZE, xmm8 );
          }
 
          for( ; (i+3UL) <= iend; i+=3UL )
@@ -2072,12 +2072,12 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+2UL : i+3UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*2UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j         ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE) );
-            SIMDType xmm3( (~C).load(i+1UL,j         ) );
-            SIMDType xmm4( (~C).load(i+1UL,j+SIMDSIZE) );
-            SIMDType xmm5( (~C).load(i+2UL,j         ) );
-            SIMDType xmm6( (~C).load(i+2UL,j+SIMDSIZE) );
+            SIMDType xmm1( (*C).load(i    ,j         ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE) );
+            SIMDType xmm3( (*C).load(i+1UL,j         ) );
+            SIMDType xmm4( (*C).load(i+1UL,j+SIMDSIZE) );
+            SIMDType xmm5( (*C).load(i+2UL,j         ) );
+            SIMDType xmm6( (*C).load(i+2UL,j+SIMDSIZE) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -2093,12 +2093,12 @@ class DTensDTensMultExpr
                xmm6 += a3 * b2;
             }
 
-            (~C).store( i    , j         , xmm1 );
-            (~C).store( i    , j+SIMDSIZE, xmm2 );
-            (~C).store( i+1UL, j         , xmm3 );
-            (~C).store( i+1UL, j+SIMDSIZE, xmm4 );
-            (~C).store( i+2UL, j         , xmm5 );
-            (~C).store( i+2UL, j+SIMDSIZE, xmm6 );
+            (*C).store( i    , j         , xmm1 );
+            (*C).store( i    , j+SIMDSIZE, xmm2 );
+            (*C).store( i+1UL, j         , xmm3 );
+            (*C).store( i+1UL, j+SIMDSIZE, xmm4 );
+            (*C).store( i+2UL, j         , xmm5 );
+            (*C).store( i+2UL, j+SIMDSIZE, xmm6 );
          }
 
          for( ; (i+2UL) <= iend; i+=2UL )
@@ -2114,10 +2114,10 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*2UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j         ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE) );
-            SIMDType xmm3( (~C).load(i+1UL,j         ) );
-            SIMDType xmm4( (~C).load(i+1UL,j+SIMDSIZE) );
+            SIMDType xmm1( (*C).load(i    ,j         ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE) );
+            SIMDType xmm3( (*C).load(i+1UL,j         ) );
+            SIMDType xmm4( (*C).load(i+1UL,j+SIMDSIZE) );
             SIMDType xmm5, xmm6, xmm7, xmm8;
             size_t k( kbegin );
 
@@ -2151,10 +2151,10 @@ class DTensDTensMultExpr
                xmm4 += a2 * b2;
             }
 
-            (~C).store( i    , j         , xmm1+xmm5 );
-            (~C).store( i    , j+SIMDSIZE, xmm2+xmm6 );
-            (~C).store( i+1UL, j         , xmm3+xmm7 );
-            (~C).store( i+1UL, j+SIMDSIZE, xmm4+xmm8 );
+            (*C).store( i    , j         , xmm1+xmm5 );
+            (*C).store( i    , j+SIMDSIZE, xmm2+xmm6 );
+            (*C).store( i+1UL, j         , xmm3+xmm7 );
+            (*C).store( i+1UL, j+SIMDSIZE, xmm4+xmm8 );
          }
 
          if( i < iend )
@@ -2166,8 +2166,8 @@ class DTensDTensMultExpr
                                  :( IsLower_v<MT5> ? j : 0UL ) );
             const size_t kend( ( IsUpper_v<MT5> )?( min( j+SIMDSIZE*2UL, K ) ):( K ) );
 
-            SIMDType xmm1( (~C).load(i,j         ) );
-            SIMDType xmm2( (~C).load(i,j+SIMDSIZE) );
+            SIMDType xmm1( (*C).load(i,j         ) );
+            SIMDType xmm2( (*C).load(i,j+SIMDSIZE) );
             SIMDType xmm3, xmm4;
             size_t k( kbegin );
 
@@ -2186,8 +2186,8 @@ class DTensDTensMultExpr
                xmm2 += a1 * B.load(k,j+SIMDSIZE);
             }
 
-            (~C).store( i, j         , xmm1+xmm3 );
-            (~C).store( i, j+SIMDSIZE, xmm2+xmm4 );
+            (*C).store( i, j         , xmm1+xmm3 );
+            (*C).store( i, j+SIMDSIZE, xmm2+xmm4 );
          }
       }
 
@@ -2207,10 +2207,10 @@ class DTensDTensMultExpr
                                ?( IsStrictlyLower_v<MT4> ? i+3UL : i+4UL )
                                :( K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j) );
-            SIMDType xmm2( (~C).load(i+1UL,j) );
-            SIMDType xmm3( (~C).load(i+2UL,j) );
-            SIMDType xmm4( (~C).load(i+3UL,j) );
+            SIMDType xmm1( (*C).load(i    ,j) );
+            SIMDType xmm2( (*C).load(i+1UL,j) );
+            SIMDType xmm3( (*C).load(i+2UL,j) );
+            SIMDType xmm4( (*C).load(i+3UL,j) );
             SIMDType xmm5, xmm6, xmm7, xmm8;
             size_t k( kbegin );
 
@@ -2235,10 +2235,10 @@ class DTensDTensMultExpr
                xmm4 += set( A(i+3UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, xmm1+xmm5 );
-            (~C).store( i+1UL, j, xmm2+xmm6 );
-            (~C).store( i+2UL, j, xmm3+xmm7 );
-            (~C).store( i+3UL, j, xmm4+xmm8 );
+            (*C).store( i    , j, xmm1+xmm5 );
+            (*C).store( i+1UL, j, xmm2+xmm6 );
+            (*C).store( i+2UL, j, xmm3+xmm7 );
+            (*C).store( i+3UL, j, xmm4+xmm8 );
          }
 
          for( ; (i+3UL) <= iend; i+=3UL )
@@ -2252,9 +2252,9 @@ class DTensDTensMultExpr
                                ?( IsStrictlyLower_v<MT4> ? i+2UL : i+3UL )
                                :( K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j) );
-            SIMDType xmm2( (~C).load(i+1UL,j) );
-            SIMDType xmm3( (~C).load(i+2UL,j) );
+            SIMDType xmm1( (*C).load(i    ,j) );
+            SIMDType xmm2( (*C).load(i+1UL,j) );
+            SIMDType xmm3( (*C).load(i+2UL,j) );
             SIMDType xmm4, xmm5, xmm6;
             size_t k( kbegin );
 
@@ -2276,9 +2276,9 @@ class DTensDTensMultExpr
                xmm3 += set( A(i+2UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, xmm1+xmm4 );
-            (~C).store( i+1UL, j, xmm2+xmm5 );
-            (~C).store( i+2UL, j, xmm3+xmm6 );
+            (*C).store( i    , j, xmm1+xmm4 );
+            (*C).store( i+1UL, j, xmm2+xmm5 );
+            (*C).store( i+2UL, j, xmm3+xmm6 );
          }
 
          for( ; (i+2UL) <= iend; i+=2UL )
@@ -2292,8 +2292,8 @@ class DTensDTensMultExpr
                                ?( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL )
                                :( K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j) );
-            SIMDType xmm2( (~C).load(i+1UL,j) );
+            SIMDType xmm1( (*C).load(i    ,j) );
+            SIMDType xmm2( (*C).load(i+1UL,j) );
             SIMDType xmm3, xmm4;
             size_t k( kbegin );
 
@@ -2312,8 +2312,8 @@ class DTensDTensMultExpr
                xmm2 += set( A(i+1UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, xmm1+xmm3 );
-            (~C).store( i+1UL, j, xmm2+xmm4 );
+            (*C).store( i    , j, xmm1+xmm3 );
+            (*C).store( i+1UL, j, xmm2+xmm4 );
          }
 
          if( i < iend )
@@ -2324,7 +2324,7 @@ class DTensDTensMultExpr
                                     :( IsStrictlyUpper_v<MT4> ? i+1UL : i ) )
                                  :( IsLower_v<MT5> ? j : 0UL ) );
 
-            SIMDType xmm1( (~C).load(i,j) );
+            SIMDType xmm1( (*C).load(i,j) );
             SIMDType xmm2;
             size_t k( kbegin );
 
@@ -2337,7 +2337,7 @@ class DTensDTensMultExpr
                xmm1 += set( A(i,k) ) * B.load(k,j);
             }
 
-            (~C).store( i, j, xmm1+xmm2 );
+            (*C).store( i, j, xmm1+xmm2 );
          }
       }
 
@@ -2357,16 +2357,16 @@ class DTensDTensMultExpr
                                ?( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL )
                                :( K ) );
 
-            ElementType value1( (~C)(i    ,j) );
-            ElementType value2( (~C)(i+1UL,j) );;
+            ElementType value1( (*C)(i    ,j) );
+            ElementType value2( (*C)(i+1UL,j) );;
 
             for( size_t k=kbegin; k<kend; ++k ) {
                value1 += A(i    ,k) * B(k,j);
                value2 += A(i+1UL,k) * B(k,j);
             }
 
-            (~C)(i    ,j) = value1;
-            (~C)(i+1UL,j) = value2;
+            (*C)(i    ,j) = value1;
+            (*C)(i+1UL,j) = value2;
          }
 
          if( i < iend )
@@ -2377,13 +2377,13 @@ class DTensDTensMultExpr
                                     :( IsStrictlyUpper_v<MT4> ? i+1UL : i ) )
                                  :( IsLower_v<MT5> ? j : 0UL ) );
 
-            ElementType value( (~C)(i,j) );
+            ElementType value( (*C)(i,j) );
 
             for( size_t k=kbegin; k<K; ++k ) {
                value += A(i,k) * B(k,j);
             }
 
-            (~C)(i,j) = value;
+            (*C)(i,j) = value;
          }
       }
    }
@@ -2532,10 +2532,10 @@ class DTensDTensMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || rhs.lhs_.columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || rhs.lhs_.columns() == 0UL ) {
          return;
       }
 
@@ -2546,10 +2546,10 @@ class DTensDTensMultExpr
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.lhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
 
-      DTensDTensMultExpr::selectSubAssignKernel( ~lhs, A, B );
+      DTensDTensMultExpr::selectSubAssignKernel( *lhs, A, B );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2852,14 +2852,14 @@ class DTensDTensMultExpr
                                      :( IsStrictlyLower_v<MT4> ? i : i+1UL ) )
                                   :( IsUpper_v<MT5> ? min( j+SIMDSIZE*8UL, K ) : K ) );
 
-               SIMDType xmm1( (~C).load(i,j             ) );
-               SIMDType xmm2( (~C).load(i,j+SIMDSIZE    ) );
-               SIMDType xmm3( (~C).load(i,j+SIMDSIZE*2UL) );
-               SIMDType xmm4( (~C).load(i,j+SIMDSIZE*3UL) );
-               SIMDType xmm5( (~C).load(i,j+SIMDSIZE*4UL) );
-               SIMDType xmm6( (~C).load(i,j+SIMDSIZE*5UL) );
-               SIMDType xmm7( (~C).load(i,j+SIMDSIZE*6UL) );
-               SIMDType xmm8( (~C).load(i,j+SIMDSIZE*7UL) );
+               SIMDType xmm1( (*C).load(i,j             ) );
+               SIMDType xmm2( (*C).load(i,j+SIMDSIZE    ) );
+               SIMDType xmm3( (*C).load(i,j+SIMDSIZE*2UL) );
+               SIMDType xmm4( (*C).load(i,j+SIMDSIZE*3UL) );
+               SIMDType xmm5( (*C).load(i,j+SIMDSIZE*4UL) );
+               SIMDType xmm6( (*C).load(i,j+SIMDSIZE*5UL) );
+               SIMDType xmm7( (*C).load(i,j+SIMDSIZE*6UL) );
+               SIMDType xmm8( (*C).load(i,j+SIMDSIZE*7UL) );
 
                for( size_t k=kbegin; k<kend; ++k ) {
                   const SIMDType a1( set( A(i,k) ) );
@@ -2873,14 +2873,14 @@ class DTensDTensMultExpr
                   xmm8 -= a1 * B.load(k,j+SIMDSIZE*7UL);
                }
 
-               (~C).store( i, j             , xmm1 );
-               (~C).store( i, j+SIMDSIZE    , xmm2 );
-               (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
-               (~C).store( i, j+SIMDSIZE*3UL, xmm4 );
-               (~C).store( i, j+SIMDSIZE*4UL, xmm5 );
-               (~C).store( i, j+SIMDSIZE*5UL, xmm6 );
-               (~C).store( i, j+SIMDSIZE*6UL, xmm7 );
-               (~C).store( i, j+SIMDSIZE*7UL, xmm8 );
+               (*C).store( i, j             , xmm1 );
+               (*C).store( i, j+SIMDSIZE    , xmm2 );
+               (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
+               (*C).store( i, j+SIMDSIZE*3UL, xmm4 );
+               (*C).store( i, j+SIMDSIZE*4UL, xmm5 );
+               (*C).store( i, j+SIMDSIZE*5UL, xmm6 );
+               (*C).store( i, j+SIMDSIZE*6UL, xmm7 );
+               (*C).store( i, j+SIMDSIZE*7UL, xmm8 );
             }
          }
       }
@@ -2902,16 +2902,16 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*5UL, K ) : K ) );
 
-            SIMDType xmm1 ( (~C).load(i    ,j             ) );
-            SIMDType xmm2 ( (~C).load(i    ,j+SIMDSIZE    ) );
-            SIMDType xmm3 ( (~C).load(i    ,j+SIMDSIZE*2UL) );
-            SIMDType xmm4 ( (~C).load(i    ,j+SIMDSIZE*3UL) );
-            SIMDType xmm5 ( (~C).load(i    ,j+SIMDSIZE*4UL) );
-            SIMDType xmm6 ( (~C).load(i+1UL,j             ) );
-            SIMDType xmm7 ( (~C).load(i+1UL,j+SIMDSIZE    ) );
-            SIMDType xmm8 ( (~C).load(i+1UL,j+SIMDSIZE*2UL) );
-            SIMDType xmm9 ( (~C).load(i+1UL,j+SIMDSIZE*3UL) );
-            SIMDType xmm10( (~C).load(i+1UL,j+SIMDSIZE*4UL) );
+            SIMDType xmm1 ( (*C).load(i    ,j             ) );
+            SIMDType xmm2 ( (*C).load(i    ,j+SIMDSIZE    ) );
+            SIMDType xmm3 ( (*C).load(i    ,j+SIMDSIZE*2UL) );
+            SIMDType xmm4 ( (*C).load(i    ,j+SIMDSIZE*3UL) );
+            SIMDType xmm5 ( (*C).load(i    ,j+SIMDSIZE*4UL) );
+            SIMDType xmm6 ( (*C).load(i+1UL,j             ) );
+            SIMDType xmm7 ( (*C).load(i+1UL,j+SIMDSIZE    ) );
+            SIMDType xmm8 ( (*C).load(i+1UL,j+SIMDSIZE*2UL) );
+            SIMDType xmm9 ( (*C).load(i+1UL,j+SIMDSIZE*3UL) );
+            SIMDType xmm10( (*C).load(i+1UL,j+SIMDSIZE*4UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -2933,16 +2933,16 @@ class DTensDTensMultExpr
                xmm10 -= a2 * b5;
             }
 
-            (~C).store( i    , j             , xmm1  );
-            (~C).store( i    , j+SIMDSIZE    , xmm2  );
-            (~C).store( i    , j+SIMDSIZE*2UL, xmm3  );
-            (~C).store( i    , j+SIMDSIZE*3UL, xmm4  );
-            (~C).store( i    , j+SIMDSIZE*4UL, xmm5  );
-            (~C).store( i+1UL, j             , xmm6  );
-            (~C).store( i+1UL, j+SIMDSIZE    , xmm7  );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm8  );
-            (~C).store( i+1UL, j+SIMDSIZE*3UL, xmm9  );
-            (~C).store( i+1UL, j+SIMDSIZE*4UL, xmm10 );
+            (*C).store( i    , j             , xmm1  );
+            (*C).store( i    , j+SIMDSIZE    , xmm2  );
+            (*C).store( i    , j+SIMDSIZE*2UL, xmm3  );
+            (*C).store( i    , j+SIMDSIZE*3UL, xmm4  );
+            (*C).store( i    , j+SIMDSIZE*4UL, xmm5  );
+            (*C).store( i+1UL, j             , xmm6  );
+            (*C).store( i+1UL, j+SIMDSIZE    , xmm7  );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm8  );
+            (*C).store( i+1UL, j+SIMDSIZE*3UL, xmm9  );
+            (*C).store( i+1UL, j+SIMDSIZE*4UL, xmm10 );
          }
 
          if( i < M )
@@ -2954,11 +2954,11 @@ class DTensDTensMultExpr
                                  :( IsLower_v<MT5> ? j : 0UL ) );
             const size_t kend( ( IsUpper_v<MT5> )?( min( j+SIMDSIZE*5UL, K ) ):( K ) );
 
-            SIMDType xmm1( (~C).load(i,j             ) );
-            SIMDType xmm2( (~C).load(i,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i,j+SIMDSIZE*2UL) );
-            SIMDType xmm4( (~C).load(i,j+SIMDSIZE*3UL) );
-            SIMDType xmm5( (~C).load(i,j+SIMDSIZE*4UL) );
+            SIMDType xmm1( (*C).load(i,j             ) );
+            SIMDType xmm2( (*C).load(i,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i,j+SIMDSIZE*2UL) );
+            SIMDType xmm4( (*C).load(i,j+SIMDSIZE*3UL) );
+            SIMDType xmm5( (*C).load(i,j+SIMDSIZE*4UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i,k) ) );
@@ -2969,11 +2969,11 @@ class DTensDTensMultExpr
                xmm5 -= a1 * B.load(k,j+SIMDSIZE*4UL);
             }
 
-            (~C).store( i, j             , xmm1 );
-            (~C).store( i, j+SIMDSIZE    , xmm2 );
-            (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
-            (~C).store( i, j+SIMDSIZE*3UL, xmm4 );
-            (~C).store( i, j+SIMDSIZE*4UL, xmm5 );
+            (*C).store( i, j             , xmm1 );
+            (*C).store( i, j+SIMDSIZE    , xmm2 );
+            (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i, j+SIMDSIZE*3UL, xmm4 );
+            (*C).store( i, j+SIMDSIZE*4UL, xmm5 );
          }
       }
 
@@ -2994,14 +2994,14 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*4UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j             ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i    ,j+SIMDSIZE*2UL) );
-            SIMDType xmm4( (~C).load(i    ,j+SIMDSIZE*3UL) );
-            SIMDType xmm5( (~C).load(i+1UL,j             ) );
-            SIMDType xmm6( (~C).load(i+1UL,j+SIMDSIZE    ) );
-            SIMDType xmm7( (~C).load(i+1UL,j+SIMDSIZE*2UL) );
-            SIMDType xmm8( (~C).load(i+1UL,j+SIMDSIZE*3UL) );
+            SIMDType xmm1( (*C).load(i    ,j             ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i    ,j+SIMDSIZE*2UL) );
+            SIMDType xmm4( (*C).load(i    ,j+SIMDSIZE*3UL) );
+            SIMDType xmm5( (*C).load(i+1UL,j             ) );
+            SIMDType xmm6( (*C).load(i+1UL,j+SIMDSIZE    ) );
+            SIMDType xmm7( (*C).load(i+1UL,j+SIMDSIZE*2UL) );
+            SIMDType xmm8( (*C).load(i+1UL,j+SIMDSIZE*3UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -3020,14 +3020,14 @@ class DTensDTensMultExpr
                xmm8 -= a2 * b4;
             }
 
-            (~C).store( i    , j             , xmm1 );
-            (~C).store( i    , j+SIMDSIZE    , xmm2 );
-            (~C).store( i    , j+SIMDSIZE*2UL, xmm3 );
-            (~C).store( i    , j+SIMDSIZE*3UL, xmm4 );
-            (~C).store( i+1UL, j             , xmm5 );
-            (~C).store( i+1UL, j+SIMDSIZE    , xmm6 );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm7 );
-            (~C).store( i+1UL, j+SIMDSIZE*3UL, xmm8 );
+            (*C).store( i    , j             , xmm1 );
+            (*C).store( i    , j+SIMDSIZE    , xmm2 );
+            (*C).store( i    , j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i    , j+SIMDSIZE*3UL, xmm4 );
+            (*C).store( i+1UL, j             , xmm5 );
+            (*C).store( i+1UL, j+SIMDSIZE    , xmm6 );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm7 );
+            (*C).store( i+1UL, j+SIMDSIZE*3UL, xmm8 );
          }
 
          if( i < M )
@@ -3039,10 +3039,10 @@ class DTensDTensMultExpr
                                  :( IsLower_v<MT5> ? j : 0UL ) );
             const size_t kend( ( IsUpper_v<MT5> )?( min( j+SIMDSIZE*4UL, K ) ):( K ) );
 
-            SIMDType xmm1( (~C).load(i,j             ) );
-            SIMDType xmm2( (~C).load(i,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i,j+SIMDSIZE*2UL) );
-            SIMDType xmm4( (~C).load(i,j+SIMDSIZE*3UL) );
+            SIMDType xmm1( (*C).load(i,j             ) );
+            SIMDType xmm2( (*C).load(i,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i,j+SIMDSIZE*2UL) );
+            SIMDType xmm4( (*C).load(i,j+SIMDSIZE*3UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i,k) ) );
@@ -3052,10 +3052,10 @@ class DTensDTensMultExpr
                xmm4 -= a1 * B.load(k,j+SIMDSIZE*3UL);
             }
 
-            (~C).store( i, j             , xmm1 );
-            (~C).store( i, j+SIMDSIZE    , xmm2 );
-            (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
-            (~C).store( i, j+SIMDSIZE*3UL, xmm4 );
+            (*C).store( i, j             , xmm1 );
+            (*C).store( i, j+SIMDSIZE    , xmm2 );
+            (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i, j+SIMDSIZE*3UL, xmm4 );
          }
       }
 
@@ -3076,12 +3076,12 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*3UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j             ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i    ,j+SIMDSIZE*2UL) );
-            SIMDType xmm4( (~C).load(i+1UL,j             ) );
-            SIMDType xmm5( (~C).load(i+1UL,j+SIMDSIZE    ) );
-            SIMDType xmm6( (~C).load(i+1UL,j+SIMDSIZE*2UL) );
+            SIMDType xmm1( (*C).load(i    ,j             ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i    ,j+SIMDSIZE*2UL) );
+            SIMDType xmm4( (*C).load(i+1UL,j             ) );
+            SIMDType xmm5( (*C).load(i+1UL,j+SIMDSIZE    ) );
+            SIMDType xmm6( (*C).load(i+1UL,j+SIMDSIZE*2UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -3097,12 +3097,12 @@ class DTensDTensMultExpr
                xmm6 -= a2 * b3;
             }
 
-            (~C).store( i    , j             , xmm1 );
-            (~C).store( i    , j+SIMDSIZE    , xmm2 );
-            (~C).store( i    , j+SIMDSIZE*2UL, xmm3 );
-            (~C).store( i+1UL, j             , xmm4 );
-            (~C).store( i+1UL, j+SIMDSIZE    , xmm5 );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm6 );
+            (*C).store( i    , j             , xmm1 );
+            (*C).store( i    , j+SIMDSIZE    , xmm2 );
+            (*C).store( i    , j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i+1UL, j             , xmm4 );
+            (*C).store( i+1UL, j+SIMDSIZE    , xmm5 );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm6 );
          }
 
          if( i < M )
@@ -3114,9 +3114,9 @@ class DTensDTensMultExpr
                                  :( IsLower_v<MT5> ? j : 0UL ) );
             const size_t kend( ( IsUpper_v<MT5> )?( min( j+SIMDSIZE*3UL, K ) ):( K ) );
 
-            SIMDType xmm1( (~C).load(i,j             ) );
-            SIMDType xmm2( (~C).load(i,j+SIMDSIZE    ) );
-            SIMDType xmm3( (~C).load(i,j+SIMDSIZE*2UL) );
+            SIMDType xmm1( (*C).load(i,j             ) );
+            SIMDType xmm2( (*C).load(i,j+SIMDSIZE    ) );
+            SIMDType xmm3( (*C).load(i,j+SIMDSIZE*2UL) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i,k) ) );
@@ -3125,9 +3125,9 @@ class DTensDTensMultExpr
                xmm3 -= a1 * B.load(k,j+SIMDSIZE*2UL);
             }
 
-            (~C).store( i, j             , xmm1 );
-            (~C).store( i, j+SIMDSIZE    , xmm2 );
-            (~C).store( i, j+SIMDSIZE*2UL, xmm3 );
+            (*C).store( i, j             , xmm1 );
+            (*C).store( i, j+SIMDSIZE    , xmm2 );
+            (*C).store( i, j+SIMDSIZE*2UL, xmm3 );
          }
       }
 
@@ -3149,14 +3149,14 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+3UL : i+4UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*2UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j         ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE) );
-            SIMDType xmm3( (~C).load(i+1UL,j         ) );
-            SIMDType xmm4( (~C).load(i+1UL,j+SIMDSIZE) );
-            SIMDType xmm5( (~C).load(i+2UL,j         ) );
-            SIMDType xmm6( (~C).load(i+2UL,j+SIMDSIZE) );
-            SIMDType xmm7( (~C).load(i+3UL,j         ) );
-            SIMDType xmm8( (~C).load(i+3UL,j+SIMDSIZE) );
+            SIMDType xmm1( (*C).load(i    ,j         ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE) );
+            SIMDType xmm3( (*C).load(i+1UL,j         ) );
+            SIMDType xmm4( (*C).load(i+1UL,j+SIMDSIZE) );
+            SIMDType xmm5( (*C).load(i+2UL,j         ) );
+            SIMDType xmm6( (*C).load(i+2UL,j+SIMDSIZE) );
+            SIMDType xmm7( (*C).load(i+3UL,j         ) );
+            SIMDType xmm8( (*C).load(i+3UL,j+SIMDSIZE) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -3175,14 +3175,14 @@ class DTensDTensMultExpr
                xmm8 -= a4 * b2;
             }
 
-            (~C).store( i    , j         , xmm1 );
-            (~C).store( i    , j+SIMDSIZE, xmm2 );
-            (~C).store( i+1UL, j         , xmm3 );
-            (~C).store( i+1UL, j+SIMDSIZE, xmm4 );
-            (~C).store( i+2UL, j         , xmm5 );
-            (~C).store( i+2UL, j+SIMDSIZE, xmm6 );
-            (~C).store( i+3UL, j         , xmm7 );
-            (~C).store( i+3UL, j+SIMDSIZE, xmm8 );
+            (*C).store( i    , j         , xmm1 );
+            (*C).store( i    , j+SIMDSIZE, xmm2 );
+            (*C).store( i+1UL, j         , xmm3 );
+            (*C).store( i+1UL, j+SIMDSIZE, xmm4 );
+            (*C).store( i+2UL, j         , xmm5 );
+            (*C).store( i+2UL, j+SIMDSIZE, xmm6 );
+            (*C).store( i+3UL, j         , xmm7 );
+            (*C).store( i+3UL, j+SIMDSIZE, xmm8 );
          }
 
          for( ; (i+3UL) <= iend; i+=3UL )
@@ -3198,12 +3198,12 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+2UL : i+3UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*2UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j         ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE) );
-            SIMDType xmm3( (~C).load(i+1UL,j         ) );
-            SIMDType xmm4( (~C).load(i+1UL,j+SIMDSIZE) );
-            SIMDType xmm5( (~C).load(i+2UL,j         ) );
-            SIMDType xmm6( (~C).load(i+2UL,j+SIMDSIZE) );
+            SIMDType xmm1( (*C).load(i    ,j         ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE) );
+            SIMDType xmm3( (*C).load(i+1UL,j         ) );
+            SIMDType xmm4( (*C).load(i+1UL,j+SIMDSIZE) );
+            SIMDType xmm5( (*C).load(i+2UL,j         ) );
+            SIMDType xmm6( (*C).load(i+2UL,j+SIMDSIZE) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                const SIMDType a1( set( A(i    ,k) ) );
@@ -3219,12 +3219,12 @@ class DTensDTensMultExpr
                xmm6 -= a3 * b2;
             }
 
-            (~C).store( i    , j         , xmm1 );
-            (~C).store( i    , j+SIMDSIZE, xmm2 );
-            (~C).store( i+1UL, j         , xmm3 );
-            (~C).store( i+1UL, j+SIMDSIZE, xmm4 );
-            (~C).store( i+2UL, j         , xmm5 );
-            (~C).store( i+2UL, j+SIMDSIZE, xmm6 );
+            (*C).store( i    , j         , xmm1 );
+            (*C).store( i    , j+SIMDSIZE, xmm2 );
+            (*C).store( i+1UL, j         , xmm3 );
+            (*C).store( i+1UL, j+SIMDSIZE, xmm4 );
+            (*C).store( i+2UL, j         , xmm5 );
+            (*C).store( i+2UL, j+SIMDSIZE, xmm6 );
          }
 
          for( ; (i+2UL) <= iend; i+=2UL )
@@ -3240,10 +3240,10 @@ class DTensDTensMultExpr
                                   :( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL ) )
                                :( IsUpper_v<MT5> ? min( j+SIMDSIZE*2UL, K ) : K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j         ) );
-            SIMDType xmm2( (~C).load(i    ,j+SIMDSIZE) );
-            SIMDType xmm3( (~C).load(i+1UL,j         ) );
-            SIMDType xmm4( (~C).load(i+1UL,j+SIMDSIZE) );
+            SIMDType xmm1( (*C).load(i    ,j         ) );
+            SIMDType xmm2( (*C).load(i    ,j+SIMDSIZE) );
+            SIMDType xmm3( (*C).load(i+1UL,j         ) );
+            SIMDType xmm4( (*C).load(i+1UL,j+SIMDSIZE) );
             SIMDType xmm5, xmm6, xmm7, xmm8;
             size_t k( kbegin );
 
@@ -3277,10 +3277,10 @@ class DTensDTensMultExpr
                xmm4 -= a2 * b2;
             }
 
-            (~C).store( i    , j         , xmm1+xmm5 );
-            (~C).store( i    , j+SIMDSIZE, xmm2+xmm6 );
-            (~C).store( i+1UL, j         , xmm3+xmm7 );
-            (~C).store( i+1UL, j+SIMDSIZE, xmm4+xmm8 );
+            (*C).store( i    , j         , xmm1+xmm5 );
+            (*C).store( i    , j+SIMDSIZE, xmm2+xmm6 );
+            (*C).store( i+1UL, j         , xmm3+xmm7 );
+            (*C).store( i+1UL, j+SIMDSIZE, xmm4+xmm8 );
          }
 
          if( i < iend )
@@ -3292,8 +3292,8 @@ class DTensDTensMultExpr
                                  :( IsLower_v<MT5> ? j : 0UL ) );
             const size_t kend( ( IsUpper_v<MT5> )?( min( j+SIMDSIZE*2UL, K ) ):( K ) );
 
-            SIMDType xmm1( (~C).load(i,j         ) );
-            SIMDType xmm2( (~C).load(i,j+SIMDSIZE) );
+            SIMDType xmm1( (*C).load(i,j         ) );
+            SIMDType xmm2( (*C).load(i,j+SIMDSIZE) );
             SIMDType xmm3, xmm4;
             size_t k( kbegin );
 
@@ -3312,8 +3312,8 @@ class DTensDTensMultExpr
                xmm2 -= a1 * B.load(k,j+SIMDSIZE);
             }
 
-            (~C).store( i, j         , xmm1+xmm3 );
-            (~C).store( i, j+SIMDSIZE, xmm2+xmm4 );
+            (*C).store( i, j         , xmm1+xmm3 );
+            (*C).store( i, j+SIMDSIZE, xmm2+xmm4 );
          }
       }
 
@@ -3333,10 +3333,10 @@ class DTensDTensMultExpr
                                ?( IsStrictlyLower_v<MT4> ? i+3UL : i+4UL )
                                :( K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j) );
-            SIMDType xmm2( (~C).load(i+1UL,j) );
-            SIMDType xmm3( (~C).load(i+2UL,j) );
-            SIMDType xmm4( (~C).load(i+3UL,j) );
+            SIMDType xmm1( (*C).load(i    ,j) );
+            SIMDType xmm2( (*C).load(i+1UL,j) );
+            SIMDType xmm3( (*C).load(i+2UL,j) );
+            SIMDType xmm4( (*C).load(i+3UL,j) );
             SIMDType xmm5, xmm6, xmm7, xmm8;
             size_t k( kbegin );
 
@@ -3361,10 +3361,10 @@ class DTensDTensMultExpr
                xmm4 -= set( A(i+3UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, xmm1+xmm5 );
-            (~C).store( i+1UL, j, xmm2+xmm6 );
-            (~C).store( i+2UL, j, xmm3+xmm7 );
-            (~C).store( i+3UL, j, xmm4+xmm8 );
+            (*C).store( i    , j, xmm1+xmm5 );
+            (*C).store( i+1UL, j, xmm2+xmm6 );
+            (*C).store( i+2UL, j, xmm3+xmm7 );
+            (*C).store( i+3UL, j, xmm4+xmm8 );
          }
 
          for( ; (i+3UL) <= iend; i+=3UL )
@@ -3378,9 +3378,9 @@ class DTensDTensMultExpr
                                ?( IsStrictlyLower_v<MT4> ? i+2UL : i+3UL )
                                :( K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j) );
-            SIMDType xmm2( (~C).load(i+1UL,j) );
-            SIMDType xmm3( (~C).load(i+2UL,j) );
+            SIMDType xmm1( (*C).load(i    ,j) );
+            SIMDType xmm2( (*C).load(i+1UL,j) );
+            SIMDType xmm3( (*C).load(i+2UL,j) );
             SIMDType xmm4, xmm5, xmm6;
             size_t k( kbegin );
 
@@ -3402,9 +3402,9 @@ class DTensDTensMultExpr
                xmm3 -= set( A(i+2UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, xmm1+xmm4 );
-            (~C).store( i+1UL, j, xmm2+xmm5 );
-            (~C).store( i+2UL, j, xmm3+xmm6 );
+            (*C).store( i    , j, xmm1+xmm4 );
+            (*C).store( i+1UL, j, xmm2+xmm5 );
+            (*C).store( i+2UL, j, xmm3+xmm6 );
          }
 
          for( ; (i+2UL) <= iend; i+=2UL )
@@ -3418,8 +3418,8 @@ class DTensDTensMultExpr
                                ?( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL )
                                :( K ) );
 
-            SIMDType xmm1( (~C).load(i    ,j) );
-            SIMDType xmm2( (~C).load(i+1UL,j) );
+            SIMDType xmm1( (*C).load(i    ,j) );
+            SIMDType xmm2( (*C).load(i+1UL,j) );
             SIMDType xmm3, xmm4;
             size_t k( kbegin );
 
@@ -3438,8 +3438,8 @@ class DTensDTensMultExpr
                xmm2 -= set( A(i+1UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, xmm1+xmm3 );
-            (~C).store( i+1UL, j, xmm2+xmm4 );
+            (*C).store( i    , j, xmm1+xmm3 );
+            (*C).store( i+1UL, j, xmm2+xmm4 );
          }
 
          if( i < iend )
@@ -3450,7 +3450,7 @@ class DTensDTensMultExpr
                                     :( IsStrictlyUpper_v<MT4> ? i+1UL : i ) )
                                  :( IsLower_v<MT5> ? j : 0UL ) );
 
-            SIMDType xmm1( (~C).load(i,j) );
+            SIMDType xmm1( (*C).load(i,j) );
             SIMDType xmm2;
             size_t k( kbegin );
 
@@ -3463,7 +3463,7 @@ class DTensDTensMultExpr
                xmm1 -= set( A(i,k) ) * B.load(k,j);
             }
 
-            (~C).store( i, j, xmm1+xmm2 );
+            (*C).store( i, j, xmm1+xmm2 );
          }
       }
 
@@ -3483,16 +3483,16 @@ class DTensDTensMultExpr
                                ?( IsStrictlyLower_v<MT4> ? i+1UL : i+2UL )
                                :( K ) );
 
-            ElementType value1( (~C)(i    ,j) );
-            ElementType value2( (~C)(i+1UL,j) );
+            ElementType value1( (*C)(i    ,j) );
+            ElementType value2( (*C)(i+1UL,j) );
 
             for( size_t k=kbegin; k<kend; ++k ) {
                value1 -= A(i    ,k) * B(k,j);
                value2 -= A(i+1UL,k) * B(k,j);
             }
 
-            (~C)(i    ,j) = value1;
-            (~C)(i+1UL,j) = value2;
+            (*C)(i    ,j) = value1;
+            (*C)(i+1UL,j) = value2;
          }
 
          if( i < iend )
@@ -3503,13 +3503,13 @@ class DTensDTensMultExpr
                                     :( IsStrictlyUpper_v<MT4> ? i+1UL : i ) )
                                  :( IsLower_v<MT5> ? j : 0UL ) );
 
-            ElementType value( (~C)(i,j) );
+            ElementType value( (*C)(i,j) );
 
             for( size_t k=kbegin; k<K; ++k ) {
                value -= A(i,k) * B(k,j);
             }
 
-            (~C)(i,j) = value;
+            (*C)(i,j) = value;
          }
       }
    }
@@ -3661,11 +3661,11 @@ class DTensDTensMultExpr
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -3692,14 +3692,14 @@ class DTensDTensMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL ) {
          return;
       }
       else if( rhs.lhs_.columns() == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
          return;
       }
 
@@ -3710,10 +3710,10 @@ class DTensDTensMultExpr
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.lhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
 
-      smpAssign( ~lhs, A * B );
+      smpAssign( *lhs, A * B );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -3741,10 +3741,10 @@ class DTensDTensMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || rhs.lhs_.columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || rhs.lhs_.columns() == 0UL ) {
          return;
       }
 
@@ -3755,10 +3755,10 @@ class DTensDTensMultExpr
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.lhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
 
-      smpAddAssign( ~lhs, A * B );
+      smpAddAssign( *lhs, A * B );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -3786,10 +3786,10 @@ class DTensDTensMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || rhs.lhs_.columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || rhs.lhs_.columns() == 0UL ) {
          return;
       }
 
@@ -3800,10 +3800,10 @@ class DTensDTensMultExpr
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.lhs_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == rhs.rhs_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == rhs.rhs_.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()     , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns()  , "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()     , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns()  , "Invalid number of columns" );
 
-      smpSubAssign( ~lhs, A * B );
+      smpSubAssign( *lhs, A * B );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -3831,11 +3831,11 @@ class DTensDTensMultExpr
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -4174,18 +4174,18 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       LeftOperand_t<MMM>  left ( rhs.tensor_.leftOperand()  );
       RightOperand_t<MMM> right( rhs.tensor_.rightOperand() );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || (~lhs).pages() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || (*lhs).pages() == 0UL ) {
          return;
       }
       else if( left.columns() == 0UL || left.pages() == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
          return;
       }
 
@@ -4196,10 +4196,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()  , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == right.rows()    , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == right.columns() , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns(), "Invalid number of columns" );
 
-      DTensScalarMultExpr::selectAssignKernel( ~lhs, A, B, rhs.scalar_ );
+      DTensScalarMultExpr::selectAssignKernel( *lhs, A, B, rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -4555,7 +4555,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
       const SIMDType factor( set( scalar ) );
 
       if( LOW && UPP && N > SIMDSIZE*3UL ) {
-         reset( ~C );
+         reset( *C );
       }
 
       {
@@ -4591,14 +4591,14 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                      xmm8 += a1 * B.load(k,j+SIMDSIZE*7UL);
                   }
 
-                  (~C).store( i, j             , xmm1 * factor );
-                  (~C).store( i, j+SIMDSIZE    , xmm2 * factor );
-                  (~C).store( i, j+SIMDSIZE*2UL, xmm3 * factor );
-                  (~C).store( i, j+SIMDSIZE*3UL, xmm4 * factor );
-                  (~C).store( i, j+SIMDSIZE*4UL, xmm5 * factor );
-                  (~C).store( i, j+SIMDSIZE*5UL, xmm6 * factor );
-                  (~C).store( i, j+SIMDSIZE*6UL, xmm7 * factor );
-                  (~C).store( i, j+SIMDSIZE*7UL, xmm8 * factor );
+                  (*C).store( i, j             , xmm1 * factor );
+                  (*C).store( i, j+SIMDSIZE    , xmm2 * factor );
+                  (*C).store( i, j+SIMDSIZE*2UL, xmm3 * factor );
+                  (*C).store( i, j+SIMDSIZE*3UL, xmm4 * factor );
+                  (*C).store( i, j+SIMDSIZE*4UL, xmm5 * factor );
+                  (*C).store( i, j+SIMDSIZE*5UL, xmm6 * factor );
+                  (*C).store( i, j+SIMDSIZE*6UL, xmm7 * factor );
+                  (*C).store( i, j+SIMDSIZE*7UL, xmm8 * factor );
                }
             }
          }
@@ -4642,16 +4642,16 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm10 += a2 * b5;
                }
 
-               (~C).store( i    , j             , xmm1  * factor );
-               (~C).store( i    , j+SIMDSIZE    , xmm2  * factor );
-               (~C).store( i    , j+SIMDSIZE*2UL, xmm3  * factor );
-               (~C).store( i    , j+SIMDSIZE*3UL, xmm4  * factor );
-               (~C).store( i    , j+SIMDSIZE*4UL, xmm5  * factor );
-               (~C).store( i+1UL, j             , xmm6  * factor );
-               (~C).store( i+1UL, j+SIMDSIZE    , xmm7  * factor );
-               (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm8  * factor );
-               (~C).store( i+1UL, j+SIMDSIZE*3UL, xmm9  * factor );
-               (~C).store( i+1UL, j+SIMDSIZE*4UL, xmm10 * factor );
+               (*C).store( i    , j             , xmm1  * factor );
+               (*C).store( i    , j+SIMDSIZE    , xmm2  * factor );
+               (*C).store( i    , j+SIMDSIZE*2UL, xmm3  * factor );
+               (*C).store( i    , j+SIMDSIZE*3UL, xmm4  * factor );
+               (*C).store( i    , j+SIMDSIZE*4UL, xmm5  * factor );
+               (*C).store( i+1UL, j             , xmm6  * factor );
+               (*C).store( i+1UL, j+SIMDSIZE    , xmm7  * factor );
+               (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm8  * factor );
+               (*C).store( i+1UL, j+SIMDSIZE*3UL, xmm9  * factor );
+               (*C).store( i+1UL, j+SIMDSIZE*4UL, xmm10 * factor );
             }
 
             if( i < M )
@@ -4674,11 +4674,11 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm5 += a1 * B.load(k,j+SIMDSIZE*4UL);
                }
 
-               (~C).store( i, j             , xmm1 * factor );
-               (~C).store( i, j+SIMDSIZE    , xmm2 * factor );
-               (~C).store( i, j+SIMDSIZE*2UL, xmm3 * factor );
-               (~C).store( i, j+SIMDSIZE*3UL, xmm4 * factor );
-               (~C).store( i, j+SIMDSIZE*4UL, xmm5 * factor );
+               (*C).store( i, j             , xmm1 * factor );
+               (*C).store( i, j+SIMDSIZE    , xmm2 * factor );
+               (*C).store( i, j+SIMDSIZE*2UL, xmm3 * factor );
+               (*C).store( i, j+SIMDSIZE*3UL, xmm4 * factor );
+               (*C).store( i, j+SIMDSIZE*4UL, xmm5 * factor );
             }
          }
 
@@ -4719,14 +4719,14 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm8 += a2 * b4;
                }
 
-               (~C).store( i    , j             , xmm1 * factor );
-               (~C).store( i    , j+SIMDSIZE    , xmm2 * factor );
-               (~C).store( i    , j+SIMDSIZE*2UL, xmm3 * factor );
-               (~C).store( i    , j+SIMDSIZE*3UL, xmm4 * factor );
-               (~C).store( i+1UL, j             , xmm5 * factor );
-               (~C).store( i+1UL, j+SIMDSIZE    , xmm6 * factor );
-               (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm7 * factor );
-               (~C).store( i+1UL, j+SIMDSIZE*3UL, xmm8 * factor );
+               (*C).store( i    , j             , xmm1 * factor );
+               (*C).store( i    , j+SIMDSIZE    , xmm2 * factor );
+               (*C).store( i    , j+SIMDSIZE*2UL, xmm3 * factor );
+               (*C).store( i    , j+SIMDSIZE*3UL, xmm4 * factor );
+               (*C).store( i+1UL, j             , xmm5 * factor );
+               (*C).store( i+1UL, j+SIMDSIZE    , xmm6 * factor );
+               (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm7 * factor );
+               (*C).store( i+1UL, j+SIMDSIZE*3UL, xmm8 * factor );
             }
 
             if( i < iend )
@@ -4748,10 +4748,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm4 += a1 * B.load(k,j+SIMDSIZE*3UL);
                }
 
-               (~C).store( i, j             , xmm1 * factor );
-               (~C).store( i, j+SIMDSIZE    , xmm2 * factor );
-               (~C).store( i, j+SIMDSIZE*2UL, xmm3 * factor );
-               (~C).store( i, j+SIMDSIZE*3UL, xmm4 * factor );
+               (*C).store( i, j             , xmm1 * factor );
+               (*C).store( i, j+SIMDSIZE    , xmm2 * factor );
+               (*C).store( i, j+SIMDSIZE*2UL, xmm3 * factor );
+               (*C).store( i, j+SIMDSIZE*3UL, xmm4 * factor );
             }
          }
 
@@ -4789,12 +4789,12 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm6 += a2 * b3;
                }
 
-               (~C).store( i    , j             , xmm1 * factor );
-               (~C).store( i    , j+SIMDSIZE    , xmm2 * factor );
-               (~C).store( i    , j+SIMDSIZE*2UL, xmm3 * factor );
-               (~C).store( i+1UL, j             , xmm4 * factor );
-               (~C).store( i+1UL, j+SIMDSIZE    , xmm5 * factor );
-               (~C).store( i+1UL, j+SIMDSIZE*2UL, xmm6 * factor );
+               (*C).store( i    , j             , xmm1 * factor );
+               (*C).store( i    , j+SIMDSIZE    , xmm2 * factor );
+               (*C).store( i    , j+SIMDSIZE*2UL, xmm3 * factor );
+               (*C).store( i+1UL, j             , xmm4 * factor );
+               (*C).store( i+1UL, j+SIMDSIZE    , xmm5 * factor );
+               (*C).store( i+1UL, j+SIMDSIZE*2UL, xmm6 * factor );
             }
 
             if( i < iend )
@@ -4815,9 +4815,9 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm3 += a1 * B.load(k,j+SIMDSIZE*2UL);
                }
 
-               (~C).store( i, j             , xmm1 * factor );
-               (~C).store( i, j+SIMDSIZE    , xmm2 * factor );
-               (~C).store( i, j+SIMDSIZE*2UL, xmm3 * factor );
+               (*C).store( i, j             , xmm1 * factor );
+               (*C).store( i, j+SIMDSIZE    , xmm2 * factor );
+               (*C).store( i, j+SIMDSIZE*2UL, xmm3 * factor );
             }
          }
 
@@ -4858,14 +4858,14 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm8 += a4 * b2;
                }
 
-               (~C).store( i    , j         , xmm1 * factor );
-               (~C).store( i    , j+SIMDSIZE, xmm2 * factor );
-               (~C).store( i+1UL, j         , xmm3 * factor );
-               (~C).store( i+1UL, j+SIMDSIZE, xmm4 * factor );
-               (~C).store( i+2UL, j         , xmm5 * factor );
-               (~C).store( i+2UL, j+SIMDSIZE, xmm6 * factor );
-               (~C).store( i+3UL, j         , xmm7 * factor );
-               (~C).store( i+3UL, j+SIMDSIZE, xmm8 * factor );
+               (*C).store( i    , j         , xmm1 * factor );
+               (*C).store( i    , j+SIMDSIZE, xmm2 * factor );
+               (*C).store( i+1UL, j         , xmm3 * factor );
+               (*C).store( i+1UL, j+SIMDSIZE, xmm4 * factor );
+               (*C).store( i+2UL, j         , xmm5 * factor );
+               (*C).store( i+2UL, j+SIMDSIZE, xmm6 * factor );
+               (*C).store( i+3UL, j         , xmm7 * factor );
+               (*C).store( i+3UL, j+SIMDSIZE, xmm8 * factor );
             }
 
             for( ; (i+3UL) <= iend; i+=3UL )
@@ -4897,12 +4897,12 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm6 += a3 * b2;
                }
 
-               (~C).store( i    , j         , xmm1 * factor );
-               (~C).store( i    , j+SIMDSIZE, xmm2 * factor );
-               (~C).store( i+1UL, j         , xmm3 * factor );
-               (~C).store( i+1UL, j+SIMDSIZE, xmm4 * factor );
-               (~C).store( i+2UL, j         , xmm5 * factor );
-               (~C).store( i+2UL, j+SIMDSIZE, xmm6 * factor );
+               (*C).store( i    , j         , xmm1 * factor );
+               (*C).store( i    , j+SIMDSIZE, xmm2 * factor );
+               (*C).store( i+1UL, j         , xmm3 * factor );
+               (*C).store( i+1UL, j+SIMDSIZE, xmm4 * factor );
+               (*C).store( i+2UL, j         , xmm5 * factor );
+               (*C).store( i+2UL, j+SIMDSIZE, xmm6 * factor );
             }
 
             for( ; (i+2UL) <= iend; i+=2UL )
@@ -4951,10 +4951,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm4 += a2 * b2;
                }
 
-               (~C).store( i    , j         , (xmm1+xmm5) * factor );
-               (~C).store( i    , j+SIMDSIZE, (xmm2+xmm6) * factor );
-               (~C).store( i+1UL, j         , (xmm3+xmm7) * factor );
-               (~C).store( i+1UL, j+SIMDSIZE, (xmm4+xmm8) * factor );
+               (*C).store( i    , j         , (xmm1+xmm5) * factor );
+               (*C).store( i    , j+SIMDSIZE, (xmm2+xmm6) * factor );
+               (*C).store( i+1UL, j         , (xmm3+xmm7) * factor );
+               (*C).store( i+1UL, j+SIMDSIZE, (xmm4+xmm8) * factor );
             }
 
             if( i < iend )
@@ -4984,8 +4984,8 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm2 += a1 * B.load(k,j+SIMDSIZE);
                }
 
-               (~C).store( i, j         , (xmm1+xmm3) * factor );
-               (~C).store( i, j+SIMDSIZE, (xmm2+xmm4) * factor );
+               (*C).store( i, j         , (xmm1+xmm3) * factor );
+               (*C).store( i, j+SIMDSIZE, (xmm2+xmm4) * factor );
             }
          }
 
@@ -5029,10 +5029,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm4 += set( A(i+3UL,k) ) * b1;
                }
 
-               (~C).store( i    , j, (xmm1+xmm5) * factor );
-               (~C).store( i+1UL, j, (xmm2+xmm6) * factor );
-               (~C).store( i+2UL, j, (xmm3+xmm7) * factor );
-               (~C).store( i+3UL, j, (xmm4+xmm8) * factor );
+               (*C).store( i    , j, (xmm1+xmm5) * factor );
+               (*C).store( i+1UL, j, (xmm2+xmm6) * factor );
+               (*C).store( i+2UL, j, (xmm3+xmm7) * factor );
+               (*C).store( i+3UL, j, (xmm4+xmm8) * factor );
             }
 
             for( ; (i+3UL) <= iend; i+=3UL )
@@ -5067,9 +5067,9 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm3 += set( A(i+2UL,k) ) * b1;
                }
 
-               (~C).store( i    , j, (xmm1+xmm4) * factor );
-               (~C).store( i+1UL, j, (xmm2+xmm5) * factor );
-               (~C).store( i+2UL, j, (xmm3+xmm6) * factor );
+               (*C).store( i    , j, (xmm1+xmm4) * factor );
+               (*C).store( i+1UL, j, (xmm2+xmm5) * factor );
+               (*C).store( i+2UL, j, (xmm3+xmm6) * factor );
             }
 
             for( ; (i+2UL) <= iend; i+=2UL )
@@ -5101,8 +5101,8 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm2 += set( A(i+1UL,k) ) * b1;
                }
 
-               (~C).store( i    , j, (xmm1+xmm3) * factor );
-               (~C).store( i+1UL, j, (xmm2+xmm4) * factor );
+               (*C).store( i    , j, (xmm1+xmm3) * factor );
+               (*C).store( i+1UL, j, (xmm2+xmm4) * factor );
             }
 
             if( i < iend )
@@ -5125,7 +5125,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm1 += set( A(i,k) ) * B.load(k,j);
                }
 
-               (~C).store( i, j, (xmm1+xmm2) * factor );
+               (*C).store( i, j, (xmm1+xmm2) * factor );
             }
          }
 
@@ -5152,8 +5152,8 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   value2 += A(i+1UL,k) * B(k,j);
                }
 
-               (~C)(i    ,j) = value1 * scalar;
-               (~C)(i+1UL,j) = value2 * scalar;
+               (*C)(i    ,j) = value1 * scalar;
+               (*C)(i+1UL,j) = value2 * scalar;
             }
 
             if( i < M )
@@ -5170,7 +5170,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   value += A(i,k) * B(k,j);
                }
 
-               (~C)(i,j) = value * scalar;
+               (*C)(i,j) = value * scalar;
             }
          }
       }
@@ -5179,7 +5179,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
          for( size_t i=SIMDSIZE*4UL; i<M; ++i ) {
             const size_t jend( ( SIMDSIZE*4UL ) * ( i / (SIMDSIZE*4UL) ) );
             for( size_t j=0UL; j<jend; ++j ) {
-               (~C)(i,j) = HERM ? conj( (~C)(j,i) ) : (~C)(j,i);
+               (*C)(i,j) = HERM ? conj( (*C)(j,i) ) : (*C)(j,i);
             }
          }
       }
@@ -5187,7 +5187,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
          for( size_t j=SIMDSIZE*4UL; j<N; ++j ) {
             const size_t iend( ( SIMDSIZE*4UL ) * ( j / (SIMDSIZE*4UL) ) );
             for( size_t i=0UL; i<iend; ++i ) {
-               reset( (~C)(i,j) );
+               reset( (*C)(i,j) );
             }
          }
       }
@@ -5195,7 +5195,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
          for( size_t i=SIMDSIZE*4UL; i<M; ++i ) {
             const size_t jend( ( SIMDSIZE*4UL ) * ( i / (SIMDSIZE*4UL) ) );
             for( size_t j=0UL; j<jend; ++j ) {
-               reset( (~C)(i,j) );
+               reset( (*C)(i,j) );
             }
          }
       }
@@ -5345,13 +5345,13 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       LeftOperand_t<MMM>  left ( rhs.tensor_.leftOperand()  );
       RightOperand_t<MMM> right( rhs.tensor_.rightOperand() );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || left.columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || left.columns() == 0UL ) {
          return;
       }
 
@@ -5362,10 +5362,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()  , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == right.rows()    , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == right.columns() , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns(), "Invalid number of columns" );
 
-      DTensScalarMultExpr::selectAddAssignKernel( ~lhs, A, B, rhs.scalar_ );
+      DTensScalarMultExpr::selectAddAssignKernel( *lhs, A, B, rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -5642,14 +5642,14 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm8 += a1 * B.load(k,j+SIMDSIZE*7UL);
                }
 
-               (~C).store( i, j             , (~C).load(i,j             ) + xmm1 * factor );
-               (~C).store( i, j+SIMDSIZE    , (~C).load(i,j+SIMDSIZE    ) + xmm2 * factor );
-               (~C).store( i, j+SIMDSIZE*2UL, (~C).load(i,j+SIMDSIZE*2UL) + xmm3 * factor );
-               (~C).store( i, j+SIMDSIZE*3UL, (~C).load(i,j+SIMDSIZE*3UL) + xmm4 * factor );
-               (~C).store( i, j+SIMDSIZE*4UL, (~C).load(i,j+SIMDSIZE*4UL) + xmm5 * factor );
-               (~C).store( i, j+SIMDSIZE*5UL, (~C).load(i,j+SIMDSIZE*5UL) + xmm6 * factor );
-               (~C).store( i, j+SIMDSIZE*6UL, (~C).load(i,j+SIMDSIZE*6UL) + xmm7 * factor );
-               (~C).store( i, j+SIMDSIZE*7UL, (~C).load(i,j+SIMDSIZE*7UL) + xmm8 * factor );
+               (*C).store( i, j             , (*C).load(i,j             ) + xmm1 * factor );
+               (*C).store( i, j+SIMDSIZE    , (*C).load(i,j+SIMDSIZE    ) + xmm2 * factor );
+               (*C).store( i, j+SIMDSIZE*2UL, (*C).load(i,j+SIMDSIZE*2UL) + xmm3 * factor );
+               (*C).store( i, j+SIMDSIZE*3UL, (*C).load(i,j+SIMDSIZE*3UL) + xmm4 * factor );
+               (*C).store( i, j+SIMDSIZE*4UL, (*C).load(i,j+SIMDSIZE*4UL) + xmm5 * factor );
+               (*C).store( i, j+SIMDSIZE*5UL, (*C).load(i,j+SIMDSIZE*5UL) + xmm6 * factor );
+               (*C).store( i, j+SIMDSIZE*6UL, (*C).load(i,j+SIMDSIZE*6UL) + xmm7 * factor );
+               (*C).store( i, j+SIMDSIZE*7UL, (*C).load(i,j+SIMDSIZE*7UL) + xmm8 * factor );
             }
          }
       }
@@ -5693,16 +5693,16 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm10 += a2 * b5;
             }
 
-            (~C).store( i    , j             , (~C).load(i    ,j             ) + xmm1  * factor );
-            (~C).store( i    , j+SIMDSIZE    , (~C).load(i    ,j+SIMDSIZE    ) + xmm2  * factor );
-            (~C).store( i    , j+SIMDSIZE*2UL, (~C).load(i    ,j+SIMDSIZE*2UL) + xmm3  * factor );
-            (~C).store( i    , j+SIMDSIZE*3UL, (~C).load(i    ,j+SIMDSIZE*3UL) + xmm4  * factor );
-            (~C).store( i    , j+SIMDSIZE*4UL, (~C).load(i    ,j+SIMDSIZE*4UL) + xmm5  * factor );
-            (~C).store( i+1UL, j             , (~C).load(i+1UL,j             ) + xmm6  * factor );
-            (~C).store( i+1UL, j+SIMDSIZE    , (~C).load(i+1UL,j+SIMDSIZE    ) + xmm7  * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, (~C).load(i+1UL,j+SIMDSIZE*2UL) + xmm8  * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*3UL, (~C).load(i+1UL,j+SIMDSIZE*3UL) + xmm9  * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*4UL, (~C).load(i+1UL,j+SIMDSIZE*4UL) + xmm10 * factor );
+            (*C).store( i    , j             , (*C).load(i    ,j             ) + xmm1  * factor );
+            (*C).store( i    , j+SIMDSIZE    , (*C).load(i    ,j+SIMDSIZE    ) + xmm2  * factor );
+            (*C).store( i    , j+SIMDSIZE*2UL, (*C).load(i    ,j+SIMDSIZE*2UL) + xmm3  * factor );
+            (*C).store( i    , j+SIMDSIZE*3UL, (*C).load(i    ,j+SIMDSIZE*3UL) + xmm4  * factor );
+            (*C).store( i    , j+SIMDSIZE*4UL, (*C).load(i    ,j+SIMDSIZE*4UL) + xmm5  * factor );
+            (*C).store( i+1UL, j             , (*C).load(i+1UL,j             ) + xmm6  * factor );
+            (*C).store( i+1UL, j+SIMDSIZE    , (*C).load(i+1UL,j+SIMDSIZE    ) + xmm7  * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, (*C).load(i+1UL,j+SIMDSIZE*2UL) + xmm8  * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*3UL, (*C).load(i+1UL,j+SIMDSIZE*3UL) + xmm9  * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*4UL, (*C).load(i+1UL,j+SIMDSIZE*4UL) + xmm10 * factor );
          }
 
          if( i < M )
@@ -5725,11 +5725,11 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm5 += a1 * B.load(k,j+SIMDSIZE*4UL);
             }
 
-            (~C).store( i, j             , (~C).load(i,j             ) + xmm1 * factor );
-            (~C).store( i, j+SIMDSIZE    , (~C).load(i,j+SIMDSIZE    ) + xmm2 * factor );
-            (~C).store( i, j+SIMDSIZE*2UL, (~C).load(i,j+SIMDSIZE*2UL) + xmm3 * factor );
-            (~C).store( i, j+SIMDSIZE*3UL, (~C).load(i,j+SIMDSIZE*3UL) + xmm4 * factor );
-            (~C).store( i, j+SIMDSIZE*4UL, (~C).load(i,j+SIMDSIZE*4UL) + xmm5 * factor );
+            (*C).store( i, j             , (*C).load(i,j             ) + xmm1 * factor );
+            (*C).store( i, j+SIMDSIZE    , (*C).load(i,j+SIMDSIZE    ) + xmm2 * factor );
+            (*C).store( i, j+SIMDSIZE*2UL, (*C).load(i,j+SIMDSIZE*2UL) + xmm3 * factor );
+            (*C).store( i, j+SIMDSIZE*3UL, (*C).load(i,j+SIMDSIZE*3UL) + xmm4 * factor );
+            (*C).store( i, j+SIMDSIZE*4UL, (*C).load(i,j+SIMDSIZE*4UL) + xmm5 * factor );
          }
       }
 
@@ -5769,14 +5769,14 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm8 += a2 * b4;
             }
 
-            (~C).store( i    , j             , (~C).load(i    ,j             ) + xmm1 * factor );
-            (~C).store( i    , j+SIMDSIZE    , (~C).load(i    ,j+SIMDSIZE    ) + xmm2 * factor );
-            (~C).store( i    , j+SIMDSIZE*2UL, (~C).load(i    ,j+SIMDSIZE*2UL) + xmm3 * factor );
-            (~C).store( i    , j+SIMDSIZE*3UL, (~C).load(i    ,j+SIMDSIZE*3UL) + xmm4 * factor );
-            (~C).store( i+1UL, j             , (~C).load(i+1UL,j             ) + xmm5 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE    , (~C).load(i+1UL,j+SIMDSIZE    ) + xmm6 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, (~C).load(i+1UL,j+SIMDSIZE*2UL) + xmm7 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*3UL, (~C).load(i+1UL,j+SIMDSIZE*3UL) + xmm8 * factor );
+            (*C).store( i    , j             , (*C).load(i    ,j             ) + xmm1 * factor );
+            (*C).store( i    , j+SIMDSIZE    , (*C).load(i    ,j+SIMDSIZE    ) + xmm2 * factor );
+            (*C).store( i    , j+SIMDSIZE*2UL, (*C).load(i    ,j+SIMDSIZE*2UL) + xmm3 * factor );
+            (*C).store( i    , j+SIMDSIZE*3UL, (*C).load(i    ,j+SIMDSIZE*3UL) + xmm4 * factor );
+            (*C).store( i+1UL, j             , (*C).load(i+1UL,j             ) + xmm5 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE    , (*C).load(i+1UL,j+SIMDSIZE    ) + xmm6 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, (*C).load(i+1UL,j+SIMDSIZE*2UL) + xmm7 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*3UL, (*C).load(i+1UL,j+SIMDSIZE*3UL) + xmm8 * factor );
          }
 
          if( i < M )
@@ -5798,10 +5798,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm4 += a1 * B.load(k,j+SIMDSIZE*3UL);
             }
 
-            (~C).store( i, j             , (~C).load(i,j             ) + xmm1 * factor );
-            (~C).store( i, j+SIMDSIZE    , (~C).load(i,j+SIMDSIZE    ) + xmm2 * factor );
-            (~C).store( i, j+SIMDSIZE*2UL, (~C).load(i,j+SIMDSIZE*2UL) + xmm3 * factor );
-            (~C).store( i, j+SIMDSIZE*3UL, (~C).load(i,j+SIMDSIZE*3UL) + xmm4 * factor );
+            (*C).store( i, j             , (*C).load(i,j             ) + xmm1 * factor );
+            (*C).store( i, j+SIMDSIZE    , (*C).load(i,j+SIMDSIZE    ) + xmm2 * factor );
+            (*C).store( i, j+SIMDSIZE*2UL, (*C).load(i,j+SIMDSIZE*2UL) + xmm3 * factor );
+            (*C).store( i, j+SIMDSIZE*3UL, (*C).load(i,j+SIMDSIZE*3UL) + xmm4 * factor );
          }
       }
 
@@ -5838,12 +5838,12 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm6 += a2 * b3;
             }
 
-            (~C).store( i    , j             , (~C).load(i    ,j             ) + xmm1 * factor );
-            (~C).store( i    , j+SIMDSIZE    , (~C).load(i    ,j+SIMDSIZE    ) + xmm2 * factor );
-            (~C).store( i    , j+SIMDSIZE*2UL, (~C).load(i    ,j+SIMDSIZE*2UL) + xmm3 * factor );
-            (~C).store( i+1UL, j             , (~C).load(i+1UL,j             ) + xmm4 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE    , (~C).load(i+1UL,j+SIMDSIZE    ) + xmm5 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, (~C).load(i+1UL,j+SIMDSIZE*2UL) + xmm6 * factor );
+            (*C).store( i    , j             , (*C).load(i    ,j             ) + xmm1 * factor );
+            (*C).store( i    , j+SIMDSIZE    , (*C).load(i    ,j+SIMDSIZE    ) + xmm2 * factor );
+            (*C).store( i    , j+SIMDSIZE*2UL, (*C).load(i    ,j+SIMDSIZE*2UL) + xmm3 * factor );
+            (*C).store( i+1UL, j             , (*C).load(i+1UL,j             ) + xmm4 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE    , (*C).load(i+1UL,j+SIMDSIZE    ) + xmm5 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, (*C).load(i+1UL,j+SIMDSIZE*2UL) + xmm6 * factor );
          }
 
          if( i < M )
@@ -5864,9 +5864,9 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm3 += a1 * B.load(k,j+SIMDSIZE*2UL);
             }
 
-            (~C).store( i, j             , (~C).load(i,j             ) + xmm1 * factor );
-            (~C).store( i, j+SIMDSIZE    , (~C).load(i,j+SIMDSIZE    ) + xmm2 * factor );
-            (~C).store( i, j+SIMDSIZE*2UL, (~C).load(i,j+SIMDSIZE*2UL) + xmm3 * factor );
+            (*C).store( i, j             , (*C).load(i,j             ) + xmm1 * factor );
+            (*C).store( i, j+SIMDSIZE    , (*C).load(i,j+SIMDSIZE    ) + xmm2 * factor );
+            (*C).store( i, j+SIMDSIZE*2UL, (*C).load(i,j+SIMDSIZE*2UL) + xmm3 * factor );
          }
       }
 
@@ -5907,14 +5907,14 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm8 += a4 * b2;
             }
 
-            (~C).store( i    , j         , (~C).load(i    ,j         ) + xmm1 * factor );
-            (~C).store( i    , j+SIMDSIZE, (~C).load(i    ,j+SIMDSIZE) + xmm2 * factor );
-            (~C).store( i+1UL, j         , (~C).load(i+1UL,j         ) + xmm3 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE, (~C).load(i+1UL,j+SIMDSIZE) + xmm4 * factor );
-            (~C).store( i+2UL, j         , (~C).load(i+2UL,j         ) + xmm5 * factor );
-            (~C).store( i+2UL, j+SIMDSIZE, (~C).load(i+2UL,j+SIMDSIZE) + xmm6 * factor );
-            (~C).store( i+3UL, j         , (~C).load(i+3UL,j         ) + xmm7 * factor );
-            (~C).store( i+3UL, j+SIMDSIZE, (~C).load(i+3UL,j+SIMDSIZE) + xmm8 * factor );
+            (*C).store( i    , j         , (*C).load(i    ,j         ) + xmm1 * factor );
+            (*C).store( i    , j+SIMDSIZE, (*C).load(i    ,j+SIMDSIZE) + xmm2 * factor );
+            (*C).store( i+1UL, j         , (*C).load(i+1UL,j         ) + xmm3 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE, (*C).load(i+1UL,j+SIMDSIZE) + xmm4 * factor );
+            (*C).store( i+2UL, j         , (*C).load(i+2UL,j         ) + xmm5 * factor );
+            (*C).store( i+2UL, j+SIMDSIZE, (*C).load(i+2UL,j+SIMDSIZE) + xmm6 * factor );
+            (*C).store( i+3UL, j         , (*C).load(i+3UL,j         ) + xmm7 * factor );
+            (*C).store( i+3UL, j+SIMDSIZE, (*C).load(i+3UL,j+SIMDSIZE) + xmm8 * factor );
          }
 
          for( ; (i+3UL) <= iend; i+=3UL )
@@ -5946,12 +5946,12 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm6 += a3 * b2;
             }
 
-            (~C).store( i    , j         , (~C).load(i    ,j         ) + xmm1 * factor );
-            (~C).store( i    , j+SIMDSIZE, (~C).load(i    ,j+SIMDSIZE) + xmm2 * factor );
-            (~C).store( i+1UL, j         , (~C).load(i+1UL,j         ) + xmm3 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE, (~C).load(i+1UL,j+SIMDSIZE) + xmm4 * factor );
-            (~C).store( i+2UL, j         , (~C).load(i+2UL,j         ) + xmm5 * factor );
-            (~C).store( i+2UL, j+SIMDSIZE, (~C).load(i+2UL,j+SIMDSIZE) + xmm6 * factor );
+            (*C).store( i    , j         , (*C).load(i    ,j         ) + xmm1 * factor );
+            (*C).store( i    , j+SIMDSIZE, (*C).load(i    ,j+SIMDSIZE) + xmm2 * factor );
+            (*C).store( i+1UL, j         , (*C).load(i+1UL,j         ) + xmm3 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE, (*C).load(i+1UL,j+SIMDSIZE) + xmm4 * factor );
+            (*C).store( i+2UL, j         , (*C).load(i+2UL,j         ) + xmm5 * factor );
+            (*C).store( i+2UL, j+SIMDSIZE, (*C).load(i+2UL,j+SIMDSIZE) + xmm6 * factor );
          }
 
          for( ; (i+2UL) <= iend; i+=2UL )
@@ -6000,10 +6000,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm4 += a2 * b2;
             }
 
-            (~C).store( i    , j         , (~C).load(i    ,j         ) + (xmm1+xmm5) * factor );
-            (~C).store( i    , j+SIMDSIZE, (~C).load(i    ,j+SIMDSIZE) + (xmm2+xmm6) * factor );
-            (~C).store( i+1UL, j         , (~C).load(i+1UL,j         ) + (xmm3+xmm7) * factor );
-            (~C).store( i+1UL, j+SIMDSIZE, (~C).load(i+1UL,j+SIMDSIZE) + (xmm4+xmm8) * factor );
+            (*C).store( i    , j         , (*C).load(i    ,j         ) + (xmm1+xmm5) * factor );
+            (*C).store( i    , j+SIMDSIZE, (*C).load(i    ,j+SIMDSIZE) + (xmm2+xmm6) * factor );
+            (*C).store( i+1UL, j         , (*C).load(i+1UL,j         ) + (xmm3+xmm7) * factor );
+            (*C).store( i+1UL, j+SIMDSIZE, (*C).load(i+1UL,j+SIMDSIZE) + (xmm4+xmm8) * factor );
          }
 
          if( i < iend )
@@ -6033,8 +6033,8 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm2 += a1 * B.load(k,j+SIMDSIZE);
             }
 
-            (~C).store( i, j         , (~C).load(i,j         ) + (xmm1+xmm3) * factor );
-            (~C).store( i, j+SIMDSIZE, (~C).load(i,j+SIMDSIZE) + (xmm2+xmm4) * factor );
+            (*C).store( i, j         , (*C).load(i,j         ) + (xmm1+xmm3) * factor );
+            (*C).store( i, j+SIMDSIZE, (*C).load(i,j+SIMDSIZE) + (xmm2+xmm4) * factor );
          }
       }
 
@@ -6078,10 +6078,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm4 += set( A(i+3UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, (~C).load(i    ,j) + (xmm1+xmm5) * factor );
-            (~C).store( i+1UL, j, (~C).load(i+1UL,j) + (xmm2+xmm6) * factor );
-            (~C).store( i+2UL, j, (~C).load(i+2UL,j) + (xmm3+xmm7) * factor );
-            (~C).store( i+3UL, j, (~C).load(i+3UL,j) + (xmm4+xmm8) * factor );
+            (*C).store( i    , j, (*C).load(i    ,j) + (xmm1+xmm5) * factor );
+            (*C).store( i+1UL, j, (*C).load(i+1UL,j) + (xmm2+xmm6) * factor );
+            (*C).store( i+2UL, j, (*C).load(i+2UL,j) + (xmm3+xmm7) * factor );
+            (*C).store( i+3UL, j, (*C).load(i+3UL,j) + (xmm4+xmm8) * factor );
          }
 
          for( ; (i+3UL) <= iend; i+=3UL )
@@ -6116,9 +6116,9 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm3 += set( A(i+2UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, (~C).load(i    ,j) + (xmm1+xmm4) * factor );
-            (~C).store( i+1UL, j, (~C).load(i+1UL,j) + (xmm2+xmm5) * factor );
-            (~C).store( i+2UL, j, (~C).load(i+2UL,j) + (xmm3+xmm6) * factor );
+            (*C).store( i    , j, (*C).load(i    ,j) + (xmm1+xmm4) * factor );
+            (*C).store( i+1UL, j, (*C).load(i+1UL,j) + (xmm2+xmm5) * factor );
+            (*C).store( i+2UL, j, (*C).load(i+2UL,j) + (xmm3+xmm6) * factor );
          }
 
          for( ; (i+2UL) <= iend; i+=2UL )
@@ -6150,8 +6150,8 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm2 += set( A(i+1UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, (~C).load(i    ,j) + (xmm1+xmm3) * factor );
-            (~C).store( i+1UL, j, (~C).load(i+1UL,j) + (xmm2+xmm4) * factor );
+            (*C).store( i    , j, (*C).load(i    ,j) + (xmm1+xmm3) * factor );
+            (*C).store( i+1UL, j, (*C).load(i+1UL,j) + (xmm2+xmm4) * factor );
          }
 
          if( i < iend )
@@ -6174,7 +6174,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm1 += set( A(i,k) ) * B.load(k,j);
             }
 
-            (~C).store( i, j, (~C).load(i,j) + (xmm1+xmm2) * factor );
+            (*C).store( i, j, (*C).load(i,j) + (xmm1+xmm2) * factor );
          }
       }
 
@@ -6202,8 +6202,8 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                value2 += A(i+1UL,k) * B(k,j);
             }
 
-            (~C)(i    ,j) += value1 * scalar;
-            (~C)(i+1UL,j) += value2 * scalar;
+            (*C)(i    ,j) += value1 * scalar;
+            (*C)(i+1UL,j) += value2 * scalar;
          }
 
          if( i < iend )
@@ -6220,7 +6220,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                value += A(i,k) * B(k,j);
             }
 
-            (~C)(i,j) += value * scalar;
+            (*C)(i,j) += value * scalar;
          }
       }
    }
@@ -6367,13 +6367,13 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       LeftOperand_t<MMM>  left ( rhs.tensor_.leftOperand()  );
       RightOperand_t<MMM> right( rhs.tensor_.rightOperand() );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || left.columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || left.columns() == 0UL ) {
          return;
       }
 
@@ -6384,10 +6384,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()  , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == right.rows()    , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == right.columns() , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns(), "Invalid number of columns" );
 
-      DTensScalarMultExpr::selectSubAssignKernel( ~lhs, A, B, rhs.scalar_ );
+      DTensScalarMultExpr::selectSubAssignKernel( *lhs, A, B, rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -6664,14 +6664,14 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                   xmm8 += a1 * B.load(k,j+SIMDSIZE*7UL);
                }
 
-               (~C).store( i, j             , (~C).load(i,j             ) - xmm1 * factor );
-               (~C).store( i, j+SIMDSIZE    , (~C).load(i,j+SIMDSIZE    ) - xmm2 * factor );
-               (~C).store( i, j+SIMDSIZE*2UL, (~C).load(i,j+SIMDSIZE*2UL) - xmm3 * factor );
-               (~C).store( i, j+SIMDSIZE*3UL, (~C).load(i,j+SIMDSIZE*3UL) - xmm4 * factor );
-               (~C).store( i, j+SIMDSIZE*4UL, (~C).load(i,j+SIMDSIZE*4UL) - xmm5 * factor );
-               (~C).store( i, j+SIMDSIZE*5UL, (~C).load(i,j+SIMDSIZE*5UL) - xmm6 * factor );
-               (~C).store( i, j+SIMDSIZE*6UL, (~C).load(i,j+SIMDSIZE*6UL) - xmm7 * factor );
-               (~C).store( i, j+SIMDSIZE*7UL, (~C).load(i,j+SIMDSIZE*7UL) - xmm8 * factor );
+               (*C).store( i, j             , (*C).load(i,j             ) - xmm1 * factor );
+               (*C).store( i, j+SIMDSIZE    , (*C).load(i,j+SIMDSIZE    ) - xmm2 * factor );
+               (*C).store( i, j+SIMDSIZE*2UL, (*C).load(i,j+SIMDSIZE*2UL) - xmm3 * factor );
+               (*C).store( i, j+SIMDSIZE*3UL, (*C).load(i,j+SIMDSIZE*3UL) - xmm4 * factor );
+               (*C).store( i, j+SIMDSIZE*4UL, (*C).load(i,j+SIMDSIZE*4UL) - xmm5 * factor );
+               (*C).store( i, j+SIMDSIZE*5UL, (*C).load(i,j+SIMDSIZE*5UL) - xmm6 * factor );
+               (*C).store( i, j+SIMDSIZE*6UL, (*C).load(i,j+SIMDSIZE*6UL) - xmm7 * factor );
+               (*C).store( i, j+SIMDSIZE*7UL, (*C).load(i,j+SIMDSIZE*7UL) - xmm8 * factor );
             }
          }
       }
@@ -6715,16 +6715,16 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm10 += a2 * b5;
             }
 
-            (~C).store( i    , j             , (~C).load(i    ,j             ) - xmm1  * factor );
-            (~C).store( i    , j+SIMDSIZE    , (~C).load(i    ,j+SIMDSIZE    ) - xmm2  * factor );
-            (~C).store( i    , j+SIMDSIZE*2UL, (~C).load(i    ,j+SIMDSIZE*2UL) - xmm3  * factor );
-            (~C).store( i    , j+SIMDSIZE*3UL, (~C).load(i    ,j+SIMDSIZE*3UL) - xmm4  * factor );
-            (~C).store( i    , j+SIMDSIZE*4UL, (~C).load(i    ,j+SIMDSIZE*4UL) - xmm5  * factor );
-            (~C).store( i+1UL, j             , (~C).load(i+1UL,j             ) - xmm6  * factor );
-            (~C).store( i+1UL, j+SIMDSIZE    , (~C).load(i+1UL,j+SIMDSIZE    ) - xmm7  * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, (~C).load(i+1UL,j+SIMDSIZE*2UL) - xmm8  * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*3UL, (~C).load(i+1UL,j+SIMDSIZE*3UL) - xmm9  * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*4UL, (~C).load(i+1UL,j+SIMDSIZE*4UL) - xmm10 * factor );
+            (*C).store( i    , j             , (*C).load(i    ,j             ) - xmm1  * factor );
+            (*C).store( i    , j+SIMDSIZE    , (*C).load(i    ,j+SIMDSIZE    ) - xmm2  * factor );
+            (*C).store( i    , j+SIMDSIZE*2UL, (*C).load(i    ,j+SIMDSIZE*2UL) - xmm3  * factor );
+            (*C).store( i    , j+SIMDSIZE*3UL, (*C).load(i    ,j+SIMDSIZE*3UL) - xmm4  * factor );
+            (*C).store( i    , j+SIMDSIZE*4UL, (*C).load(i    ,j+SIMDSIZE*4UL) - xmm5  * factor );
+            (*C).store( i+1UL, j             , (*C).load(i+1UL,j             ) - xmm6  * factor );
+            (*C).store( i+1UL, j+SIMDSIZE    , (*C).load(i+1UL,j+SIMDSIZE    ) - xmm7  * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, (*C).load(i+1UL,j+SIMDSIZE*2UL) - xmm8  * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*3UL, (*C).load(i+1UL,j+SIMDSIZE*3UL) - xmm9  * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*4UL, (*C).load(i+1UL,j+SIMDSIZE*4UL) - xmm10 * factor );
          }
 
          if( i < M )
@@ -6747,11 +6747,11 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm5 += a1 * B.load(k,j+SIMDSIZE*4UL);
             }
 
-            (~C).store( i, j             , (~C).load(i,j             ) - xmm1 * factor );
-            (~C).store( i, j+SIMDSIZE    , (~C).load(i,j+SIMDSIZE    ) - xmm2 * factor );
-            (~C).store( i, j+SIMDSIZE*2UL, (~C).load(i,j+SIMDSIZE*2UL) - xmm3 * factor );
-            (~C).store( i, j+SIMDSIZE*3UL, (~C).load(i,j+SIMDSIZE*3UL) - xmm4 * factor );
-            (~C).store( i, j+SIMDSIZE*4UL, (~C).load(i,j+SIMDSIZE*4UL) - xmm5 * factor );
+            (*C).store( i, j             , (*C).load(i,j             ) - xmm1 * factor );
+            (*C).store( i, j+SIMDSIZE    , (*C).load(i,j+SIMDSIZE    ) - xmm2 * factor );
+            (*C).store( i, j+SIMDSIZE*2UL, (*C).load(i,j+SIMDSIZE*2UL) - xmm3 * factor );
+            (*C).store( i, j+SIMDSIZE*3UL, (*C).load(i,j+SIMDSIZE*3UL) - xmm4 * factor );
+            (*C).store( i, j+SIMDSIZE*4UL, (*C).load(i,j+SIMDSIZE*4UL) - xmm5 * factor );
          }
       }
 
@@ -6791,14 +6791,14 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm8 += a2 * b4;
             }
 
-            (~C).store( i    , j             , (~C).load(i    ,j             ) - xmm1 * factor );
-            (~C).store( i    , j+SIMDSIZE    , (~C).load(i    ,j+SIMDSIZE    ) - xmm2 * factor );
-            (~C).store( i    , j+SIMDSIZE*2UL, (~C).load(i    ,j+SIMDSIZE*2UL) - xmm3 * factor );
-            (~C).store( i    , j+SIMDSIZE*3UL, (~C).load(i    ,j+SIMDSIZE*3UL) - xmm4 * factor );
-            (~C).store( i+1UL, j             , (~C).load(i+1UL,j             ) - xmm5 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE    , (~C).load(i+1UL,j+SIMDSIZE    ) - xmm6 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, (~C).load(i+1UL,j+SIMDSIZE*2UL) - xmm7 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*3UL, (~C).load(i+1UL,j+SIMDSIZE*3UL) - xmm8 * factor );
+            (*C).store( i    , j             , (*C).load(i    ,j             ) - xmm1 * factor );
+            (*C).store( i    , j+SIMDSIZE    , (*C).load(i    ,j+SIMDSIZE    ) - xmm2 * factor );
+            (*C).store( i    , j+SIMDSIZE*2UL, (*C).load(i    ,j+SIMDSIZE*2UL) - xmm3 * factor );
+            (*C).store( i    , j+SIMDSIZE*3UL, (*C).load(i    ,j+SIMDSIZE*3UL) - xmm4 * factor );
+            (*C).store( i+1UL, j             , (*C).load(i+1UL,j             ) - xmm5 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE    , (*C).load(i+1UL,j+SIMDSIZE    ) - xmm6 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, (*C).load(i+1UL,j+SIMDSIZE*2UL) - xmm7 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*3UL, (*C).load(i+1UL,j+SIMDSIZE*3UL) - xmm8 * factor );
          }
 
          if( i < M )
@@ -6820,10 +6820,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm4 += a1 * B.load(k,j+SIMDSIZE*3UL);
             }
 
-            (~C).store( i, j             , (~C).load(i,j             ) - xmm1 * factor );
-            (~C).store( i, j+SIMDSIZE    , (~C).load(i,j+SIMDSIZE    ) - xmm2 * factor );
-            (~C).store( i, j+SIMDSIZE*2UL, (~C).load(i,j+SIMDSIZE*2UL) - xmm3 * factor );
-            (~C).store( i, j+SIMDSIZE*3UL, (~C).load(i,j+SIMDSIZE*3UL) - xmm4 * factor );
+            (*C).store( i, j             , (*C).load(i,j             ) - xmm1 * factor );
+            (*C).store( i, j+SIMDSIZE    , (*C).load(i,j+SIMDSIZE    ) - xmm2 * factor );
+            (*C).store( i, j+SIMDSIZE*2UL, (*C).load(i,j+SIMDSIZE*2UL) - xmm3 * factor );
+            (*C).store( i, j+SIMDSIZE*3UL, (*C).load(i,j+SIMDSIZE*3UL) - xmm4 * factor );
          }
       }
 
@@ -6860,12 +6860,12 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm6 += a2 * b3;
             }
 
-            (~C).store( i    , j             , (~C).load(i    ,j             ) - xmm1 * factor );
-            (~C).store( i    , j+SIMDSIZE    , (~C).load(i    ,j+SIMDSIZE    ) - xmm2 * factor );
-            (~C).store( i    , j+SIMDSIZE*2UL, (~C).load(i    ,j+SIMDSIZE*2UL) - xmm3 * factor );
-            (~C).store( i+1UL, j             , (~C).load(i+1UL,j             ) - xmm4 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE    , (~C).load(i+1UL,j+SIMDSIZE    ) - xmm5 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE*2UL, (~C).load(i+1UL,j+SIMDSIZE*2UL) - xmm6 * factor );
+            (*C).store( i    , j             , (*C).load(i    ,j             ) - xmm1 * factor );
+            (*C).store( i    , j+SIMDSIZE    , (*C).load(i    ,j+SIMDSIZE    ) - xmm2 * factor );
+            (*C).store( i    , j+SIMDSIZE*2UL, (*C).load(i    ,j+SIMDSIZE*2UL) - xmm3 * factor );
+            (*C).store( i+1UL, j             , (*C).load(i+1UL,j             ) - xmm4 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE    , (*C).load(i+1UL,j+SIMDSIZE    ) - xmm5 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE*2UL, (*C).load(i+1UL,j+SIMDSIZE*2UL) - xmm6 * factor );
          }
 
          if( i < M )
@@ -6886,9 +6886,9 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm3 += a1 * B.load(k,j+SIMDSIZE*2UL);
             }
 
-            (~C).store( i, j             , (~C).load(i,j             ) - xmm1 * factor );
-            (~C).store( i, j+SIMDSIZE    , (~C).load(i,j+SIMDSIZE    ) - xmm2 * factor );
-            (~C).store( i, j+SIMDSIZE*2UL, (~C).load(i,j+SIMDSIZE*2UL) - xmm3 * factor );
+            (*C).store( i, j             , (*C).load(i,j             ) - xmm1 * factor );
+            (*C).store( i, j+SIMDSIZE    , (*C).load(i,j+SIMDSIZE    ) - xmm2 * factor );
+            (*C).store( i, j+SIMDSIZE*2UL, (*C).load(i,j+SIMDSIZE*2UL) - xmm3 * factor );
          }
       }
 
@@ -6929,14 +6929,14 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm8 += a4 * b2;
             }
 
-            (~C).store( i    , j         , (~C).load(i    ,j         ) - xmm1 * factor );
-            (~C).store( i    , j+SIMDSIZE, (~C).load(i    ,j+SIMDSIZE) - xmm2 * factor );
-            (~C).store( i+1UL, j         , (~C).load(i+1UL,j         ) - xmm3 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE, (~C).load(i+1UL,j+SIMDSIZE) - xmm4 * factor );
-            (~C).store( i+2UL, j         , (~C).load(i+2UL,j         ) - xmm5 * factor );
-            (~C).store( i+2UL, j+SIMDSIZE, (~C).load(i+2UL,j+SIMDSIZE) - xmm6 * factor );
-            (~C).store( i+3UL, j         , (~C).load(i+3UL,j         ) - xmm7 * factor );
-            (~C).store( i+3UL, j+SIMDSIZE, (~C).load(i+3UL,j+SIMDSIZE) - xmm8 * factor );
+            (*C).store( i    , j         , (*C).load(i    ,j         ) - xmm1 * factor );
+            (*C).store( i    , j+SIMDSIZE, (*C).load(i    ,j+SIMDSIZE) - xmm2 * factor );
+            (*C).store( i+1UL, j         , (*C).load(i+1UL,j         ) - xmm3 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE, (*C).load(i+1UL,j+SIMDSIZE) - xmm4 * factor );
+            (*C).store( i+2UL, j         , (*C).load(i+2UL,j         ) - xmm5 * factor );
+            (*C).store( i+2UL, j+SIMDSIZE, (*C).load(i+2UL,j+SIMDSIZE) - xmm6 * factor );
+            (*C).store( i+3UL, j         , (*C).load(i+3UL,j         ) - xmm7 * factor );
+            (*C).store( i+3UL, j+SIMDSIZE, (*C).load(i+3UL,j+SIMDSIZE) - xmm8 * factor );
          }
 
          for( ; (i+3UL) <= iend; i+=3UL )
@@ -6968,12 +6968,12 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm6 += a3 * b2;
             }
 
-            (~C).store( i    , j         , (~C).load(i    ,j         ) - xmm1 * factor );
-            (~C).store( i    , j+SIMDSIZE, (~C).load(i    ,j+SIMDSIZE) - xmm2 * factor );
-            (~C).store( i+1UL, j         , (~C).load(i+1UL,j         ) - xmm3 * factor );
-            (~C).store( i+1UL, j+SIMDSIZE, (~C).load(i+1UL,j+SIMDSIZE) - xmm4 * factor );
-            (~C).store( i+2UL, j         , (~C).load(i+2UL,j         ) - xmm5 * factor );
-            (~C).store( i+2UL, j+SIMDSIZE, (~C).load(i+2UL,j+SIMDSIZE) - xmm6 * factor );
+            (*C).store( i    , j         , (*C).load(i    ,j         ) - xmm1 * factor );
+            (*C).store( i    , j+SIMDSIZE, (*C).load(i    ,j+SIMDSIZE) - xmm2 * factor );
+            (*C).store( i+1UL, j         , (*C).load(i+1UL,j         ) - xmm3 * factor );
+            (*C).store( i+1UL, j+SIMDSIZE, (*C).load(i+1UL,j+SIMDSIZE) - xmm4 * factor );
+            (*C).store( i+2UL, j         , (*C).load(i+2UL,j         ) - xmm5 * factor );
+            (*C).store( i+2UL, j+SIMDSIZE, (*C).load(i+2UL,j+SIMDSIZE) - xmm6 * factor );
          }
 
          for( ; (i+2UL) <= iend; i+=2UL )
@@ -7022,10 +7022,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm4 += a2 * b2;
             }
 
-            (~C).store( i    , j         , (~C).load(i    ,j         ) - (xmm1+xmm5) * factor );
-            (~C).store( i    , j+SIMDSIZE, (~C).load(i    ,j+SIMDSIZE) - (xmm2+xmm6) * factor );
-            (~C).store( i+1UL, j         , (~C).load(i+1UL,j         ) - (xmm3+xmm7) * factor );
-            (~C).store( i+1UL, j+SIMDSIZE, (~C).load(i+1UL,j+SIMDSIZE) - (xmm4+xmm8) * factor );
+            (*C).store( i    , j         , (*C).load(i    ,j         ) - (xmm1+xmm5) * factor );
+            (*C).store( i    , j+SIMDSIZE, (*C).load(i    ,j+SIMDSIZE) - (xmm2+xmm6) * factor );
+            (*C).store( i+1UL, j         , (*C).load(i+1UL,j         ) - (xmm3+xmm7) * factor );
+            (*C).store( i+1UL, j+SIMDSIZE, (*C).load(i+1UL,j+SIMDSIZE) - (xmm4+xmm8) * factor );
          }
 
          if( i < iend )
@@ -7055,8 +7055,8 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm2 += a1 * B.load(k,j+SIMDSIZE);
             }
 
-            (~C).store( i, j         , (~C).load(i,j         ) - (xmm1+xmm3) * factor );
-            (~C).store( i, j+SIMDSIZE, (~C).load(i,j+SIMDSIZE) - (xmm2+xmm4) * factor );
+            (*C).store( i, j         , (*C).load(i,j         ) - (xmm1+xmm3) * factor );
+            (*C).store( i, j+SIMDSIZE, (*C).load(i,j+SIMDSIZE) - (xmm2+xmm4) * factor );
          }
       }
 
@@ -7100,10 +7100,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm4 += set( A(i+3UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, (~C).load(i    ,j) - (xmm1+xmm5) * factor );
-            (~C).store( i+1UL, j, (~C).load(i+1UL,j) - (xmm2+xmm6) * factor );
-            (~C).store( i+2UL, j, (~C).load(i+2UL,j) - (xmm3+xmm7) * factor );
-            (~C).store( i+3UL, j, (~C).load(i+3UL,j) - (xmm4+xmm8) * factor );
+            (*C).store( i    , j, (*C).load(i    ,j) - (xmm1+xmm5) * factor );
+            (*C).store( i+1UL, j, (*C).load(i+1UL,j) - (xmm2+xmm6) * factor );
+            (*C).store( i+2UL, j, (*C).load(i+2UL,j) - (xmm3+xmm7) * factor );
+            (*C).store( i+3UL, j, (*C).load(i+3UL,j) - (xmm4+xmm8) * factor );
          }
 
          for( ; (i+3UL) <= iend; i+=3UL )
@@ -7138,9 +7138,9 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm3 += set( A(i+2UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, (~C).load(i    ,j) - (xmm1+xmm4) * factor );
-            (~C).store( i+1UL, j, (~C).load(i+1UL,j) - (xmm2+xmm5) * factor );
-            (~C).store( i+2UL, j, (~C).load(i+2UL,j) - (xmm3+xmm6) * factor );
+            (*C).store( i    , j, (*C).load(i    ,j) - (xmm1+xmm4) * factor );
+            (*C).store( i+1UL, j, (*C).load(i+1UL,j) - (xmm2+xmm5) * factor );
+            (*C).store( i+2UL, j, (*C).load(i+2UL,j) - (xmm3+xmm6) * factor );
          }
 
          for( ; (i+2UL) <= iend; i+=2UL )
@@ -7172,8 +7172,8 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm2 += set( A(i+1UL,k) ) * b1;
             }
 
-            (~C).store( i    , j, (~C).load(i    ,j) - (xmm1+xmm3) * factor );
-            (~C).store( i+1UL, j, (~C).load(i+1UL,j) - (xmm2+xmm4) * factor );
+            (*C).store( i    , j, (*C).load(i    ,j) - (xmm1+xmm3) * factor );
+            (*C).store( i+1UL, j, (*C).load(i+1UL,j) - (xmm2+xmm4) * factor );
          }
 
          if( i < iend )
@@ -7196,7 +7196,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                xmm1 += set( A(i,k) ) * B.load(k,j);
             }
 
-            (~C).store( i, j, (~C).load(i,j) - (xmm1+xmm2) * factor );
+            (*C).store( i, j, (*C).load(i,j) - (xmm1+xmm2) * factor );
          }
       }
 
@@ -7224,8 +7224,8 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                value2 += A(i+1UL,k) * B(k,j);
             }
 
-            (~C)(i    ,j) -= value1 * scalar;
-            (~C)(i+1UL,j) -= value2 * scalar;
+            (*C)(i    ,j) -= value1 * scalar;
+            (*C)(i+1UL,j) -= value2 * scalar;
          }
 
          if( i < iend )
@@ -7242,7 +7242,7 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
                value += A(i,k) * B(k,j);
             }
 
-            (~C)(i,j) -= value * scalar;
+            (*C)(i,j) -= value * scalar;
          }
       }
    }
@@ -7392,11 +7392,11 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    //**********************************************************************************************
 
@@ -7434,17 +7434,17 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       LeftOperand_t<MMM>  left ( rhs.tensor_.leftOperand()  );
       RightOperand_t<MMM> right( rhs.tensor_.rightOperand() );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL ) {
          return;
       }
       else if( left.columns() == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
          return;
       }
 
@@ -7455,10 +7455,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()  , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == right.rows()    , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == right.columns() , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns(), "Invalid number of columns" );
 
-      smpAssign( ~lhs, A * B * rhs.scalar_ );
+      smpAssign( *lhs, A * B * rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -7484,13 +7484,13 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       LeftOperand_t<MMM>  left ( rhs.tensor_.leftOperand()  );
       RightOperand_t<MMM> right( rhs.tensor_.rightOperand() );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || left.columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || left.columns() == 0UL ) {
          return;
       }
 
@@ -7501,10 +7501,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()  , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == right.rows()    , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == right.columns() , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns(), "Invalid number of columns" );
 
-      smpAddAssign( ~lhs, A * B * rhs.scalar_ );
+      smpAddAssign( *lhs, A * B * rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -7534,13 +7534,13 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       LeftOperand_t<MMM>  left ( rhs.tensor_.leftOperand()  );
       RightOperand_t<MMM> right( rhs.tensor_.rightOperand() );
 
-      if( (~lhs).rows() == 0UL || (~lhs).columns() == 0UL || left.columns() == 0UL ) {
+      if( (*lhs).rows() == 0UL || (*lhs).columns() == 0UL || left.columns() == 0UL ) {
          return;
       }
 
@@ -7551,10 +7551,10 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()  , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( B.rows()    == right.rows()    , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( B.columns() == right.columns() , "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( B.columns() == (~lhs).columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( B.columns() == (*lhs).columns(), "Invalid number of columns" );
 
-      smpSubAssign( ~lhs, A * B * rhs.scalar_ );
+      smpSubAssign( *lhs, A * B * rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -7584,11 +7584,11 @@ class DTensScalarMultExpr< DTensDTensMultExpr<MT1,MT2>, ST >
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    //**********************************************************************************************
 
@@ -7661,12 +7661,12 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   if( (~lhs).columns() != (~rhs).rows() ) {
+   if( (*lhs).columns() != (*rhs).rows() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using ReturnType = const DTensDTensMultExpr<MT1,MT2>;
-   return ReturnType( ~lhs, ~rhs );
+   return ReturnType( *lhs, *rhs );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensDTensSchurExpr.h
+++ b/blaze_tensor/math/expressions/DTensDTensSchurExpr.h
@@ -663,17 +663,17 @@ class DTensDTensSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      if( !IsOperation_v<MT1> && isSame( ~lhs, rhs.lhs_ ) ) {
-         schurAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<MT1> && isSame( *lhs, rhs.lhs_ ) ) {
+         schurAssign( *lhs, rhs.rhs_ );
       }
       else {
          CT1 A( serial( rhs.lhs_ ) );
          CT2 B( serial( rhs.rhs_ ) );
-         assign( ~lhs, A % B );
+         assign( *lhs, A % B );
       }
    }
    /*! \endcond */
@@ -699,23 +699,23 @@ class DTensDTensSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      if( !IsOperation_v<MT1> && isSame( ~lhs, rhs.lhs_ ) ) {
-         schurAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<MT1> && isSame( *lhs, rhs.lhs_ ) ) {
+         schurAssign( *lhs, rhs.rhs_ );
       }
-      else if( !IsOperation_v<MT2> && isSame( ~lhs, rhs.rhs_ ) ) {
-         schurAssign( ~lhs, rhs.lhs_ );
+      else if( !IsOperation_v<MT2> && isSame( *lhs, rhs.rhs_ ) ) {
+         schurAssign( *lhs, rhs.lhs_ );
       }
       else if( !RequiresEvaluation_v<MT2> ) {
-         assign     ( ~lhs, rhs.rhs_ );
-         schurAssign( ~lhs, rhs.lhs_ );
+         assign     ( *lhs, rhs.rhs_ );
+         schurAssign( *lhs, rhs.lhs_ );
       }
       else {
-         assign     ( ~lhs, rhs.lhs_ );
-         schurAssign( ~lhs, rhs.rhs_ );
+         assign     ( *lhs, rhs.lhs_ );
+         schurAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -744,12 +744,12 @@ class DTensDTensSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
       const ResultType tmp( serial( rhs ) );
-      addAssign( ~lhs, tmp );
+      addAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -781,12 +781,12 @@ class DTensDTensSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
       const ResultType tmp( serial( rhs ) );
-      subAssign( ~lhs, tmp );
+      subAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -815,12 +815,12 @@ class DTensDTensSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -846,17 +846,17 @@ class DTensDTensSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         schurAssign( ~lhs, rhs.rhs_ );
-         schurAssign( ~lhs, rhs.lhs_ );
+         schurAssign( *lhs, rhs.rhs_ );
+         schurAssign( *lhs, rhs.lhs_ );
       }
       else {
-         schurAssign( ~lhs, rhs.lhs_ );
-         schurAssign( ~lhs, rhs.rhs_ );
+         schurAssign( *lhs, rhs.lhs_ );
+         schurAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -883,17 +883,17 @@ class DTensDTensSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      if( !IsOperation_v<MT1> && isSame( ~lhs, rhs.lhs_ ) ) {
-         smpSchurAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<MT1> && isSame( *lhs, rhs.lhs_ ) ) {
+         smpSchurAssign( *lhs, rhs.rhs_ );
       }
       else {
          CT1 A( rhs.lhs_ );
          CT2 B( rhs.rhs_ );
-         smpAssign( ~lhs, A % B );
+         smpAssign( *lhs, A % B );
       }
    }
    /*! \endcond */
@@ -920,23 +920,23 @@ class DTensDTensSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      if( !IsOperation_v<MT1> && isSame( ~lhs, rhs.lhs_ ) ) {
-         smpSchurAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<MT1> && isSame( *lhs, rhs.lhs_ ) ) {
+         smpSchurAssign( *lhs, rhs.rhs_ );
       }
-      else if( !IsOperation_v<MT2> && isSame( ~lhs, rhs.rhs_ ) ) {
-         smpSchurAssign( ~lhs, rhs.lhs_ );
+      else if( !IsOperation_v<MT2> && isSame( *lhs, rhs.rhs_ ) ) {
+         smpSchurAssign( *lhs, rhs.lhs_ );
       }
       else if( !RequiresEvaluation_v<MT2> ) {
-         smpAssign     ( ~lhs, rhs.rhs_ );
-         smpSchurAssign( ~lhs, rhs.lhs_ );
+         smpAssign     ( *lhs, rhs.rhs_ );
+         smpSchurAssign( *lhs, rhs.lhs_ );
       }
       else {
-         smpAssign     ( ~lhs, rhs.lhs_ );
-         smpSchurAssign( ~lhs, rhs.rhs_ );
+         smpAssign     ( *lhs, rhs.lhs_ );
+         smpSchurAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -965,12 +965,12 @@ class DTensDTensSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
       const ResultType tmp( rhs );
-      smpAddAssign( ~lhs, tmp );
+      smpAddAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -999,12 +999,12 @@ class DTensDTensSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
       const ResultType tmp( rhs );
-      smpSubAssign( ~lhs, tmp );
+      smpSubAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1033,12 +1033,12 @@ class DTensDTensSchurExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1064,17 +1064,17 @@ class DTensDTensSchurExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         smpSchurAssign( ~lhs, rhs.rhs_ );
-         smpSchurAssign( ~lhs, rhs.lhs_ );
+         smpSchurAssign( *lhs, rhs.rhs_ );
+         smpSchurAssign( *lhs, rhs.lhs_ );
       }
       else {
-         smpSchurAssign( ~lhs, rhs.lhs_ );
-         smpSchurAssign( ~lhs, rhs.rhs_ );
+         smpSchurAssign( *lhs, rhs.lhs_ );
+         smpSchurAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -1121,11 +1121,11 @@ inline const DTensDTensSchurExpr<MT1,MT2>
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
-   return DTensDTensSchurExpr<MT1,MT2>( ~lhs, ~rhs );
+   return DTensDTensSchurExpr<MT1,MT2>( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1155,11 +1155,11 @@ inline const DTensDTensSchurExpr<MT1,MT2>
 //
 //    MAYBE_UNUSED( rhs );
 //
-//    BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-//    BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-//    BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages()  , "Invalid number of pages" );
+//    BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+//    BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+//    BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages()  , "Invalid number of pages" );
 //
-//    return IdentityTensor< MultTrait_t< ElementType_t<MT1>, ElementType_t<MT2> > >( (~lhs).rows() );
+//    return IdentityTensor< MultTrait_t< ElementType_t<MT1>, ElementType_t<MT2> > >( (*lhs).rows() );
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1197,11 +1197,11 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   if( (~lhs).rows() != (~rhs).rows() || (~lhs).columns() != (~rhs).columns() || (~lhs).pages() != (~rhs).pages() ) {
+   if( (*lhs).rows() != (*rhs).rows() || (*lhs).columns() != (*rhs).columns() || (*lhs).pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   return dtensdtensschur( ~lhs, ~rhs );
+   return dtensdtensschur( *lhs, *rhs );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensDTensSubExpr.h
+++ b/blaze_tensor/math/expressions/DTensDTensSubExpr.h
@@ -624,21 +624,21 @@ class DTensDTensSubExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      if( !IsOperation_v<MT1> && isSame( ~lhs, rhs.lhs_ ) ) {
-         subAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<MT1> && isSame( *lhs, rhs.lhs_ ) ) {
+         subAssign( *lhs, rhs.rhs_ );
       }
-      else if( ( !IsOperation_v<MT2> && isSame( ~lhs, rhs.rhs_ ) ) ||
-               ( !RequiresEvaluation_v<MT2> && rhs.rhs_.isAliased( &(~lhs) ) ) ) {
-         assign   ( ~lhs, -rhs.rhs_ );
-         addAssign( ~lhs,  rhs.lhs_ );
+      else if( ( !IsOperation_v<MT2> && isSame( *lhs, rhs.rhs_ ) ) ||
+               ( !RequiresEvaluation_v<MT2> && rhs.rhs_.isAliased( &(*lhs) ) ) ) {
+         assign   ( *lhs, -rhs.rhs_ );
+         addAssign( *lhs,  rhs.lhs_ );
       }
       else {
-         assign   ( ~lhs, rhs.lhs_ );
-         subAssign( ~lhs, rhs.rhs_ );
+         assign   ( *lhs, rhs.lhs_ );
+         subAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -664,17 +664,17 @@ class DTensDTensSubExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         subAssign( ~lhs, rhs.rhs_ );
-         addAssign( ~lhs, rhs.lhs_ );
+         subAssign( *lhs, rhs.rhs_ );
+         addAssign( *lhs, rhs.lhs_ );
       }
       else {
-         addAssign( ~lhs, rhs.lhs_ );
-         subAssign( ~lhs, rhs.rhs_ );
+         addAssign( *lhs, rhs.lhs_ );
+         subAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -700,17 +700,17 @@ class DTensDTensSubExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         addAssign( ~lhs, rhs.rhs_ );
-         subAssign( ~lhs, rhs.lhs_ );
+         addAssign( *lhs, rhs.rhs_ );
+         subAssign( *lhs, rhs.lhs_ );
       }
       else {
-         subAssign( ~lhs, rhs.lhs_ );
-         addAssign( ~lhs, rhs.rhs_ );
+         subAssign( *lhs, rhs.lhs_ );
+         addAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -739,12 +739,12 @@ class DTensDTensSubExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -769,21 +769,21 @@ class DTensDTensSubExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      if( !IsOperation_v<MT1> && isSame( ~lhs, rhs.lhs_ ) ) {
-         smpSubAssign( ~lhs, rhs.rhs_ );
+      if( !IsOperation_v<MT1> && isSame( *lhs, rhs.lhs_ ) ) {
+         smpSubAssign( *lhs, rhs.rhs_ );
       }
-      else if( ( !IsOperation_v<MT2> && isSame( ~lhs, rhs.rhs_ ) ) ||
-               ( !RequiresEvaluation_v<MT2> && rhs.rhs_.isAliased( &(~lhs) ) ) ) {
-         smpAssign   ( ~lhs, -rhs.rhs_ );
-         smpAddAssign( ~lhs,  rhs.lhs_ );
+      else if( ( !IsOperation_v<MT2> && isSame( *lhs, rhs.rhs_ ) ) ||
+               ( !RequiresEvaluation_v<MT2> && rhs.rhs_.isAliased( &(*lhs) ) ) ) {
+         smpAssign   ( *lhs, -rhs.rhs_ );
+         smpAddAssign( *lhs,  rhs.lhs_ );
       }
       else {
-         smpAssign   ( ~lhs, rhs.lhs_ );
-         smpSubAssign( ~lhs, rhs.rhs_ );
+         smpAssign   ( *lhs, rhs.lhs_ );
+         smpSubAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -809,17 +809,17 @@ class DTensDTensSubExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         smpSubAssign( ~lhs, rhs.rhs_ );
-         smpAddAssign( ~lhs, rhs.lhs_ );
+         smpSubAssign( *lhs, rhs.rhs_ );
+         smpAddAssign( *lhs, rhs.lhs_ );
       }
       else {
-         smpAddAssign( ~lhs, rhs.lhs_ );
-         smpSubAssign( ~lhs, rhs.rhs_ );
+         smpAddAssign( *lhs, rhs.lhs_ );
+         smpSubAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -845,17 +845,17 @@ class DTensDTensSubExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       if( !RequiresEvaluation_v<MT2> ) {
-         smpAddAssign( ~lhs, rhs.rhs_ );
-         smpSubAssign( ~lhs, rhs.lhs_ );
+         smpAddAssign( *lhs, rhs.rhs_ );
+         smpSubAssign( *lhs, rhs.lhs_ );
       }
       else {
-         smpSubAssign( ~lhs, rhs.lhs_ );
-         smpAddAssign( ~lhs, rhs.rhs_ );
+         smpSubAssign( *lhs, rhs.lhs_ );
+         smpAddAssign( *lhs, rhs.rhs_ );
       }
    }
    /*! \endcond */
@@ -885,12 +885,12 @@ class DTensDTensSubExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -947,12 +947,12 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   if( (~lhs).rows() != (~rhs).rows() || (~lhs).columns() != (~rhs).columns() ) {
+   if( (*lhs).rows() != (*rhs).rows() || (*lhs).columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using ReturnType = const DTensDTensSubExpr<MT1,MT2>;
-   return ReturnType( ~lhs, ~rhs );
+   return ReturnType( *lhs, *rhs );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensDVecMultExpr.h
+++ b/blaze_tensor/math/expressions/DTensDVecMultExpr.h
@@ -402,13 +402,13 @@ class DTensDVecMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT( ((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL ) {
          return;
       }
       else if( rhs.tens_.columns() == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
          return;
       }
 
@@ -419,10 +419,10 @@ class DTensDVecMultExpr
       BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns()   , "Invalid matrix columns"    );
 
-      DTensDVecMultExpr::selectAssignKernel( ~lhs, A, x );
+      DTensDVecMultExpr::selectAssignKernel( *lhs, A, x );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -979,10 +979,10 @@ class DTensDVecMultExpr
    //   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( ResultType );
    //   BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-   //   BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+   //   BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid vector sizes" );
 
    //   const ResultType tmp( serial( rhs ) );
-   //   assign( ~lhs, tmp );
+   //   assign( *lhs, tmp );
    //}
    ///*! \endcond */
    ////**********************************************************************************************
@@ -1005,7 +1005,7 @@ class DTensDVecMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT(((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT(((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL || rhs.tens_.columns() == 0UL ) {
          return;
@@ -1018,10 +1018,10 @@ class DTensDVecMultExpr
       BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns()   , "Invalid matrix columns"    );
 
-      DTensDVecMultExpr::selectAddAssignKernel( ~lhs, A, x );
+      DTensDVecMultExpr::selectAddAssignKernel( *lhs, A, x );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1572,7 +1572,7 @@ class DTensDVecMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT(((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT(((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL || rhs.tens_.columns() == 0UL ) {
          return;
@@ -1585,10 +1585,10 @@ class DTensDVecMultExpr
       BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns()   , "Invalid matrix columns"    );
 
-      DTensDVecMultExpr::selectSubAssignKernel( ~lhs, A, x );
+      DTensDVecMultExpr::selectSubAssignKernel( *lhs, A, x );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2143,11 +2143,11 @@ class DTensDVecMultExpr
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2173,13 +2173,13 @@ class DTensDVecMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT( ((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL ) {
          return;
       }
       else if( rhs.tens_.columns() == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
          return;
       }
 
@@ -2190,10 +2190,10 @@ class DTensDVecMultExpr
       BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns()   , "Invalid matrix columns"    );
 
-      smpAssign( ~lhs, A * x );
+      smpAssign( *lhs, A * x );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2223,10 +2223,10 @@ class DTensDVecMultExpr
    //   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE( ResultType );
    //   BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-   //   BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+   //   BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid vector sizes" );
 
    //   const ResultType tmp( rhs );
-   //   smpAssign( ~lhs, tmp );
+   //   smpAssign( *lhs, tmp );
    //}
    ///*! \endcond */
    ////**********************************************************************************************
@@ -2252,7 +2252,7 @@ class DTensDVecMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT( ((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL || rhs.tens_.columns() == 0UL ) {
          return;
@@ -2265,10 +2265,10 @@ class DTensDVecMultExpr
       BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns()   , "Invalid matrix columns"    );
 
-      smpAddAssign( ~lhs, A * x );
+      smpAddAssign( *lhs, A * x );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2298,7 +2298,7 @@ class DTensDVecMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT( ((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       if( rhs.tens_.pages() == 0UL || rhs.tens_.rows() == 0UL || rhs.tens_.columns() == 0UL ) {
          return;
@@ -2311,10 +2311,10 @@ class DTensDVecMultExpr
       BLAZE_INTERNAL_ASSERT( A.rows()    == rhs.tens_.rows()   , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == rhs.tens_.columns(), "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == rhs.vec_.size()    , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()      , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns()   , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()      , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns()   , "Invalid matrix columns"    );
 
-      smpSubAssign( ~lhs, A * x );
+      smpSubAssign( *lhs, A * x );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2348,11 +2348,11 @@ class DTensDVecMultExpr
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2667,7 +2667,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( ((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT( ((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       LeftOperand_t<MVM>  left ( rhs.matrix_.leftOperand()  );
       RightOperand_t<MVM> right( rhs.matrix_.rightOperand() );
@@ -2676,7 +2676,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
          return;
       }
       else if( left.columns() == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
          return;
       }
 
@@ -2687,10 +2687,10 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()      , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()   , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == right.size()     , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()    , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns() , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()    , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns() , "Invalid matrix columns"    );
 
-      DMatScalarMultExpr::selectAssignKernel( ~lhs, A, x, rhs.scalar_ );
+      DMatScalarMultExpr::selectAssignKernel( *lhs, A, x, rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -3261,10 +3261,10 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    //   BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE ( ResultType );
    //   BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-   //   BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+   //   BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid vector sizes" );
 
    //   const ResultType tmp( serial( rhs ) );
-   //   assign( ~lhs, tmp );
+   //   assign( *lhs, tmp );
    //}
    //**********************************************************************************************
 
@@ -3285,7 +3285,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT(((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT(((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       LeftOperand_t<MVM>  left ( rhs.matrix_.leftOperand()  );
       RightOperand_t<MVM> right( rhs.matrix_.rightOperand() );
@@ -3301,10 +3301,10 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()      , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()   , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == right.size()     , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()    , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns() , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()    , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns() , "Invalid matrix columns"    );
 
-      DMatScalarMultExpr::selectAddAssignKernel( ~lhs, A, x, rhs.scalar_ );
+      DMatScalarMultExpr::selectAddAssignKernel( *lhs, A, x, rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -3869,7 +3869,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT(((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT(((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       LeftOperand_t<MVM>  left ( rhs.matrix_.leftOperand()  );
       RightOperand_t<MVM> right( rhs.matrix_.rightOperand() );
@@ -3885,10 +3885,10 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()      , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()   , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == right.size()     , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()    , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns() , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()    , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns() , "Invalid matrix columns"    );
 
-      DMatScalarMultExpr::selectSubAssignKernel( ~lhs, A, x, rhs.scalar_ );
+      DMatScalarMultExpr::selectSubAssignKernel( *lhs, A, x, rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -4441,11 +4441,11 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    //**********************************************************************************************
 
@@ -4469,7 +4469,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT(((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT(((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       LeftOperand_t<MVM>  left ( rhs.matrix_.leftOperand()  );
       RightOperand_t<MVM> right( rhs.matrix_.rightOperand() );
@@ -4478,7 +4478,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
          return;
       }
       else if( left.columns() == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
          return;
       }
 
@@ -4489,10 +4489,10 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()      , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()   , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == right.size()     , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()    , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns() , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()    , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns() , "Invalid matrix columns"    );
 
-      smpAssign( ~lhs, A * x * rhs.scalar_ );
+      smpAssign( *lhs, A * x * rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -4520,10 +4520,10 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
 //      BLAZE_CONSTRAINT_MUST_BE_COLUMN_VECTOR_TYPE ( ResultType );
 //      BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 //
-//      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid vector sizes" );
+//      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid vector sizes" );
 //
 //      const ResultType tmp( rhs );
-//      smpAssign( ~lhs, tmp );
+//      smpAssign( *lhs, tmp );
 //   }
    //**********************************************************************************************
 
@@ -4547,7 +4547,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT(((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT(((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       LeftOperand_t<MVM>  left ( rhs.matrix_.leftOperand()  );
       RightOperand_t<MVM> right( rhs.matrix_.rightOperand() );
@@ -4556,7 +4556,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
          return;
       }
       else if( left.columns() == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
          return;
       }
 
@@ -4567,10 +4567,10 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()      , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()   , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == right.size()     , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()    , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns() , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()    , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns() , "Invalid matrix columns"    );
 
-      smpAddAssign( ~lhs, A * x * rhs.scalar_ );
+      smpAddAssign( *lhs, A * x * rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -4598,7 +4598,7 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT(((~lhs).rows() == rhs.rows() && (~lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
+      BLAZE_INTERNAL_ASSERT(((*lhs).rows() == rhs.rows() && (*lhs).columns() == rhs.columns()), "Invalid matrix sizes" );
 
       LeftOperand_t<MVM>  left ( rhs.matrix_.leftOperand()  );
       RightOperand_t<MVM> right( rhs.matrix_.rightOperand() );
@@ -4614,10 +4614,10 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       BLAZE_INTERNAL_ASSERT( A.rows()    == left.rows()      , "Invalid number of rows"    );
       BLAZE_INTERNAL_ASSERT( A.columns() == left.columns()   , "Invalid number of columns" );
       BLAZE_INTERNAL_ASSERT( x.size()    == right.size()     , "Invalid vector size"       );
-      BLAZE_INTERNAL_ASSERT( A.pages()   == (~lhs).rows()    , "Invalid matrix rows"       );
-      BLAZE_INTERNAL_ASSERT( A.rows()    == (~lhs).columns() , "Invalid matrix columns"    );
+      BLAZE_INTERNAL_ASSERT( A.pages()   == (*lhs).rows()    , "Invalid matrix rows"       );
+      BLAZE_INTERNAL_ASSERT( A.rows()    == (*lhs).columns() , "Invalid matrix columns"    );
 
-      smpSubAssign( ~lhs, A * x * rhs.scalar_ );
+      smpSubAssign( *lhs, A * x * rhs.scalar_ );
    }
    //**********************************************************************************************
 
@@ -4649,11 +4649,11 @@ class DMatScalarMultExpr< DTensDVecMultExpr<TT,VT>, ST, false >
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    //**********************************************************************************************
 
@@ -4719,12 +4719,12 @@ inline decltype(auto)
 
    //BLAZE_CONSTRAINT_MUST_NOT_BE_MATMATMULTEXPR_TYPE( TT );
 
-   if( (~tens).columns() != (~vec).size() ) {
+   if( (*tens).columns() != (*vec).size() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor and vector sizes do not match" );
    }
 
    using ReturnType = const DTensDVecMultExpr<TT,VT>;
-   return ReturnType( ~tens, ~vec );
+   return ReturnType( *tens, *vec );
 }
 //*************************************************************************************************
 
@@ -4758,7 +4758,7 @@ inline decltype(auto)
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return (~tens).leftOperand() * ( (~tens).rightOperand() * vec );
+//   return (*tens).leftOperand() * ( (*tens).rightOperand() * vec );
 //}
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DTensEvalExpr.h
+++ b/blaze_tensor/math/expressions/DTensEvalExpr.h
@@ -243,11 +243,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      assign( ~lhs, rhs.dt_ );
+      assign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -269,11 +269,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      addAssign( ~lhs, rhs.dt_ );
+      addAssign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -295,11 +295,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      subAssign( ~lhs, rhs.dt_ );
+      subAssign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -321,11 +321,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      schurAssign( ~lhs, rhs.dt_ );
+      schurAssign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -347,11 +347,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      multAssign( ~lhs, rhs.dt_ );
+      multAssign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -373,11 +373,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      smpAssign( ~lhs, rhs.dt_ );
+      smpAssign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -399,11 +399,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      smpAddAssign( ~lhs, rhs.dt_ );
+      smpAddAssign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -425,11 +425,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      smpSubAssign( ~lhs, rhs.dt_ );
+      smpSubAssign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -451,11 +451,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      smpSchurAssign( ~lhs, rhs.dt_ );
+      smpSchurAssign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -478,11 +478,11 @@ class DTensEvalExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages(),   "Invalid number of pages"   );
 
-      smpMultAssign( ~lhs, rhs.dt_ );
+      smpMultAssign( *lhs, rhs.dt_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -527,7 +527,7 @@ inline decltype(auto) eval( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensEvalExpr<MT>;
-   return ReturnType( ~dm );
+   return ReturnType( *dm );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensMapExpr.h
+++ b/blaze_tensor/math/expressions/DTensMapExpr.h
@@ -610,12 +610,12 @@ class DTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
-      assign( ~lhs, rhs.dm_ );
-      assign( ~lhs, rhs.op_( ~lhs ) );
+      assign( *lhs, rhs.dm_ );
+      assign( *lhs, rhs.op_( *lhs ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -645,12 +645,12 @@ class DTensMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
       const RT tmp( serial( rhs.dm_ ) );
-      assign( ~lhs, map( tmp, rhs.op_ ) );
+      assign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -678,12 +678,12 @@ class DTensMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
       const RT tmp( serial( rhs.dm_ ) );
-      addAssign( ~lhs, map( tmp, rhs.op_ ) );
+      addAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -711,12 +711,12 @@ class DTensMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
       const RT tmp( serial( rhs.dm_ ) );
-      subAssign( ~lhs, map( tmp, rhs.op_ ) );
+      subAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -744,12 +744,12 @@ class DTensMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
       const RT tmp( serial( rhs.dm_ ) );
-      schurAssign( ~lhs, map( tmp, rhs.op_ ) );
+      schurAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -776,12 +776,12 @@ class DTensMapExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
-      smpAssign( ~lhs, rhs.dm_ );
-      smpAssign( ~lhs, rhs.op_( ~lhs ) );
+      smpAssign( *lhs, rhs.dm_ );
+      smpAssign( *lhs, rhs.op_( *lhs ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -811,12 +811,12 @@ class DTensMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
       const RT tmp( rhs.dm_ );
-      smpAssign( ~lhs, map( tmp, rhs.op_ ) );
+      smpAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -844,12 +844,12 @@ class DTensMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
       const RT tmp( rhs.dm_ );
-      smpAddAssign( ~lhs, map( tmp, rhs.op_ ) );
+      smpAddAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -877,12 +877,12 @@ class DTensMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
       const RT tmp( rhs.dm_ );
-      smpSubAssign( ~lhs, map( tmp, rhs.op_ ) );
+      smpSubAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -910,12 +910,12 @@ class DTensMapExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( RT );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( RT );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid pages of columns" );
 
       const RT tmp( rhs.dm_ );
-      smpSchurAssign( ~lhs, map( tmp, rhs.op_ ) );
+      smpSchurAssign( *lhs, map( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -962,7 +962,7 @@ inline decltype(auto) map( const DenseTensor<MT>& dm, OP op )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,OP>;
-   return ReturnType( ~dm, op );
+   return ReturnType( *dm, op );
 }
 //*************************************************************************************************
 
@@ -992,7 +992,7 @@ inline decltype(auto) forEach( const DenseTensor<MT>& dm, OP op )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,OP>;
-   return ReturnType( ~dm, op );
+   return ReturnType( *dm, op );
 }
 //*************************************************************************************************
 
@@ -1020,7 +1020,7 @@ inline decltype(auto) abs( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Abs>;
-   return ReturnType( ~dm, Abs() );
+   return ReturnType( *dm, Abs() );
 }
 //*************************************************************************************************
 
@@ -1048,7 +1048,7 @@ inline decltype(auto) sign( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Sign>;
-   return ReturnType( ~dm, Sign() );
+   return ReturnType( *dm, Sign() );
 }
 //*************************************************************************************************
 
@@ -1076,7 +1076,7 @@ inline decltype(auto) floor( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Floor>;
-   return ReturnType( ~dm, Floor() );
+   return ReturnType( *dm, Floor() );
 }
 //*************************************************************************************************
 
@@ -1104,7 +1104,7 @@ inline decltype(auto) ceil( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Ceil>;
-   return ReturnType( ~dm, Ceil() );
+   return ReturnType( *dm, Ceil() );
 }
 //*************************************************************************************************
 
@@ -1132,7 +1132,7 @@ inline decltype(auto) trunc( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Trunc>;
-   return ReturnType( ~dm, Trunc() );
+   return ReturnType( *dm, Trunc() );
 }
 //*************************************************************************************************
 
@@ -1160,7 +1160,7 @@ inline decltype(auto) round( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Round>;
-   return ReturnType( ~dm, Round() );
+   return ReturnType( *dm, Round() );
 }
 //*************************************************************************************************
 
@@ -1188,7 +1188,7 @@ inline decltype(auto) conj( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Conj>;
-   return ReturnType( ~dm, Conj() );
+   return ReturnType( *dm, Conj() );
 }
 //*************************************************************************************************
 
@@ -1225,7 +1225,7 @@ inline decltype(auto) ctrans( const DenseTensor<MT>& dm, RTAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( conj( ~dm ), args... );
+   return trans( conj( *dm ), args... );
 }
 //*************************************************************************************************
 
@@ -1253,7 +1253,7 @@ inline decltype(auto) real( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Real>;
-   return ReturnType( ~dm, Real() );
+   return ReturnType( *dm, Real() );
 }
 //*************************************************************************************************
 
@@ -1281,7 +1281,7 @@ inline decltype(auto) imag( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Imag>;
-   return ReturnType( ~dm, Imag() );
+   return ReturnType( *dm, Imag() );
 }
 //*************************************************************************************************
 
@@ -1312,7 +1312,7 @@ inline decltype(auto) sqrt( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Sqrt>;
-   return ReturnType( ~dm, Sqrt() );
+   return ReturnType( *dm, Sqrt() );
 }
 //*************************************************************************************************
 
@@ -1343,7 +1343,7 @@ inline decltype(auto) invsqrt( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,InvSqrt>;
-   return ReturnType( ~dm, InvSqrt() );
+   return ReturnType( *dm, InvSqrt() );
 }
 //*************************************************************************************************
 
@@ -1374,7 +1374,7 @@ inline decltype(auto) cbrt( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Cbrt>;
-   return ReturnType( ~dm, Cbrt() );
+   return ReturnType( *dm, Cbrt() );
 }
 //*************************************************************************************************
 
@@ -1405,7 +1405,7 @@ inline decltype(auto) invcbrt( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,InvCbrt>;
-   return ReturnType( ~dm, InvCbrt() );
+   return ReturnType( *dm, InvCbrt() );
 }
 //*************************************************************************************************
 
@@ -1435,7 +1435,7 @@ inline decltype(auto) clamp( const DenseTensor<MT>& dm, const DT& min, const DT&
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( ~dm, bind2nd( bind3rd( Clamp(), max ), min ) );
+   return map( *dm, bind2nd( bind3rd( Clamp(), max ), min ) );
 }
 //*************************************************************************************************
 
@@ -1466,7 +1466,7 @@ inline decltype(auto) pow( const DenseTensor<MT>& dm, ST exp )
    BLAZE_FUNCTION_TRACE;
 
    using ScalarType = MultTrait_t< UnderlyingBuiltin_t<MT>, ST >;
-   return map( ~dm, blaze::bind2nd( Pow(), ScalarType( exp ) ) );
+   return map( *dm, blaze::bind2nd( Pow(), ScalarType( exp ) ) );
 }
 //*************************************************************************************************
 
@@ -1494,7 +1494,7 @@ inline decltype(auto) exp( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Exp>;
-   return ReturnType( ~dm, Exp() );
+   return ReturnType( *dm, Exp() );
 }
 //*************************************************************************************************
 
@@ -1522,7 +1522,7 @@ inline decltype(auto) exp2( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Exp2>;
-   return ReturnType( ~dm, Exp2() );
+   return ReturnType( *dm, Exp2() );
 }
 //*************************************************************************************************
 
@@ -1550,7 +1550,7 @@ inline decltype(auto) exp10( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Exp10>;
-   return ReturnType( ~dm, Exp10() );
+   return ReturnType( *dm, Exp10() );
 }
 //*************************************************************************************************
 
@@ -1581,7 +1581,7 @@ inline decltype(auto) log( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Log>;
-   return ReturnType( ~dm, Log() );
+   return ReturnType( *dm, Log() );
 }
 //*************************************************************************************************
 
@@ -1612,7 +1612,7 @@ inline decltype(auto) log2( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Log2>;
-   return ReturnType( ~dm, Log2() );
+   return ReturnType( *dm, Log2() );
 }
 //*************************************************************************************************
 
@@ -1643,7 +1643,7 @@ inline decltype(auto) log10( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Log10>;
-   return ReturnType( ~dm, Log10() );
+   return ReturnType( *dm, Log10() );
 }
 //*************************************************************************************************
 
@@ -1671,7 +1671,7 @@ inline decltype(auto) sin( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Sin>;
-   return ReturnType( ~dm, Sin() );
+   return ReturnType( *dm, Sin() );
 }
 //*************************************************************************************************
 
@@ -1702,7 +1702,7 @@ inline decltype(auto) asin( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Asin>;
-   return ReturnType( ~dm, Asin() );
+   return ReturnType( *dm, Asin() );
 }
 //*************************************************************************************************
 
@@ -1730,7 +1730,7 @@ inline decltype(auto) sinh( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Sinh>;
-   return ReturnType( ~dm, Sinh() );
+   return ReturnType( *dm, Sinh() );
 }
 //*************************************************************************************************
 
@@ -1758,7 +1758,7 @@ inline decltype(auto) asinh( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Asinh>;
-   return ReturnType( ~dm, Asinh() );
+   return ReturnType( *dm, Asinh() );
 }
 //*************************************************************************************************
 
@@ -1786,7 +1786,7 @@ inline decltype(auto) cos( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Cos>;
-   return ReturnType( ~dm, Cos() );
+   return ReturnType( *dm, Cos() );
 }
 //*************************************************************************************************
 
@@ -1817,7 +1817,7 @@ inline decltype(auto) acos( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Acos>;
-   return ReturnType( ~dm, Acos() );
+   return ReturnType( *dm, Acos() );
 }
 //*************************************************************************************************
 
@@ -1845,7 +1845,7 @@ inline decltype(auto) cosh( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Cosh>;
-   return ReturnType( ~dm, Cosh() );
+   return ReturnType( *dm, Cosh() );
 }
 //*************************************************************************************************
 
@@ -1876,7 +1876,7 @@ inline decltype(auto) acosh( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Acosh>;
-   return ReturnType( ~dm, Acosh() );
+   return ReturnType( *dm, Acosh() );
 }
 //*************************************************************************************************
 
@@ -1904,7 +1904,7 @@ inline decltype(auto) tan( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Tan>;
-   return ReturnType( ~dm, Tan() );
+   return ReturnType( *dm, Tan() );
 }
 //*************************************************************************************************
 
@@ -1932,7 +1932,7 @@ inline decltype(auto) atan( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Atan>;
-   return ReturnType( ~dm, Atan() );
+   return ReturnType( *dm, Atan() );
 }
 //*************************************************************************************************
 
@@ -1963,7 +1963,7 @@ inline decltype(auto) tanh( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Tanh>;
-   return ReturnType( ~dm, Tanh() );
+   return ReturnType( *dm, Tanh() );
 }
 //*************************************************************************************************
 
@@ -1994,7 +1994,7 @@ inline decltype(auto) atanh( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Atanh>;
-   return ReturnType( ~dm, Atanh() );
+   return ReturnType( *dm, Atanh() );
 }
 //*************************************************************************************************
 
@@ -2022,7 +2022,7 @@ inline decltype(auto) erf( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Erf>;
-   return ReturnType( ~dm, Erf() );
+   return ReturnType( *dm, Erf() );
 }
 //*************************************************************************************************
 
@@ -2050,7 +2050,7 @@ inline decltype(auto) erfc( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensMapExpr<MT,Erfc>;
-   return ReturnType( ~dm, Erfc() );
+   return ReturnType( *dm, Erfc() );
 }
 //*************************************************************************************************
 
@@ -2250,7 +2250,7 @@ inline decltype(auto) conj( const DTensTransExpr<DTensMapExpr<MT,Conj>, CTAs... 
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensTransExpr<MT,CTAs...>;
-   return ReturnType( dm.operand().operand(), (~dm).idces() );
+   return ReturnType( dm.operand().operand(), (*dm).idces() );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DTensNormExpr.h
+++ b/blaze_tensor/math/expressions/DTensNormExpr.h
@@ -155,9 +155,9 @@ inline decltype(auto) norm_backend( const DenseTensor<MT>& dm, Abs abs, Power po
    using ET = ElementType_t<MT>;
    using RT = decltype( evaluate( root( std::declval<ET>() ) ) );
 
-   if( (~dm).pages() == 0UL || (~dm).rows() == 0UL || (~dm).columns() == 0UL ) return RT();
+   if( (*dm).pages() == 0UL || (*dm).rows() == 0UL || (*dm).columns() == 0UL ) return RT();
 
-   CT tmp( ~dm );
+   CT tmp( *dm );
 
    const size_t O( tmp.pages()   );
    const size_t M( tmp.rows()    );
@@ -249,9 +249,9 @@ inline decltype(auto) norm_backend( const DenseTensor<MT>& dm, Abs abs, Power po
 
    static constexpr size_t SIMDSIZE = SIMDTrait<ET>::size;
 
-   if( (~dm).pages() == 0UL || (~dm).rows() == 0UL || (~dm).columns() == 0UL ) return RT();
+   if( (*dm).pages() == 0UL || (*dm).rows() == 0UL || (*dm).columns() == 0UL ) return RT();
 
-   CT tmp( ~dm );
+   CT tmp( *dm );
 
    const size_t O( tmp.pages()   );
    const size_t M( tmp.rows()    );
@@ -329,7 +329,7 @@ template< typename MT      // Type of the dense tensor
         , typename Root >  // Type of the root operation
 decltype(auto) norm_backend( const DenseTensor<MT>& dm, Abs abs, Power power, Root root )
 {
-   return norm_backend( ~dm, abs, power, root, Bool_t< DTensNormHelper<MT,Abs,Power>::value >() );
+   return norm_backend( *dm, abs, power, root, Bool_t< DTensNormHelper<MT,Abs,Power>::value >() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -355,7 +355,7 @@ decltype(auto) norm( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, SqrAbs(), Noop(), Sqrt() );
+   return norm_backend( *dm, SqrAbs(), Noop(), Sqrt() );
 }
 //*************************************************************************************************
 
@@ -380,7 +380,7 @@ decltype(auto) sqrNorm( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, SqrAbs(), Noop(), Noop() );
+   return norm_backend( *dm, SqrAbs(), Noop(), Noop() );
 }
 //*************************************************************************************************
 
@@ -405,7 +405,7 @@ decltype(auto) l1Norm( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, Abs(), Noop(), Noop() );
+   return norm_backend( *dm, Abs(), Noop(), Noop() );
 }
 //*************************************************************************************************
 
@@ -430,7 +430,7 @@ decltype(auto) l2Norm( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, SqrAbs(), Noop(), Sqrt() );
+   return norm_backend( *dm, SqrAbs(), Noop(), Sqrt() );
 }
 //*************************************************************************************************
 
@@ -455,7 +455,7 @@ decltype(auto) l3Norm( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, Abs(), Pow3(), Cbrt() );
+   return norm_backend( *dm, Abs(), Pow3(), Cbrt() );
 }
 //*************************************************************************************************
 
@@ -480,7 +480,7 @@ decltype(auto) l4Norm( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return norm_backend( ~dm, SqrAbs(), Pow2(), Qdrt() );
+   return norm_backend( *dm, SqrAbs(), Pow2(), Qdrt() );
 }
 //*************************************************************************************************
 
@@ -515,7 +515,7 @@ decltype(auto) lpNorm( const DenseTensor<MT>& dm, ST p )
 
    using ScalarType = MultTrait_t< UnderlyingBuiltin_t<MT>, decltype( inv( p ) ) >;
    using UnaryPow = Bind2nd<Pow,ScalarType>;
-   return norm_backend( ~dm, Abs(), UnaryPow( Pow(), p ), UnaryPow( Pow(), inv( p ) ) );
+   return norm_backend( *dm, Abs(), UnaryPow( Pow(), p ), UnaryPow( Pow(), inv( p ) ) );
 }
 //*************************************************************************************************
 
@@ -548,7 +548,7 @@ inline decltype(auto) lpNorm( const DenseTensor<MT>& dm )
    using Norms = TypeList< L1Norm, L2Norm, L3Norm, L4Norm, LpNorm<P> >;
    using Norm  = typename TypeAt< Norms, min( P-1UL, 4UL ) >::Type;
 
-   return Norm()( ~dm );
+   return Norm()( *dm );
 }
 //*************************************************************************************************
 
@@ -573,7 +573,7 @@ decltype(auto) maxNorm( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return max( abs( ~dm ) );
+   return max( abs( *dm ) );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensRavelExpr.h
+++ b/blaze_tensor/math/expressions/DTensRavelExpr.h
@@ -642,11 +642,11 @@ class DTensRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      assign( ~lhs, ravel( tmp ) );
+      assign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -674,11 +674,11 @@ class DTensRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      subAssign( ~lhs, ravel( tmp ) );
+      subAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -706,11 +706,11 @@ class DTensRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      schurAssign( ~lhs, ravel( tmp ) );
+      schurAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -738,11 +738,11 @@ class DTensRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( serial( ~rhs.dm_ ) );
+      CT tmp( serial( *rhs.dm_ ) );
 
-      multAssign( ~lhs, ravel( tmp ) );
+      multAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -770,11 +770,11 @@ class DTensRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpAssign( ~lhs, ravel( tmp ) );
+      smpAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -802,11 +802,11 @@ class DTensRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpAddAssign( ~lhs, ravel( tmp ) );
+      smpAddAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -834,11 +834,11 @@ class DTensRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpSubAssign( ~lhs, ravel( tmp ) );
+      smpSubAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -866,11 +866,11 @@ class DTensRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpSchurAssign( ~lhs, ravel( tmp ) );
+      smpSchurAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -898,11 +898,11 @@ class DTensRavelExpr
 
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).size() == rhs.size(), "Invalid number of elements");
+      BLAZE_INTERNAL_ASSERT( (*lhs).size() == rhs.size(), "Invalid number of elements");
 
-      CT tmp( ~rhs.dm_ );
+      CT tmp( *rhs.dm_ );
 
-      smpMultAssign( ~lhs, ravel( tmp ) );
+      smpMultAssign( *lhs, ravel( tmp ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -964,7 +964,7 @@ inline decltype(auto) ravel( const DenseTensor<TT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensRavelExpr<TT>;
-   return ReturnType( ~dm );
+   return ReturnType( *dm );
 }
 //*************************************************************************************************
 
@@ -989,7 +989,7 @@ inline decltype(auto) subvector( const DTensRavelExpr<TT>& tensor, RSAs... args 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subvector<AF,CSAs...>( evaluate( ~tensor ), args... );
+   return subvector<AF,CSAs...>( evaluate( *tensor ), args... );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DTensReduceExpr.h
+++ b/blaze_tensor/math/expressions/DTensReduceExpr.h
@@ -571,21 +571,21 @@ class DTensReduceExpr<MT,OP,columnwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const size_t M( rhs.dm_.rows() );
 
       if( M == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
          return;
       }
 
       CT tmp( serial( rhs.dm_ ) );
 
-      assign( ~lhs, rowslice( tmp, 0UL, unchecked ) );
+      assign( *lhs, rowslice( tmp, 0UL, unchecked ) );
       for( size_t i=1UL; i<M; ++i ) {
-         assign( ~lhs, map( ~lhs, rowslice( tmp, i, unchecked ), rhs.op_ ) );
+         assign( *lhs, map( *lhs, rowslice( tmp, i, unchecked ), rhs.op_ ) );
       }
    }
    /*! \endcond */
@@ -613,11 +613,11 @@ class DTensReduceExpr<MT,OP,columnwise>
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const ResultType tmp( serial( rhs ) );
-      assign( ~lhs, tmp );
+      assign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -641,8 +641,8 @@ class DTensReduceExpr<MT,OP,columnwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       if( rhs.dm_.rows() == 0UL ) {
          return;
@@ -651,12 +651,12 @@ class DTensReduceExpr<MT,OP,columnwise>
          CT tmp( serial( rhs.dm_ ) );
          const size_t M( tmp.rows() );
          for( size_t i=0UL; i<M; ++i ) {
-            addAssign( (~lhs), rowslice( tmp, i, unchecked ) );
+            addAssign( (*lhs), rowslice( tmp, i, unchecked ) );
          }
       }
       else {
          const ResultType tmp( serial( rhs ) );
-         addAssign( ~lhs, tmp );
+         addAssign( *lhs, tmp );
       }
    }
    /*! \endcond */
@@ -685,11 +685,11 @@ class DTensReduceExpr<MT,OP,columnwise>
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const ResultType tmp( serial( rhs ) );
-      addAssign( ~lhs, tmp );
+      addAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -713,8 +713,8 @@ class DTensReduceExpr<MT,OP,columnwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       if( rhs.dm_.rows() == 0UL ) {
          return;
@@ -723,12 +723,12 @@ class DTensReduceExpr<MT,OP,columnwise>
          CT tmp( serial( rhs.dm_ ) );
          const size_t M( tmp.rows() );
          for( size_t i=0UL; i<M; ++i ) {
-            subAssign( (~lhs), rowslice( tmp, i, unchecked ) );
+            subAssign( (*lhs), rowslice( tmp, i, unchecked ) );
          }
       }
       else {
          const ResultType tmp( serial( rhs ) );
-         subAssign( ~lhs, tmp );
+         subAssign( *lhs, tmp );
       }
    }
    /*! \endcond */
@@ -757,11 +757,11 @@ class DTensReduceExpr<MT,OP,columnwise>
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const ResultType tmp( serial( rhs ) );
-      subAssign( ~lhs, tmp );
+      subAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -785,22 +785,22 @@ class DTensReduceExpr<MT,OP,columnwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       if( rhs.dm_.rows() == 0UL ) {
-         reset( ~lhs );
+         reset( *lhs );
       }
       else if( IsSame_v<OP,Mult> ) {
          CT tmp( serial( rhs.dm_ ) );
          const size_t M( tmp.rows() );
          for( size_t i=0UL; i<M; ++i ) {
-            multAssign( (~lhs), rowslice( tmp, i, unchecked ) );
+            multAssign( (*lhs), rowslice( tmp, i, unchecked ) );
          }
       }
       else {
          const ResultType tmp( serial( rhs ) );
-         multAssign( ~lhs, tmp );
+         multAssign( *lhs, tmp );
       }
    }
    /*! \endcond */
@@ -829,11 +829,11 @@ class DTensReduceExpr<MT,OP,columnwise>
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const ResultType tmp( serial( rhs ) );
-      multAssign( ~lhs, tmp );
+      multAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -861,11 +861,11 @@ class DTensReduceExpr<MT,OP,columnwise>
       BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const ResultType tmp( serial( rhs ) );
-      divAssign( ~lhs, tmp );
+      divAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -891,11 +891,11 @@ class DTensReduceExpr<MT,OP,columnwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpAssign( ~lhs, reduce<columnwise>( tmp, rhs.op_ ) );
+      smpAssign( *lhs, reduce<columnwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -922,11 +922,11 @@ class DTensReduceExpr<MT,OP,columnwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpAddAssign( ~lhs, reduce<columnwise>( tmp, rhs.op_ ) );
+      smpAddAssign( *lhs, reduce<columnwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -953,11 +953,11 @@ class DTensReduceExpr<MT,OP,columnwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpSubAssign( ~lhs, reduce<columnwise>( tmp, rhs.op_ ) );
+      smpSubAssign( *lhs, reduce<columnwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -984,11 +984,11 @@ class DTensReduceExpr<MT,OP,columnwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpMultAssign( ~lhs, reduce<columnwise>( tmp, rhs.op_ ) );
+      smpMultAssign( *lhs, reduce<columnwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1015,11 +1015,11 @@ class DTensReduceExpr<MT,OP,columnwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpDivAssign( ~lhs, reduce<columnwise>( tmp, rhs.op_ ) );
+      smpDivAssign( *lhs, reduce<columnwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1526,11 +1526,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      assign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      assign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1556,11 +1556,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      addAssign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      addAssign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1587,11 +1587,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      subAssign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      subAssign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1618,11 +1618,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      multAssign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      multAssign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1648,11 +1648,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      divAssign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      divAssign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1678,11 +1678,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpAssign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      smpAssign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1709,11 +1709,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpAddAssign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      smpAddAssign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1740,11 +1740,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpSubAssign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      smpSubAssign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1771,11 +1771,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpMultAssign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      smpMultAssign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -1802,11 +1802,11 @@ class DTensReduceExpr<MT,OP,rowwise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpDivAssign( ~lhs, reduce<rowwise>( tmp, rhs.op_ ) );
+      smpDivAssign( *lhs, reduce<rowwise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2313,11 +2313,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      assign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      assign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2343,11 +2343,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      addAssign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      addAssign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2374,11 +2374,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      subAssign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      subAssign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2405,11 +2405,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      multAssign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      multAssign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2435,11 +2435,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( serial( rhs.dm_ ) );  // Evaluation of the dense tensor operand
-      divAssign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      divAssign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2465,11 +2465,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpAssign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      smpAssign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2496,11 +2496,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpAddAssign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      smpAddAssign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2527,11 +2527,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpSubAssign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      smpSubAssign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2558,11 +2558,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpMultAssign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      smpMultAssign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2589,11 +2589,11 @@ class DTensReduceExpr<MT,OP,pagewise>
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows() == rhs.rows(), "Invalid tensor sizes" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid tensor sizes" );
 
       const RT tmp( rhs.dm_ );  // Evaluation of the dense tensor operand
-      smpDivAssign( ~lhs, reduce<pagewise>( tmp, rhs.op_ ) );
+      smpDivAssign( *lhs, reduce<pagewise>( tmp, rhs.op_ ) );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -2672,14 +2672,14 @@ inline auto dtensreduce( const DenseTensor<MT>& dm, OP op )
    using CT = CompositeType_t<MT>;
    using ET = ElementType_t<MT>;
 
-   const size_t M( (~dm).rows()    );
-   const size_t N( (~dm).columns() );
-   const size_t O( (~dm).pages()   );
+   const size_t M( (*dm).rows()    );
+   const size_t N( (*dm).columns() );
+   const size_t O( (*dm).pages()   );
 
    if( M == 0UL || N == 0UL || O == 0UL ) return ET{};
-   if( M == 1UL && N == 1UL && O == 1UL ) return (~dm)(0UL,0UL,0UL);
+   if( M == 1UL && N == 1UL && O == 1UL ) return (*dm)(0UL,0UL,0UL);
 
-   CT tmp( ~dm );
+   CT tmp( *dm );
 
    BLAZE_INTERNAL_ASSERT( tmp.rows()    == M, "Invalid number of rows"    );
    BLAZE_INTERNAL_ASSERT( tmp.columns() == N, "Invalid number of columns" );
@@ -2759,13 +2759,13 @@ inline auto dtensreduce( const DenseTensor<MT>& dm, OP op )
    using CT = CompositeType_t<MT>;
    using ET = ElementType_t<MT>;
 
-   const size_t M( (~dm).rows()    );
-   const size_t N( (~dm).columns() );
-   const size_t O( (~dm).pages()   );
+   const size_t M( (*dm).rows()    );
+   const size_t N( (*dm).columns() );
+   const size_t O( (*dm).pages()   );
 
    if( M == 0UL || N == 0UL || O == 0UL ) return ET{};
 
-   CT tmp( ~dm );
+   CT tmp( *dm );
 
    BLAZE_INTERNAL_ASSERT( tmp.rows()    == M, "Invalid number of rows"    );
    BLAZE_INTERNAL_ASSERT( tmp.columns() == N, "Invalid number of columns" );
@@ -2955,13 +2955,13 @@ inline auto dtensreduce( const DenseTensor<MT>& dm, Add /*op*/ )
    using CT = CompositeType_t<MT>;
    using ET = ElementType_t<MT>;
 
-   const size_t M( (~dm).rows()    );
-   const size_t N( (~dm).columns() );
-   const size_t O( (~dm).pages()   );
+   const size_t M( (*dm).rows()    );
+   const size_t N( (*dm).columns() );
+   const size_t O( (*dm).pages()   );
 
    if( M == 0UL || N == 0UL || O == 0UL ) return ET{};
 
-   CT tmp( ~dm );
+   CT tmp( *dm );
 
    BLAZE_INTERNAL_ASSERT( tmp.rows()    == M, "Invalid number of rows"    );
    BLAZE_INTERNAL_ASSERT( tmp.columns() == N, "Invalid number of columns" );
@@ -3098,7 +3098,7 @@ inline decltype(auto) reduce( const DenseTensor<MT>& dm, OP op )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dtensreduce( ~dm, op );
+   return dtensreduce( *dm, op );
 }
 //*************************************************************************************************
 
@@ -3117,7 +3117,7 @@ template< size_t RF      // Reduction flag
         , typename OP >  // Type of the reduction operation
 inline const DTensReduceExpr<MT,OP,RF> reduce_backend( const DenseTensor<MT>& dm, OP op )
 {
-   return DTensReduceExpr<MT,OP,RF>( ~dm, op );
+   return DTensReduceExpr<MT,OP,RF>( *dm, op );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -3178,7 +3178,7 @@ inline decltype(auto) reduce( const DenseTensor<MT>& dm, OP op )
 
    BLAZE_STATIC_ASSERT_MSG( RF < 3UL, "Invalid reduction flag" );
 
-   return reduce_backend<RF>( ~dm, op );
+   return reduce_backend<RF>( *dm, op );
 }
 //*************************************************************************************************
 
@@ -3205,7 +3205,7 @@ inline decltype(auto) sum( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce( ~dm, Add() );
+   return reduce( *dm, Add() );
 }
 //*************************************************************************************************
 
@@ -3249,7 +3249,7 @@ inline decltype(auto) sum( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce<RF>( ~dm, Add() );
+   return reduce<RF>( *dm, Add() );
 }
 //*************************************************************************************************
 
@@ -3276,7 +3276,7 @@ inline decltype(auto) prod( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce( ~dm, Mult() );
+   return reduce( *dm, Mult() );
 }
 //*************************************************************************************************
 
@@ -3320,7 +3320,7 @@ inline decltype(auto) prod( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce<RF>( ~dm, Mult() );
+   return reduce<RF>( *dm, Mult() );
 }
 //*************************************************************************************************
 
@@ -3348,7 +3348,7 @@ inline decltype(auto) min( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce( ~dm, Min() );
+   return reduce( *dm, Min() );
 }
 //*************************************************************************************************
 
@@ -3389,7 +3389,7 @@ inline decltype(auto) min( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce<RF>( ~dm, Min() );
+   return reduce<RF>( *dm, Min() );
 }
 //*************************************************************************************************
 
@@ -3417,7 +3417,7 @@ inline decltype(auto) max( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce( ~dm, Max() );
+   return reduce( *dm, Max() );
 }
 //*************************************************************************************************
 
@@ -3458,7 +3458,7 @@ inline decltype(auto) max( const DenseTensor<MT>& dm )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return reduce<RF>( ~dm, Max() );
+   return reduce<RF>( *dm, Max() );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensScalarDivExpr.h
+++ b/blaze_tensor/math/expressions/DTensScalarDivExpr.h
@@ -608,12 +608,12 @@ class DTensScalarDivExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
-      assign( ~lhs, rhs.tensor_ );
-      assign( ~lhs, (~lhs) / rhs.scalar_ );
+      assign( *lhs, rhs.tensor_ );
+      assign( *lhs, (*lhs) / rhs.scalar_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -641,12 +641,12 @@ class DTensScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( serial( rhs ) );
-      addAssign( ~lhs, tmp );
+      addAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -678,12 +678,12 @@ class DTensScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( serial( rhs ) );
-      subAssign( ~lhs, tmp );
+      subAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -715,12 +715,12 @@ class DTensScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -745,12 +745,12 @@ class DTensScalarDivExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
-      smpAssign( ~lhs, rhs.tensor_ );
-      smpAssign( ~lhs, (~lhs) / rhs.scalar_ );
+      smpAssign( *lhs, rhs.tensor_ );
+      smpAssign( *lhs, (*lhs) / rhs.scalar_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -778,12 +778,12 @@ class DTensScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( rhs );
-      smpAddAssign( ~lhs, tmp );
+      smpAddAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -811,12 +811,12 @@ class DTensScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( rhs );
-      smpSubAssign( ~lhs, tmp );
+      smpSubAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -844,12 +844,12 @@ class DTensScalarDivExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -940,10 +940,10 @@ inline decltype(auto) operator/( const DenseTensor<MT>& mat, ST scalar )
    using ScalarType = RightOperand_t<ReturnType>;
 
    if( IsMultExpr_v<ReturnType> ) {
-      return ReturnType( ~mat, ScalarType(1)/ScalarType(scalar) );
+      return ReturnType( *mat, ScalarType(1)/ScalarType(scalar) );
    }
    else {
-      return ReturnType( ~mat, scalar );
+      return ReturnType( *mat, scalar );
    }
 }
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DTensScalarMultExpr.h
+++ b/blaze_tensor/math/expressions/DTensScalarMultExpr.h
@@ -607,12 +607,12 @@ class DTensScalarMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
-      assign( ~lhs, rhs.tensor_ );
-      assign( ~lhs, (~lhs) * rhs.scalar_ );
+      assign( *lhs, rhs.tensor_ );
+      assign( *lhs, (*lhs) * rhs.scalar_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -640,12 +640,12 @@ class DTensScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( serial( rhs ) );
-      addAssign( ~lhs, tmp );
+      addAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -673,12 +673,12 @@ class DTensScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( serial( rhs ) );
-      subAssign( ~lhs, tmp );
+      subAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -706,12 +706,12 @@ class DTensScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( serial( rhs ) );
-      schurAssign( ~lhs, tmp );
+      schurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -736,12 +736,12 @@ class DTensScalarMultExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
-      smpAssign( ~lhs, rhs.tensor_ );
-      smpAssign( ~lhs, (~lhs) * rhs.scalar_ );
+      smpAssign( *lhs, rhs.tensor_ );
+      smpAssign( *lhs, (*lhs) * rhs.scalar_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -769,12 +769,12 @@ class DTensScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( rhs );
-      smpAddAssign( ~lhs, tmp );
+      smpAddAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -802,12 +802,12 @@ class DTensScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( rhs );
-      smpSubAssign( ~lhs, tmp );
+      smpSubAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -835,12 +835,12 @@ class DTensScalarMultExpr
       BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE( ResultType );
       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType );
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages() == rhs.pages(),     "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages() == rhs.pages(),     "Invalid number of pages" );
 
       const ResultType tmp( rhs );
-      smpSchurAssign( ~lhs, tmp );
+      smpSchurAssign( *lhs, tmp );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -888,7 +888,7 @@ inline decltype(auto) operator-( const DenseTensor<MT>& dm )
 
    using ScalarType = UnderlyingBuiltin_t<MT>;
    using ReturnType = const DTensScalarMultExpr<MT,ScalarType>;
-   return ReturnType( ~dm, ScalarType(-1) );
+   return ReturnType( *dm, ScalarType(-1) );
 }
 //*************************************************************************************************
 
@@ -931,7 +931,7 @@ inline decltype(auto) operator*( const DenseTensor<MT>& mat, ST scalar )
 
    using ScalarType = MultTrait_t< UnderlyingBuiltin_t<MT>, ST >;
    using ReturnType = const DTensScalarMultExpr<MT,ScalarType>;
-   return ReturnType( ~mat, scalar );
+   return ReturnType( *mat, scalar );
 }
 //*************************************************************************************************
 
@@ -966,7 +966,7 @@ inline decltype(auto) operator*( ST scalar, const DenseTensor<MT>& mat )
 
    using ScalarType = MultTrait_t< ST, UnderlyingBuiltin_t<MT> >;
    using ReturnType = const DTensScalarMultExpr<MT,ScalarType>;
-   return ReturnType( ~mat, scalar );
+   return ReturnType( *mat, scalar );
 }
 //*************************************************************************************************
 
@@ -1115,7 +1115,7 @@ inline decltype(auto) operator/( const DTensScalarMultExpr<MT,ST1>& mat, ST2 sca
 // {
 //    BLAZE_FUNCTION_TRACE;
 //
-//    return ( mat.leftOperand() * (~vec) ) * mat.rightOperand();
+//    return ( mat.leftOperand() * (*vec) ) * mat.rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1143,7 +1143,7 @@ inline decltype(auto) operator/( const DTensScalarMultExpr<MT,ST1>& mat, ST2 sca
 // {
 //    BLAZE_FUNCTION_TRACE;
 //
-//    return ( (~vec) * mat.leftOperand() ) * mat.rightOperand();
+//    return ( (*vec) * mat.leftOperand() ) * mat.rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1233,7 +1233,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return ( lhs.leftOperand() * (~rhs) ) * lhs.rightOperand();
+   return ( lhs.leftOperand() * (*rhs) ) * lhs.rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1261,7 +1261,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return ( (~lhs) * rhs.leftOperand() ) * rhs.rightOperand();
+   return ( (*lhs) * rhs.leftOperand() ) * rhs.rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DTensSerialExpr.h
+++ b/blaze_tensor/math/expressions/DTensSerialExpr.h
@@ -272,11 +272,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      assign( ~lhs, rhs.dm_ );
+      assign( *lhs, rhs.dm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -298,11 +298,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      addAssign( ~lhs, rhs.dm_ );
+      addAssign( *lhs, rhs.dm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -325,11 +325,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      subAssign( ~lhs, rhs.dm_ );
+      subAssign( *lhs, rhs.dm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -352,11 +352,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      schurAssign( ~lhs, rhs.dm_ );
+      schurAssign( *lhs, rhs.dm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -379,11 +379,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      multAssign( ~lhs, rhs.sm_ );
+      multAssign( *lhs, rhs.sm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -405,11 +405,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      assign( ~lhs, rhs.dm_ );
+      assign( *lhs, rhs.dm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -432,11 +432,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      addAssign( ~lhs, rhs.dm_ );
+      addAssign( *lhs, rhs.dm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -459,11 +459,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      subAssign( ~lhs, rhs.dm_ );
+      subAssign( *lhs, rhs.dm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -486,11 +486,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      schurAssign( ~lhs, rhs.dm_ );
+      schurAssign( *lhs, rhs.dm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -513,11 +513,11 @@ class DTensSerialExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages" );
 
-      multAssign( ~lhs, rhs.sm_ );
+      multAssign( *lhs, rhs.sm_ );
    }
    /*! \endcond */
    //**********************************************************************************************
@@ -562,7 +562,7 @@ inline decltype(auto) serial( const DenseTensor<MT>& dm )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensSerialExpr<MT>;
-   return ReturnType( ~dm );
+   return ReturnType( *dm );
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DTensTransExpr.h
+++ b/blaze_tensor/math/expressions/DTensTransExpr.h
@@ -437,11 +437,11 @@ class DTensTransExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DTensTransposer<MT2> tmp( ~lhs, rhs.pages(), rhs.rows(), rhs.columns() );
+      DTensTransposer<MT2> tmp( *lhs, rhs.pages(), rhs.rows(), rhs.columns() );
       assign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -476,11 +476,11 @@ class DTensTransExpr
 //       BLAZE_CONSTRAINT_MATRICES_MUST_HAVE_SAME_STORAGE_ORDER( MT2, TmpType );
 //       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( TmpType );
 //
-//       BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-//       BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+//       BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+//       BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 //
 //       const TmpType tmp( serial( rhs ) );
-//       assign( ~lhs, tmp );
+//       assign( *lhs, tmp );
 //    }
    /*! \endcond */
    //**********************************************************************************************
@@ -505,11 +505,11 @@ class DTensTransExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DTensTransposer<MT2> tmp( ~lhs, rhs.pages(), rhs.rows(), rhs.columns() );
+      DTensTransposer<MT2> tmp( *lhs, rhs.pages(), rhs.rows(), rhs.columns() );
       addAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -539,11 +539,11 @@ class DTensTransExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DTensTransposer<MT2> tmp( ~lhs, rhs.pages(), rhs.rows(), rhs.columns() );
+      DTensTransposer<MT2> tmp( *lhs, rhs.pages(), rhs.rows(), rhs.columns() );
       subAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -573,11 +573,11 @@ class DTensTransExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DTensTransposer<MT2> tmp( ~lhs, rhs.pages(), rhs.rows(), rhs.columns() );
+      DTensTransposer<MT2> tmp( *lhs, rhs.pages(), rhs.rows(), rhs.columns() );
       schurAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -615,11 +615,11 @@ class DTensTransExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DTensTransposer<MT2> tmp( ~lhs, rhs.pages(), rhs.rows(), rhs.columns() );
+      DTensTransposer<MT2> tmp( *lhs, rhs.pages(), rhs.rows(), rhs.columns() );
       smpAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -654,11 +654,11 @@ class DTensTransExpr
 //       BLAZE_CONSTRAINT_MATRICES_MUST_HAVE_SAME_STORAGE_ORDER( MT2, TmpType );
 //       BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( TmpType );
 //
-//       BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-//       BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+//       BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+//       BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 //
 //       const TmpType tmp( rhs );
-//       smpAssign( ~lhs, tmp );
+//       smpAssign( *lhs, tmp );
 //    }
    /*! \endcond */
    //**********************************************************************************************
@@ -683,11 +683,11 @@ class DTensTransExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DTensTransposer<MT2> tmp( ~lhs, rhs.pages(), rhs.rows(), rhs.columns() );
+      DTensTransposer<MT2> tmp( *lhs, rhs.pages(), rhs.rows(), rhs.columns() );
       smpAddAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -717,11 +717,11 @@ class DTensTransExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DTensTransposer<MT2> tmp( ~lhs, rhs.pages(), rhs.rows(), rhs.columns() );
+      DTensTransposer<MT2> tmp( *lhs, rhs.pages(), rhs.rows(), rhs.columns() );
       smpSubAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -752,11 +752,11 @@ class DTensTransExpr
    {
       BLAZE_FUNCTION_TRACE;
 
-      BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
-      BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
-      BLAZE_INTERNAL_ASSERT( (~lhs).columns() == rhs.columns(), "Invalid number of columns" );
+      BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == rhs.pages()  , "Invalid number of pages"   );
+      BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == rhs.rows()   , "Invalid number of rows"    );
+      BLAZE_INTERNAL_ASSERT( (*lhs).columns() == rhs.columns(), "Invalid number of columns" );
 
-      DTensTransposer<MT2> tmp( ~lhs, rhs.pages(), rhs.rows(), rhs.columns() );
+      DTensTransposer<MT2> tmp( *lhs, rhs.pages(), rhs.rows(), rhs.columns() );
       smpSchurAssign( tmp, rhs.dm_ );
    }
    /*! \endcond */
@@ -818,7 +818,7 @@ inline decltype(auto) trans( const DenseTensor<MT>& dm, RTAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensTransExpr<MT, O, M, N>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -846,7 +846,7 @@ inline decltype(auto) trans( const DenseTensor<MT>& dm, RTAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensTransExpr<MT>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -875,7 +875,7 @@ inline decltype(auto) trans( const DenseTensor<MT>& dm, const T* indices, size_t
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensTransExpr<MT>;
-   return ReturnType( ~dm, indices, n, args... );
+   return ReturnType( *dm, indices, n, args... );
 }
 //*************************************************************************************************
 
@@ -903,7 +903,7 @@ inline decltype(auto) trans( const DenseTensor<MT>& dm, std::index_sequence<Is..
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans<Is...>( ~dm, args... );
+   return trans<Is...>( *dm, args... );
 }
 //*************************************************************************************************
 
@@ -931,7 +931,7 @@ inline decltype(auto) trans( const DenseTensor<MT>& dm, std::initializer_list<T>
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( ~dm, indices.begin(), indices.size(), args... );
+   return trans( *dm, indices.begin(), indices.size(), args... );
 }
 //*************************************************************************************************
 
@@ -974,7 +974,7 @@ inline decltype(auto) trans( const DTensTransExpr<MT, CTAs...>& dm, RTAs... args
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensTransExpr<MT, O, M, N>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1006,7 +1006,7 @@ inline decltype(auto) trans( const DTensTransExpr<MT, CTAs...>& dm, RTAs... args
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DTensTransExpr<MT, CTAs...>;
-   return ReturnType( ~dm, args... );
+   return ReturnType( *dm, args... );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/expressions/DTensTransposer.h
+++ b/blaze_tensor/math/expressions/DTensTransposer.h
@@ -574,7 +574,7 @@ class DTensTransposer
             , typename... RTAs >  // Runtime arguments
    inline void assign( const Tensor<MT2>& rhs, RTAs... args )
    {
-      dm_.assign( trans( ~rhs, args... ) );
+      dm_.assign( trans( *rhs, args... ) );
    }
    //**********************************************************************************************
 
@@ -593,7 +593,7 @@ class DTensTransposer
             , typename... RTAs >  // Runtime arguments
    inline void addAssign( const Tensor<MT2>& rhs, RTAs... args )
    {
-      dm_.addAssign( trans( ~rhs, args... ) );
+      dm_.addAssign( trans( *rhs, args... ) );
    }
    //**********************************************************************************************
 
@@ -612,7 +612,7 @@ class DTensTransposer
             , typename... RTAs >  // Runtime arguments
    inline void subAssign( const Tensor<MT2>& rhs, RTAs... args )
    {
-      dm_.subAssign( trans( ~rhs, args... ) );
+      dm_.subAssign( trans( *rhs, args... ) );
    }
    //**********************************************************************************************
 
@@ -631,7 +631,7 @@ class DTensTransposer
             , typename... RTAs >  // Runtime arguments
    inline void schurAssign( const Tensor<MT2>& rhs, RTAs... args )
    {
-      dm_.schurAssign( trans( ~rhs, args... ) );
+      dm_.schurAssign( trans( *rhs, args... ) );
    }
    //**********************************************************************************************
 

--- a/blaze_tensor/math/expressions/DenseArray.h
+++ b/blaze_tensor/math/expressions/DenseArray.h
@@ -139,7 +139,7 @@ template< typename TT > // Type of the array
 BLAZE_ALWAYS_INLINE EnableIf_t< HasMutableDataAccess_v<TT>, typename TT::ElementType* >
    data_backend( DenseArray<TT>& dm ) noexcept
 {
-   return (~dm).data();
+   return (*dm).data();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -161,7 +161,7 @@ BLAZE_ALWAYS_INLINE EnableIf_t< HasMutableDataAccess_v<TT>, typename TT::Element
 template< typename TT > // Type of the array
 BLAZE_ALWAYS_INLINE typename TT::ElementType* data( DenseArray<TT>& dm ) noexcept
 {
-   return data_backend( ~dm );
+   return data_backend( *dm );
 }
 //*************************************************************************************************
 
@@ -203,7 +203,7 @@ template< typename TT > // Type of the array
 BLAZE_ALWAYS_INLINE EnableIf_t< HasConstDataAccess_v<TT>, typename TT::ElementType* >
    data_backend( const DenseArray<TT>& dm ) noexcept
 {
-   return (~dm).data();
+   return (*dm).data();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -225,7 +225,7 @@ BLAZE_ALWAYS_INLINE EnableIf_t< HasConstDataAccess_v<TT>, typename TT::ElementTy
 template< typename TT > // Type of the array
 BLAZE_ALWAYS_INLINE typename TT::ElementType* data( const DenseArray<TT>& dm ) noexcept
 {
-   return data_backend( ~dm );
+   return data_backend( *dm );
 }
 //*************************************************************************************************
 
@@ -240,7 +240,7 @@ BLAZE_ALWAYS_INLINE typename TT::ElementType* data( const DenseArray<TT>& dm ) n
 template< typename TT > // Type of the array
 BLAZE_ALWAYS_INLINE size_t spacing( const DenseArray<TT>& dm ) noexcept
 {
-   return (~dm).spacing();
+   return (*dm).spacing();
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/DenseTensor.h
+++ b/blaze_tensor/math/expressions/DenseTensor.h
@@ -139,7 +139,7 @@ template< typename TT > // Type of the tensor
 BLAZE_ALWAYS_INLINE EnableIf_t< HasMutableDataAccess_v<TT>, typename TT::ElementType* >
    data_backend( DenseTensor<TT>& dm ) noexcept
 {
-   return (~dm).data();
+   return (*dm).data();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -161,7 +161,7 @@ BLAZE_ALWAYS_INLINE EnableIf_t< HasMutableDataAccess_v<TT>, typename TT::Element
 template< typename TT > // Type of the tensor
 BLAZE_ALWAYS_INLINE typename TT::ElementType* data( DenseTensor<TT>& dm ) noexcept
 {
-   return data_backend( ~dm );
+   return data_backend( *dm );
 }
 //*************************************************************************************************
 
@@ -203,7 +203,7 @@ template< typename TT > // Type of the tensor
 BLAZE_ALWAYS_INLINE EnableIf_t< HasConstDataAccess_v<TT>, typename TT::ElementType* >
    data_backend( const DenseTensor<TT>& dm ) noexcept
 {
-   return (~dm).data();
+   return (*dm).data();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -225,7 +225,7 @@ BLAZE_ALWAYS_INLINE EnableIf_t< HasConstDataAccess_v<TT>, typename TT::ElementTy
 template< typename TT > // Type of the tensor
 BLAZE_ALWAYS_INLINE typename TT::ElementType* data( const DenseTensor<TT>& dm ) noexcept
 {
-   return data_backend( ~dm );
+   return data_backend( *dm );
 }
 //*************************************************************************************************
 
@@ -240,7 +240,7 @@ BLAZE_ALWAYS_INLINE typename TT::ElementType* data( const DenseTensor<TT>& dm ) 
 template< typename TT > // Type of the tensor
 BLAZE_ALWAYS_INLINE size_t spacing( const DenseTensor<TT>& dm ) noexcept
 {
-   return (~dm).spacing();
+   return (*dm).spacing();
 }
 //*************************************************************************************************
 

--- a/blaze_tensor/math/expressions/Tensor.h
+++ b/blaze_tensor/math/expressions/Tensor.h
@@ -80,7 +80,7 @@ struct Tensor
    //
    // \return Reference of the actual type of the tensor.
    */
-   BLAZE_ALWAYS_INLINE constexpr TensorType& operator~() noexcept {
+   [[deprecated]] BLAZE_ALWAYS_INLINE constexpr TensorType& operator~() noexcept {
       return *static_cast<TensorType*>( this );
    }
    //**********************************************************************************************
@@ -90,7 +90,33 @@ struct Tensor
    //
    // \return Constant reference of the actual type of the tensor.
    */
-   BLAZE_ALWAYS_INLINE constexpr const TensorType& operator~() const noexcept {
+   [[deprecated]] BLAZE_ALWAYS_INLINE constexpr const TensorType& operator~() const noexcept {
+      return *static_cast<const TensorType*>( this );
+   }
+   //**********************************************************************************************
+
+   //**Non-const conversion operator***************************************************************
+   /*!\brief CRTP-based conversion operation for non-constant tensors.
+   //
+   // \return Mutable reference of the actual type of the tensor.
+   //
+   // This operator performs the CRTP-based type-safe downcast to the actual type \a VT of the
+   // tensor. It will return a mutable reference to the actual type \a VT.
+   */
+   BLAZE_ALWAYS_INLINE constexpr TensorType& operator*() noexcept {
+      return *static_cast<TensorType*>( this );
+   }
+   //**********************************************************************************************
+
+   //**Const conversion operator*******************************************************************
+   /*!\brief CRTP-based conversion operation for constant tensors.
+   //
+   // \return Constant reference of the actual type of the tensor.
+   //
+   // This operator performs the CRTP-based type-safe downcast to the actual type \a VT of the
+   // tensor. It will return a constant reference to the actual type \a VT.
+   */
+   BLAZE_ALWAYS_INLINE constexpr const TensorType& operator*() const noexcept {
       return *static_cast<const TensorType*>( this );
    }
    //**********************************************************************************************
@@ -120,9 +146,9 @@ template< typename TT1  // Type of the left-hand side tensor
         , typename TT2 > // Type of the right-hand side tensor
 inline TT1& operator*=( Tensor<TT1>& lhs, const Tensor<TT2>& rhs )
 {
-   ResultType_t<TT1> tmp( (~lhs) * (~rhs) );
-   (~lhs) = std::move( tmp );
-   return (~lhs);
+   ResultType_t<TT1> tmp( (*lhs) * (*rhs) );
+   (*lhs) = std::move( tmp );
+   return (*lhs);
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -146,7 +172,7 @@ template< typename TT1  // Type of the left-hand side tensor
         , typename TT2 > // Type of the right-hand side tensor
 inline TT1& operator*=( Tensor<TT1>&& lhs, const Tensor<TT2>& rhs )
 {
-   return (~lhs) *= (~rhs);
+   return (*lhs) *= (*rhs);
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -174,9 +200,9 @@ template< typename MT    // Type of the tensor
         , typename ET >  // Type of the element
 BLAZE_ALWAYS_INLINE bool trySet( const Tensor<MT>& mat, size_t k, size_t i, size_t j, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( i < (~mat).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < (~mat).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( k < (~mat).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( i < (*mat).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( j < (*mat).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( k < (*mat).pages(), "Invalid page access index" );
 
    MAYBE_UNUSED( mat, k, i, j, value );
 
@@ -207,9 +233,9 @@ template< typename MT    // Type of the tensor
         , typename ET >  // Type of the element
 BLAZE_ALWAYS_INLINE bool tryAdd( const Tensor<MT>& mat, size_t k, size_t i, size_t j, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( i < (~mat).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < (~mat).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( k < (~mat).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( i < (*mat).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( j < (*mat).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( k < (*mat).pages(), "Invalid page access index" );
 
    MAYBE_UNUSED( mat, k, i, j, value );
 
@@ -240,9 +266,9 @@ template< typename MT    // Type of the tensor
         , typename ET >  // Type of the element
 BLAZE_ALWAYS_INLINE bool trySub( const Tensor<MT>& mat, size_t k, size_t i, size_t j, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( i < (~mat).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < (~mat).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( k < (~mat).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( i < (*mat).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( j < (*mat).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( k < (*mat).pages(), "Invalid page access index" );
 
    MAYBE_UNUSED( mat, k, i, j, value );
 
@@ -273,9 +299,9 @@ template< typename MT    // Type of the tensor
         , typename ET >  // Type of the element
 BLAZE_ALWAYS_INLINE bool tryMult( const Tensor<MT>& tens, size_t k, size_t i, size_t j, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( i < (~tens).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < (~tens).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( k < (~tens).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( i < (*tens).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( j < (*tens).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( k < (*tens).pages(), "Invalid page access index" );
 
    MAYBE_UNUSED( tens, k, i, j, value );
 
@@ -310,12 +336,12 @@ template< typename MT    // Type of the tensor
 BLAZE_ALWAYS_INLINE bool
    tryMult( const Tensor<MT>& tens, size_t row, size_t column, size_t page, size_t o, size_t m, size_t n, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~tens).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~tens).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~tens).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + m <= (~tens).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + n <= (~tens).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + o <= (~tens).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*tens).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*tens).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*tens).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + m <= (*tens).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + n <= (*tens).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + o <= (*tens).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( tens, page, row, column, o, m, n, value );
 
@@ -346,9 +372,9 @@ template< typename MT    // Type of the tensor
         , typename ET >  // Type of the element
 BLAZE_ALWAYS_INLINE bool tryDiv( const Tensor<MT>& tens, size_t k, size_t i, size_t j, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( i < (~tens).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( j < (~tens).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( k < (~tens).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( i < (*tens).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( j < (*tens).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( k < (*tens).pages(), "Invalid page access index" );
 
    MAYBE_UNUSED( tens, k, i, j, value );
 
@@ -383,12 +409,12 @@ template< typename MT    // Type of the tensor
 BLAZE_ALWAYS_INLINE bool
    tryDiv( const Tensor<MT>& tens, size_t row, size_t column, size_t page, size_t o, size_t m, size_t n, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~tens).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~tens).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~tens).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + m <= (~tens).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + n <= (~tens).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + o <= (~tens).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*tens).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*tens).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*tens).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + m <= (*tens).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + n <= (*tens).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + o <= (*tens).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( tens, page, row, column, o, m, n, value );
 
@@ -420,12 +446,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool tryAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                     size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -457,12 +483,12 @@ template< typename TT1  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool tryAssign( const Tensor<TT1>& lhs, const Tensor<TT2>& rhs,
                                     size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + (~rhs).pages() <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + (*rhs).pages() <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -494,12 +520,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool tryAddAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                        size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -532,12 +558,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool tryAddAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                        ptrdiff_t band, size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, band, page, row, column );
 
@@ -568,12 +594,12 @@ template< typename TT1  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool tryAddAssign( const Tensor<TT1>& lhs, const Tensor<TT2>& rhs,
                                        size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + (~rhs).pages() <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + (*rhs).pages() <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -605,12 +631,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool trySubAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                        size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -644,12 +670,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool trySubAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                        ptrdiff_t band, size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, band, page, row, column );
 
@@ -680,12 +706,12 @@ template< typename TT1  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool trySubAssign( const Tensor<TT1>& lhs, const Tensor<TT2>& rhs,
                                        size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + (~rhs).pages() <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + (*rhs).pages() <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -717,12 +743,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool tryMultAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                         size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -756,12 +782,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool tryMultAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                         ptrdiff_t band, size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, band, page, row, column );
 
@@ -792,12 +818,12 @@ template< typename TT1  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool trySchurAssign( const Tensor<TT1>& lhs, const Tensor<TT2>& rhs,
                                          size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + (~rhs).pages() <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + (*rhs).pages() <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -830,12 +856,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool trySchurAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                         size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -867,12 +893,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool tryDivAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                        size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, page, row, column );
 
@@ -906,12 +932,12 @@ template< typename MT  // Type of the left-hand side tensor
 BLAZE_ALWAYS_INLINE bool tryDivAssign( const Tensor<MT>& lhs, const Matrix<VT,SO>& rhs,
                                        ptrdiff_t band, size_t row, size_t column, size_t page )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~lhs).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~lhs).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~lhs).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= (~lhs).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= (~lhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + 1 <= (~lhs).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*lhs).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*lhs).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*lhs).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= (*lhs).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= (*lhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + 1 <= (*lhs).pages(), "Invalid number of pages" );
 
    MAYBE_UNUSED( lhs, rhs, band, page, row, column );
 
@@ -1028,7 +1054,7 @@ BLAZE_ALWAYS_INLINE bool isSame( const Tensor<TT1>& a, const Tensor<TT2>& b ) no
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE typename MT::Iterator begin( Tensor<MT>& tensor, size_t i, size_t k )
 {
-   return (~tensor).begin(i, k);
+   return (*tensor).begin(i, k);
 }
 //*************************************************************************************************
 
@@ -1049,7 +1075,7 @@ BLAZE_ALWAYS_INLINE typename MT::Iterator begin( Tensor<MT>& tensor, size_t i, s
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE typename MT::ConstIterator begin( const Tensor<MT>& tensor, size_t i, size_t k )
 {
-   return (~tensor).begin(i, k);
+   return (*tensor).begin(i, k);
 }
 //*************************************************************************************************
 
@@ -1070,7 +1096,7 @@ BLAZE_ALWAYS_INLINE typename MT::ConstIterator begin( const Tensor<MT>& tensor, 
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE typename MT::ConstIterator cbegin( const Tensor<MT>& tensor, size_t i, size_t k )
 {
-   return (~tensor).cbegin(i, k);
+   return (*tensor).cbegin(i, k);
 }
 //*************************************************************************************************
 
@@ -1091,7 +1117,7 @@ BLAZE_ALWAYS_INLINE typename MT::ConstIterator cbegin( const Tensor<MT>& tensor,
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE typename MT::Iterator end( Tensor<MT>& tensor, size_t i, size_t k )
 {
-   return (~tensor).end(i, k);
+   return (*tensor).end(i, k);
 }
 //*************************************************************************************************
 
@@ -1112,7 +1138,7 @@ BLAZE_ALWAYS_INLINE typename MT::Iterator end( Tensor<MT>& tensor, size_t i, siz
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE typename MT::ConstIterator end( const Tensor<MT>& tensor, size_t i, size_t k )
 {
-   return (~tensor).end(i, k);
+   return (*tensor).end(i, k);
 }
 //*************************************************************************************************
 
@@ -1133,7 +1159,7 @@ BLAZE_ALWAYS_INLINE typename MT::ConstIterator end( const Tensor<MT>& tensor, si
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE typename MT::ConstIterator cend( const Tensor<MT>& tensor, size_t i, size_t k )
 {
-   return (~tensor).cend(i, k);
+   return (*tensor).cend(i, k);
 }
 //*************************************************************************************************
 
@@ -1148,7 +1174,7 @@ BLAZE_ALWAYS_INLINE typename MT::ConstIterator cend( const Tensor<MT>& tensor, s
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE constexpr size_t rows( const Tensor<MT>& tensor ) noexcept
 {
-   return (~tensor).rows();
+   return (*tensor).rows();
 }
 //*************************************************************************************************
 
@@ -1163,7 +1189,7 @@ BLAZE_ALWAYS_INLINE constexpr size_t rows( const Tensor<MT>& tensor ) noexcept
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE constexpr size_t columns( const Tensor<MT>& tensor ) noexcept
 {
-   return (~tensor).columns();
+   return (*tensor).columns();
 }
 //*************************************************************************************************
 
@@ -1178,7 +1204,7 @@ BLAZE_ALWAYS_INLINE constexpr size_t columns( const Tensor<MT>& tensor ) noexcep
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE constexpr size_t pages( const Tensor<MT>& tensor ) noexcept
 {
-   return (~tensor).pages();
+   return (*tensor).pages();
 }
 //*************************************************************************************************
 
@@ -1193,7 +1219,7 @@ BLAZE_ALWAYS_INLINE constexpr size_t pages( const Tensor<MT>& tensor ) noexcept
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE constexpr size_t size( const Tensor<MT>& tensor ) noexcept
 {
-   return (~tensor).rows() * (~tensor).columns() * (~tensor).pages();
+   return (*tensor).rows() * (*tensor).columns() * (*tensor).pages();
 }
 //*************************************************************************************************
 
@@ -1208,7 +1234,7 @@ BLAZE_ALWAYS_INLINE constexpr size_t size( const Tensor<MT>& tensor ) noexcept
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE size_t capacity( const Tensor<MT>& tensor ) noexcept
 {
-   return (~tensor).capacity();
+   return (*tensor).capacity();
 }
 //*************************************************************************************************
 
@@ -1229,7 +1255,7 @@ BLAZE_ALWAYS_INLINE size_t capacity( const Tensor<MT>& tensor ) noexcept
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE size_t capacity( const Tensor<MT>& tensor, size_t i, size_t k ) noexcept
 {
-   return (~tensor).capacity( i, k );
+   return (*tensor).capacity( i, k );
 }
 //*************************************************************************************************
 
@@ -1244,7 +1270,7 @@ BLAZE_ALWAYS_INLINE size_t capacity( const Tensor<MT>& tensor, size_t i, size_t 
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE size_t nonZeros( const Tensor<MT>& tensor )
 {
-   return (~tensor).nonZeros();
+   return (*tensor).nonZeros();
 }
 //*************************************************************************************************
 
@@ -1265,7 +1291,7 @@ BLAZE_ALWAYS_INLINE size_t nonZeros( const Tensor<MT>& tensor )
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE size_t nonZeros( const Tensor<MT>& tensor, size_t i, size_t k )
 {
-   return (~tensor).nonZeros( i, k );
+   return (*tensor).nonZeros( i, k );
 }
 //*************************************************************************************************
 
@@ -1293,7 +1319,7 @@ BLAZE_ALWAYS_INLINE EnableIf_t< !IsResizable_v<MT> >
 {
    MAYBE_UNUSED( preserve );
 
-   if( (~tensor).rows() != m || (~tensor).columns() != n || (~tensor).pages() != o) {
+   if( (*tensor).rows() != m || (*tensor).columns() != n || (*tensor).pages() != o) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor cannot be resized" );
    }
 }
@@ -1318,7 +1344,7 @@ template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE EnableIf_t< IsResizable_v<MT> && !IsSquare_v<MT> >
    resize_backend( Tensor<MT>& tensor, size_t o, size_t m, size_t n, bool preserve )
 {
-   (~tensor).resize( o, m, n, preserve );
+   (*tensor).resize( o, m, n, preserve );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1346,7 +1372,7 @@ BLAZE_ALWAYS_INLINE EnableIf_t< IsResizable_v<MT> && !IsSquare_v<MT> >
 //       BLAZE_THROW_INVALID_ARGUMENT( "Invalid resize arguments for square tensor" );
 //    }
 //
-//    (~tensor).resize( m, preserve );
+//    (*tensor).resize( m, preserve );
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1428,7 +1454,7 @@ template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE EnableIf_t< IsShrinkable_v<MT> >
    shrinkToFit_backend( Tensor<MT>& tensor )
 {
-   (~tensor).shrinkToFit();
+   (*tensor).shrinkToFit();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1476,7 +1502,7 @@ BLAZE_ALWAYS_INLINE void shrinkToFit( Tensor<MT>& tensor )
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE void transpose( Tensor<MT>& tensor )
 {
-   (~tensor).transpose( );
+   (*tensor).transpose( );
 }
 //*************************************************************************************************
 
@@ -1502,7 +1528,7 @@ template< typename MT   // Type of the tensor
         , typename T >  // Type of the index initializer
 BLAZE_ALWAYS_INLINE void transpose( Tensor<MT>& tensor, const T* indices, size_t n )
 {
-   (~tensor).transpose( indices, n );
+   (*tensor).transpose( indices, n );
 }
 //*************************************************************************************************
 
@@ -1528,7 +1554,7 @@ template< typename MT   // Type of the tensor
         , typename T >  // Type of the index initializer
 BLAZE_ALWAYS_INLINE void transpose( Tensor<MT>& tensor, std::initializer_list<T> indices )
 {
-   (~tensor).transpose( indices.begin(), indices.size() );
+   (*tensor).transpose( indices.begin(), indices.size() );
 }
 //*************************************************************************************************
 
@@ -1553,7 +1579,7 @@ BLAZE_ALWAYS_INLINE void transpose( Tensor<MT>& tensor, std::initializer_list<T>
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE void ctranspose( Tensor<MT>& tensor )
 {
-   (~tensor).ctranspose();
+   (*tensor).ctranspose();
 }
 //*************************************************************************************************
 
@@ -1579,7 +1605,7 @@ template< typename MT   // Type of the tensor
         , typename T >  // Type of the index initializer
 BLAZE_ALWAYS_INLINE void ctranspose( Tensor<MT>& tensor, const T* indices, size_t n )
 {
-   (~tensor).ctranspose( indices, n );
+   (*tensor).ctranspose( indices, n );
 }
 //*************************************************************************************************
 
@@ -1605,7 +1631,7 @@ template< typename MT   // Type of the tensor
         , typename T >  // Type of the index initializer
 BLAZE_ALWAYS_INLINE void ctranspose( Tensor<MT>& tensor, std::initializer_list<T> indices )
 {
-   (~tensor).ctranspose( indices.begin(), indices.size() );
+   (*tensor).ctranspose( indices.begin(), indices.size() );
 }
 //*************************************************************************************************
 
@@ -1665,7 +1691,7 @@ BLAZE_ALWAYS_INLINE void ctranspose( Tensor<MT>& tensor, std::initializer_list<T
 template< typename MT > // Type of the tensor
 inline const typename MT::ResultType evaluate( const Tensor<MT>& tensor )
 {
-   const typename MT::ResultType tmp( ~tensor );
+   const typename MT::ResultType tmp( *tensor );
    return tmp;
 }
 //*************************************************************************************************
@@ -1684,7 +1710,7 @@ inline const typename MT::ResultType evaluate( const Tensor<MT>& tensor )
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE constexpr bool isEmpty( const Tensor<MT>& tensor ) noexcept
 {
-   return size( ~tensor ) == 0UL;
+   return size( *tensor ) == 0UL;
 }
 //*************************************************************************************************
 
@@ -1702,7 +1728,7 @@ BLAZE_ALWAYS_INLINE constexpr bool isEmpty( const Tensor<MT>& tensor ) noexcept
 template< typename MT > // Type of the tensor
 BLAZE_ALWAYS_INLINE bool isSquare( const Tensor<MT>& tensor ) noexcept
 {
-   return ( IsSquare_v<MT> || ( (~tensor).rows() == (~tensor).columns() && (~tensor).rows() == (~tensor).pages() ) );
+   return ( IsSquare_v<MT> || ( (*tensor).rows() == (*tensor).columns() && (*tensor).rows() == (*tensor).pages() ) );
 }
 //*************************************************************************************************
 
@@ -1763,7 +1789,7 @@ BLAZE_ALWAYS_INLINE void assign_backend( Tensor<TT1>& lhs, const Tensor<TT2>& rh
 {
    BLAZE_FUNCTION_TRACE;
 
-   (~lhs).assign( ~rhs );
+   (*lhs).assign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1790,11 +1816,11 @@ BLAZE_ALWAYS_INLINE void assign( Tensor<TT1>& lhs, const Tensor<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   assign_backend( ~lhs, ~rhs );
+   assign_backend( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1816,7 +1842,7 @@ BLAZE_ALWAYS_INLINE void addAssign_backend( Tensor<TT1>& lhs, const Tensor<TT2>&
 {
    BLAZE_FUNCTION_TRACE;
 
-   (~lhs).addAssign( ~rhs );
+   (*lhs).addAssign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1843,11 +1869,11 @@ BLAZE_ALWAYS_INLINE void addAssign( Tensor<TT1>& lhs, const Tensor<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   addAssign_backend( ~lhs, ~rhs );
+   addAssign_backend( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1869,7 +1895,7 @@ BLAZE_ALWAYS_INLINE void subAssign_backend( Tensor<TT1>& lhs, const Tensor<TT2>&
 {
    BLAZE_FUNCTION_TRACE;
 
-   (~lhs).subAssign( ~rhs );
+   (*lhs).subAssign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1896,11 +1922,11 @@ BLAZE_ALWAYS_INLINE void subAssign( Tensor<TT1>& lhs, const Tensor<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   subAssign_backend( ~lhs, ~rhs );
+   subAssign_backend( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1922,7 +1948,7 @@ BLAZE_ALWAYS_INLINE void schurAssign_backend( Tensor<TT1>& lhs, const Tensor<TT2
 {
    BLAZE_FUNCTION_TRACE;
 
-   (~lhs).schurAssign( ~rhs );
+   (*lhs).schurAssign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1949,11 +1975,11 @@ BLAZE_ALWAYS_INLINE void schurAssign( Tensor<TT1>& lhs, const Tensor<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   schurAssign_backend( ~lhs, ~rhs );
+   schurAssign_backend( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1980,9 +2006,9 @@ BLAZE_ALWAYS_INLINE void multAssign( Tensor<TT1>& lhs, const Tensor<TT2>& rhs )
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).rows(), "Invalid tensor sizes" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).rows(), "Invalid tensor sizes" );
 
-   (~lhs).multAssign( ~rhs );
+   (*lhs).multAssign( *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -2007,7 +2033,7 @@ BLAZE_ALWAYS_INLINE void multAssign( Tensor<TT1>& lhs, const Tensor<TT2>& rhs )
 template< typename TT > // Type of the tensor
 BLAZE_ALWAYS_INLINE TT& derestrict( Tensor<TT>& tensor )
 {
-   return ~tensor;
+   return *tensor;
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -2030,7 +2056,7 @@ BLAZE_ALWAYS_INLINE TT& derestrict( Tensor<TT>& tensor )
 template< typename TT > // Type of the tensor
 inline decltype(auto) unview( Tensor<TT>& t )
 {
-   return ~t;
+   return *t;
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -2053,7 +2079,7 @@ inline decltype(auto) unview( Tensor<TT>& t )
 template< typename TT > // Type of the tensor
 inline decltype(auto) unview( const Tensor<TT>& t )
 {
-   return ~t;
+   return *t;
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/smp/ArrayThreadMapping.h
+++ b/blaze_tensor/math/smp/ArrayThreadMapping.h
@@ -75,8 +75,8 @@ namespace blaze {
 template< typename MT >// Type of the tensor
 ThreadMapping createThreadMapping( size_t threads, const Array<MT>& A )
 {
-   const size_t M( (~A).template dimension<1>() );
-   const size_t N( (~A).template dimension<0>() );
+   const size_t M( (*A).template dimension<1>() );
+   const size_t N( (*A).template dimension<0>() );
 
    if( M > N )
    {

--- a/blaze_tensor/math/smp/TensorThreadMapping.h
+++ b/blaze_tensor/math/smp/TensorThreadMapping.h
@@ -75,8 +75,8 @@ namespace blaze {
 template< typename MT >// Type of the tensor
 ThreadMapping createThreadMapping( size_t threads, const Tensor<MT>& A )
 {
-   const size_t M( (~A).rows() );
-   const size_t N( (~A).columns() );
+   const size_t M( (*A).rows() );
+   const size_t N( (*A).columns() );
 
    if( M > N )
    {

--- a/blaze_tensor/math/smp/default/DenseArray.h
+++ b/blaze_tensor/math/smp/default/DenseArray.h
@@ -101,9 +101,9 @@ inline EnableIf_t< IsDenseArray_v<TT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions(), "Invalid dimensions"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions(), "Invalid dimensions"    );
 
-   assign( ~lhs, ~rhs );
+   assign( *lhs, *rhs );
 }
 //*************************************************************************************************
 
@@ -129,9 +129,9 @@ inline EnableIf_t< IsDenseArray_v<TT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions(), "Invalid dimensions"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions(), "Invalid dimensions"    );
 
-   addAssign( ~lhs, ~rhs );
+   addAssign( *lhs, *rhs );
 }
 //*************************************************************************************************
 
@@ -157,9 +157,9 @@ inline EnableIf_t< IsDenseArray_v<TT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions(), "Invalid dimensions"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions(), "Invalid dimensions"    );
 
-   subAssign( ~lhs, ~rhs );
+   subAssign( *lhs, *rhs );
 }
 //*************************************************************************************************
 
@@ -186,9 +186,9 @@ inline EnableIf_t< IsDenseArray_v<TT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions(), "Invalid dimensions"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions(), "Invalid dimensions"    );
 
-   schurAssign( ~lhs, ~rhs );
+   schurAssign( *lhs, *rhs );
 }
 //*************************************************************************************************
 
@@ -222,9 +222,9 @@ inline EnableIf_t< IsDenseArray_v<AT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions(), "Invalid dimensions"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions(), "Invalid dimensions"    );
 
-   multAssign( ~lhs, ~rhs );
+   multAssign( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/smp/default/DenseTensor.h
+++ b/blaze_tensor/math/smp/default/DenseTensor.h
@@ -101,11 +101,11 @@ inline EnableIf_t< IsDenseTensor_v<TT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   assign( ~lhs, ~rhs );
+   assign( *lhs, *rhs );
 }
 //*************************************************************************************************
 
@@ -131,11 +131,11 @@ inline EnableIf_t< IsDenseTensor_v<TT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   addAssign( ~lhs, ~rhs );
+   addAssign( *lhs, *rhs );
 }
 //*************************************************************************************************
 
@@ -161,11 +161,11 @@ inline EnableIf_t< IsDenseTensor_v<TT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   subAssign( ~lhs, ~rhs );
+   subAssign( *lhs, *rhs );
 }
 //*************************************************************************************************
 
@@ -192,11 +192,11 @@ inline EnableIf_t< IsDenseTensor_v<TT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages"   );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages"   );
 
-   schurAssign( ~lhs, ~rhs );
+   schurAssign( *lhs, *rhs );
 }
 //*************************************************************************************************
 
@@ -230,11 +230,11 @@ inline EnableIf_t< IsDenseTensor_v<MT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( (~lhs).columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( (~lhs).pages()   == (~rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( (*lhs).pages()   == (*rhs).pages(),   "Invalid number of pages" );
 
-   multAssign( ~lhs, ~rhs );
+   multAssign( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/smp/hpx/DenseArray.h
+++ b/blaze_tensor/math/smp/hpx/DenseArray.h
@@ -110,12 +110,12 @@ void hpxAssign( DenseArray<TT1>& lhs, const DenseArray<TT2>& rhs, OP op )
    constexpr bool simdEnabled( TT1::simdEnabled && TT2::simdEnabled && IsSIMDCombinable_v<ET1,ET2> );
    constexpr size_t SIMDSIZE( SIMDTrait< ElementType_t<TT1> >::size );
 
-   const bool lhsAligned( (~lhs).isAligned() );
-   const bool rhsAligned( (~rhs).isAligned() );
+   const bool lhsAligned( (*lhs).isAligned() );
+   const bool rhsAligned( (*rhs).isAligned() );
 
-   const size_t pages = (~rhs).template dimension<2>();
-   const size_t rows  = (~rhs).template dimension<1>();
-   const size_t columns = (~rhs).template dimension<0>();
+   const size_t pages = (*rhs).template dimension<2>();
+   const size_t rows  = (*rhs).template dimension<1>();
+   const size_t columns = (*rhs).template dimension<0>();
 
    const size_t threads    ( getNumThreads() );
    const size_t numPages( min( static_cast<std::size_t>( BLAZE_HPX_TENSOR_BLOCK_SIZE_PAGE ), pages ) );
@@ -146,33 +146,33 @@ void hpxAssign( DenseArray<TT1>& lhs, const DenseArray<TT2>& rhs, OP op )
    //   if( page >= pages || row >= rows || column >= columns )
    //      return;
 
-   //    for (size_t k = 0; k != (~rhs).quats(); ++k)
+   //    for (size_t k = 0; k != (*rhs).quats(); ++k)
    //    {
    //       const size_t o( min( pagesPerIter, pages   - page    ) );
    //       const size_t m( min( rowsPerIter,  rows    - row    ) );
    //       const size_t n( min( colsPerIter,  columns - column ) );
 
-   //       auto lhs_slice = quatslice( ~lhs, k );
-   //       auto rhs_slice = quatslice( ~rhs, k );
+   //       auto lhs_slice = quatslice( *lhs, k );
+   //       auto rhs_slice = quatslice( *rhs, k );
 
    //       if( simdEnabled && lhsAligned && rhsAligned ) {
-   //          auto       target( subtensor  ( ~lhs_slice, page, row, column, o, m, n ) );
-   //          const auto source( subtensor  ( ~rhs_slice, page, row, column, o, m, n ) );
+   //          auto       target( subtensor  ( *lhs_slice, page, row, column, o, m, n ) );
+   //          const auto source( subtensor  ( *rhs_slice, page, row, column, o, m, n ) );
    //          op( target, source );
    //       }
    //       else if( simdEnabled && lhsAligned ) {
-   //          auto       target( subtensor  ( ~lhs_slice, page, row, column, o, m, n ) );
-   //          const auto source( subtensor  ( ~rhs_slice, page, row, column, o, m, n ) );
+   //          auto       target( subtensor  ( *lhs_slice, page, row, column, o, m, n ) );
+   //          const auto source( subtensor  ( *rhs_slice, page, row, column, o, m, n ) );
    //          op( target, source );
    //       }
    //       else if( simdEnabled && rhsAligned ) {
-   //          auto       target( subtensor  ( ~lhs_slice, page, row, column, o, m, n ) );
-   //          const auto source( subtensor  ( ~rhs_slice, page, row, column, o, m, n ) );
+   //          auto       target( subtensor  ( *lhs_slice, page, row, column, o, m, n ) );
+   //          const auto source( subtensor  ( *rhs_slice, page, row, column, o, m, n ) );
    //          op( target, source );
    //       }
    //       else {
-   //          auto       target( subtensor  ( ~lhs_slice, page, row, column, o, m, n ));
-   //          const auto source( subtensor  ( ~rhs_slice, page, row, column, o, m, n ));
+   //          auto       target( subtensor  ( *lhs_slice, page, row, column, o, m, n ));
+   //          const auto source( subtensor  ( *rhs_slice, page, row, column, o, m, n ));
    //          op(target, source);
    //       }
    //    }
@@ -215,9 +215,9 @@ inline EnableIf_t< IsDenseArray_v<TT1> && ( !IsSMPAssignable_v<TT1> || !IsSMPAss
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions()   , "Invalid array sizes"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions()   , "Invalid array sizes"    );
 
-   assign( ~lhs, ~rhs );
+   assign( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -251,13 +251,13 @@ inline EnableIf_t< IsDenseArray_v<TT1> && IsSMPAssignable_v<TT1> && IsSMPAssigna
    BLAZE_CONSTRAINT_MUST_NOT_BE_SMP_ASSIGNABLE( ElementType_t<TT1> );
    BLAZE_CONSTRAINT_MUST_NOT_BE_SMP_ASSIGNABLE( ElementType_t<TT2> );
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions()   , "Invalid array sizes"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions()   , "Invalid array sizes"    );
 
-   if( isSerialSectionActive() || !(~rhs).canSMPAssign() ) {
-      assign( ~lhs, ~rhs );
+   if( isSerialSectionActive() || !(*rhs).canSMPAssign() ) {
+      assign( *lhs, *rhs );
    }
    else {
-      hpxAssign( ~lhs, ~rhs, []( auto& a, const auto& b ){ assign( a, b ); } );
+      hpxAssign( *lhs, *rhs, []( auto& a, const auto& b ){ assign( a, b ); } );
    }
 }
 /*! \endcond */
@@ -297,9 +297,9 @@ inline EnableIf_t< IsDenseArray_v<TT1> && ( !IsSMPAssignable_v<TT1> || !IsSMPAss
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions()   , "Invalid array sizes"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions()   , "Invalid array sizes"    );
 
-   addAssign( ~lhs, ~rhs );
+   addAssign( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -333,13 +333,13 @@ inline EnableIf_t< IsDenseArray_v<TT1> && IsSMPAssignable_v<TT1> && IsSMPAssigna
    BLAZE_CONSTRAINT_MUST_NOT_BE_SMP_ASSIGNABLE( ElementType_t<TT1> );
    BLAZE_CONSTRAINT_MUST_NOT_BE_SMP_ASSIGNABLE( ElementType_t<TT2> );
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions()   , "Invalid array sizes"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions()   , "Invalid array sizes"    );
 
-   if( isSerialSectionActive() || !(~rhs).canSMPAssign() ) {
-      addAssign( ~lhs, ~rhs );
+   if( isSerialSectionActive() || !(*rhs).canSMPAssign() ) {
+      addAssign( *lhs, *rhs );
    }
    else {
-      hpxAssign( ~lhs, ~rhs, []( auto& a, const auto& b ){ addAssign( a, b ); } );
+      hpxAssign( *lhs, *rhs, []( auto& a, const auto& b ){ addAssign( a, b ); } );
    }
 }
 /*! \endcond */
@@ -379,9 +379,9 @@ inline EnableIf_t< IsDenseArray_v<TT1> && ( !IsSMPAssignable_v<TT1> || !IsSMPAss
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions()   , "Invalid array sizes"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions()   , "Invalid array sizes"    );
 
-   subAssign( ~lhs, ~rhs );
+   subAssign( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -415,13 +415,13 @@ inline EnableIf_t< IsDenseArray_v<TT1> && IsSMPAssignable_v<TT1> && IsSMPAssigna
    BLAZE_CONSTRAINT_MUST_NOT_BE_SMP_ASSIGNABLE( ElementType_t<TT1> );
    BLAZE_CONSTRAINT_MUST_NOT_BE_SMP_ASSIGNABLE( ElementType_t<TT2> );
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions()   , "Invalid array sizes"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions()   , "Invalid array sizes"    );
 
-   if( isSerialSectionActive() || !(~rhs).canSMPAssign() ) {
-      subAssign( ~lhs, ~rhs );
+   if( isSerialSectionActive() || !(*rhs).canSMPAssign() ) {
+      subAssign( *lhs, *rhs );
    }
    else {
-      hpxAssign( ~lhs, ~rhs, []( auto& a, const auto& b ){ subAssign( a, b ); } );
+      hpxAssign( *lhs, *rhs, []( auto& a, const auto& b ){ subAssign( a, b ); } );
    }
 }
 /*! \endcond */
@@ -461,9 +461,9 @@ inline EnableIf_t< IsDenseArray_v<TT1> && ( !IsSMPAssignable_v<TT1> || !IsSMPAss
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions()   , "Invalid array sizes"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions()   , "Invalid array sizes"    );
 
-   schurAssign( ~lhs, ~rhs );
+   schurAssign( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -497,13 +497,13 @@ inline EnableIf_t< IsDenseArray_v<TT1> && IsSMPAssignable_v<TT1> && IsSMPAssigna
    BLAZE_CONSTRAINT_MUST_NOT_BE_SMP_ASSIGNABLE( ElementType_t<TT1> );
    BLAZE_CONSTRAINT_MUST_NOT_BE_SMP_ASSIGNABLE( ElementType_t<TT2> );
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions()   , "Invalid array sizes"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions()   , "Invalid array sizes"    );
 
-   if( isSerialSectionActive() || !(~rhs).canSMPAssign() ) {
-      schurAssign( ~lhs, ~rhs );
+   if( isSerialSectionActive() || !(*rhs).canSMPAssign() ) {
+      schurAssign( *lhs, *rhs );
    }
    else {
-      hpxAssign( ~lhs, ~rhs, []( auto& a, const auto& b ){ schurAssign( a, b ); } );
+      hpxAssign( *lhs, *rhs, []( auto& a, const auto& b ){ schurAssign( a, b ); } );
    }
 }
 /*! \endcond */
@@ -541,9 +541,9 @@ inline EnableIf_t< IsDenseArray_v<TT1> >
 {
    BLAZE_FUNCTION_TRACE;
 
-   BLAZE_INTERNAL_ASSERT( (~lhs).dimensions() == (~rhs).dimensions()   , "Invalid array sizes"    );
+   BLAZE_INTERNAL_ASSERT( (*lhs).dimensions() == (*rhs).dimensions()   , "Invalid array sizes"    );
 
-   multAssign( ~lhs, ~rhs );
+   multAssign( *lhs, *rhs );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/views/ColumnSlice.h
+++ b/blaze_tensor/math/views/ColumnSlice.h
@@ -114,7 +114,7 @@ inline decltype(auto) columnslice( Tensor<MT>& tensor, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = ColumnSlice_<MT,I>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -161,7 +161,7 @@ inline decltype(auto) columnslice( const Tensor<MT>& tensor, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const ColumnSlice_<const MT,I>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -188,7 +188,7 @@ inline decltype(auto) columnslice( Tensor<MT>&& tensor, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = ColumnSlice_<MT,I>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -234,7 +234,7 @@ inline decltype(auto) columnslice( Tensor<MT>& tensor, size_t index, RRAs... arg
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = ColumnSlice_<MT>;
-   return ReturnType( ~tensor, index, args... );
+   return ReturnType( *tensor, index, args... );
 }
 //*************************************************************************************************
 
@@ -280,7 +280,7 @@ inline decltype(auto) columnslice( const Tensor<MT>& tensor, size_t index, RRAs.
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const ColumnSlice_<const MT>;
-   return ReturnType( ~tensor, index, args... );
+   return ReturnType( *tensor, index, args... );
 }
 //*************************************************************************************************
 
@@ -307,7 +307,7 @@ inline decltype(auto) columnslice( Tensor<MT>&& tensor, size_t index, RRAs... ar
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = ColumnSlice_<MT>;
-   return ReturnType( ~tensor, index, args... );
+   return ReturnType( *tensor, index, args... );
 }
 //*************************************************************************************************
 
@@ -339,8 +339,8 @@ inline decltype(auto) columnslice( const TensTensAddExpr<MT>& tensor, RRAs... ar
 {
    BLAZE_FUNCTION_TRACE;
 
-   return columnslice<CRAs...>( (~tensor).leftOperand(), args... ) +
-          columnslice<CRAs...>( (~tensor).rightOperand(), args... );
+   return columnslice<CRAs...>( (*tensor).leftOperand(), args... ) +
+          columnslice<CRAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -365,8 +365,8 @@ inline decltype(auto) columnslice( const TensTensSubExpr<MT>& tensor, RRAs... ar
 {
    BLAZE_FUNCTION_TRACE;
 
-   return columnslice<CRAs...>( (~tensor).leftOperand(), args... ) -
-          columnslice<CRAs...>( (~tensor).rightOperand(), args... );
+   return columnslice<CRAs...>( (*tensor).leftOperand(), args... ) -
+          columnslice<CRAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -390,8 +390,8 @@ inline decltype(auto) columnslice( const SchurExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return columnslice<CRAs...>( (~tensor).leftOperand(), args... ) %
-          columnslice<CRAs...>( (~tensor).rightOperand(), args... );
+   return columnslice<CRAs...>( (*tensor).leftOperand(), args... ) %
+          columnslice<CRAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -415,8 +415,8 @@ inline decltype(auto) columnslice( const SchurExpr<MT>& tensor, RRAs... args )
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return columnslice<CRAs...>( (~tensor).leftOperand(), args... ) %
-//          column<CRAs...>     ( (~tensor).rightOperand(), args... );
+//   return columnslice<CRAs...>( (*tensor).leftOperand(), args... ) %
+//          column<CRAs...>     ( (*tensor).rightOperand(), args... );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -441,7 +441,7 @@ inline decltype(auto) columnslice( const TensTensMultExpr<MT>& tensor, RRAs... a
 {
    BLAZE_FUNCTION_TRACE;
 
-   return columnslice<CRAs...>( (~tensor).leftOperand(), args... ) * (~tensor).rightOperand();
+   return columnslice<CRAs...>( (*tensor).leftOperand(), args... ) * (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -469,12 +469,12 @@ inline decltype(auto) columnslice( const TensTensMultExpr<MT>& tensor, RRAs... a
 //    MAYBE_UNUSED( args... );
 //
 //    if( !Contains_v< TypeList<RRAs...>, Unchecked > ) {
-//       if( (~tensor).columnslices() <= I ) {
+//       if( (*tensor).columnslices() <= I ) {
 //          BLAZE_THCOLUMNSLICE_INVALID_ARGUMENT( "Invalid columnslice access index" );
 //       }
 //    }
 //
-//    return (~tensor).leftOperand()[I] * (~tensor).rightOperand();
+//    return (*tensor).leftOperand()[I] * (*tensor).rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -502,12 +502,12 @@ inline decltype(auto) columnslice( const TensTensMultExpr<MT>& tensor, RRAs... a
 //    MAYBE_UNUSED( args... );
 //
 //    if( !Contains_v< TypeList<RRAs...>, Unchecked > ) {
-//       if( (~tensor).columnslices() <= index ) {
+//       if( (*tensor).columnslices() <= index ) {
 //          BLAZE_THCOLUMNSLICE_INVALID_ARGUMENT( "Invalid columnslice access index" );
 //       }
 //    }
 //
-//    return (~tensor).leftOperand()[index] * (~tensor).rightOperand();
+//    return (*tensor).leftOperand()[index] * (*tensor).rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -532,7 +532,7 @@ inline decltype(auto) columnslice( const TensScalarMultExpr<MT>& tensor, RRAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return columnslice<CRAs...>( (~tensor).leftOperand(), args... ) * (~tensor).rightOperand();
+   return columnslice<CRAs...>( (*tensor).leftOperand(), args... ) * (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -557,7 +557,7 @@ inline decltype(auto) columnslice( const TensScalarDivExpr<MT>& tensor, RRAs... 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return columnslice<CRAs...>( (~tensor).leftOperand(), args... ) / (~tensor).rightOperand();
+   return columnslice<CRAs...>( (*tensor).leftOperand(), args... ) / (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -582,7 +582,7 @@ inline decltype(auto) columnslice( const TensMapExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( columnslice<CRAs...>( (~tensor).operand(), args... ), (~tensor).operation() );
+   return map( columnslice<CRAs...>( (*tensor).operand(), args... ), (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -607,9 +607,9 @@ inline decltype(auto) columnslice( const TensTensMapExpr<MT>& tensor, RRAs... ar
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( columnslice<CRAs...>( (~tensor).leftOperand(), args... ),
-               columnslice<CRAs...>( (~tensor).rightOperand(), args... ),
-               (~tensor).operation() );
+   return map( columnslice<CRAs...>( (*tensor).leftOperand(), args... ),
+               columnslice<CRAs...>( (*tensor).rightOperand(), args... ),
+               (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -634,7 +634,7 @@ inline decltype(auto) columnslice( const TensEvalExpr<MT>& tensor, RRAs... args 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return eval( columnslice<CRAs...>( (~tensor).operand(), args... ) );
+   return eval( columnslice<CRAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -659,7 +659,7 @@ inline decltype(auto) columnslice( const TensSerialExpr<MT>& tensor, RRAs... arg
 {
    BLAZE_FUNCTION_TRACE;
 
-   return serial( columnslice<CRAs...>( (~tensor).operand(), args... ) );
+   return serial( columnslice<CRAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -684,7 +684,7 @@ inline decltype(auto) columnslice( const DeclExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return columnslice<CRAs...>( (~tensor).operand(), args... );
+   return columnslice<CRAs...>( (*tensor).operand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -714,7 +714,7 @@ inline decltype(auto) columnslice( const MatExpandExpr<TT,CEAs...>& tensor, CSAs
 
    MAYBE_UNUSED( args... );
 
-   return expand( trans( column( (~tensor).operand(), 0UL ) ), (~tensor).expansion() );
+   return expand( trans( column( (*tensor).operand(), 0UL ) ), (*tensor).expansion() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1051,10 +1051,10 @@ template< typename MT     // Type of the tensor
 BLAZE_ALWAYS_INLINE bool
    tryMult( const ColumnSlice<MT,CRAs...>& columnslice, size_t row, size_t col, size_t rows, size_t cols, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~columnslice).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( row + rows <= (~columnslice).rows(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( col <= (~columnslice).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( col + cols <= (~columnslice).columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( row <= (*columnslice).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( row + rows <= (*columnslice).rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( col <= (*columnslice).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( col + cols <= (*columnslice).columns(), "Invalid columns range size" );
 
    return tryMult( columnslice.operand(), row, columnslice.column(), col, rows, 1UL, cols, value );
 }
@@ -1113,10 +1113,10 @@ template< typename MT     // Type of the tensor
 BLAZE_ALWAYS_INLINE bool
    tryDiv( const ColumnSlice<MT,CRAs...>& columnslice, size_t row, size_t col, size_t rows, size_t cols, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~columnslice).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( row + rows <= (~columnslice).rows(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( col <= (~columnslice).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( col + cols <= (~columnslice).columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( row <= (*columnslice).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( row + rows <= (*columnslice).rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( col <= (*columnslice).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( col + cols <= (*columnslice).columns(), "Invalid columns range size" );
 
    return tryDiv( columnslice.operand(), row, columnslice.column(), col, rows, 1UL, cols, value );
 }
@@ -1146,11 +1146,11 @@ inline bool tryAssign( const ColumnSlice<MT,CRAs...>& lhs,
                        const Matrix<VT,false>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryAssign(lhs.operand(), ~rhs, j, lhs.column(), i);
+   return tryAssign(lhs.operand(), *rhs, j, lhs.column(), i);
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1178,11 +1178,11 @@ inline bool tryAddAssign( const ColumnSlice<MT,CRAs...>& lhs,
                           const Matrix<VT,false>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryAddAssign(lhs.operand(), ~rhs, j, lhs.column(), i);
+   return tryAddAssign(lhs.operand(), *rhs, j, lhs.column(), i);
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1210,11 +1210,11 @@ inline bool trySubAssign( const ColumnSlice<MT,CRAs...>& lhs,
                           const Matrix<VT,false>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return trySubAssign(lhs.operand(), ~rhs, j, lhs.column(), i);
+   return trySubAssign(lhs.operand(), *rhs, j, lhs.column(), i);
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1242,11 +1242,11 @@ inline bool tryMultAssign( const ColumnSlice<MT,CRAs...>& lhs,
                            const Vector<VT,true>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryMultAssign(lhs.operand(), ~rhs, j, lhs.column(), i);
+   return tryMultAssign(lhs.operand(), *rhs, j, lhs.column(), i);
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1274,11 +1274,11 @@ inline bool tryDivAssign( const ColumnSlice<MT,CRAs...>& lhs,
                           const Matrix<VT,false>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryDivAssign(lhs.operand(), ~rhs, j, lhs.column(), i);
+   return tryDivAssign(lhs.operand(), *rhs, j, lhs.column(), i);
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/views/DilatedSubmatrix.h
+++ b/blaze_tensor/math/views/DilatedSubmatrix.h
@@ -181,7 +181,7 @@ inline decltype(auto) dilatedsubmatrix( Matrix<MT,SO>& matrix, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubmatrix<I,J,M,N,RowDilation,ColumnDilation>( ~matrix, args... );
+   return dilatedsubmatrix<I,J,M,N,RowDilation,ColumnDilation>( *matrix, args... );
 }
 //*************************************************************************************************
 
@@ -252,7 +252,7 @@ inline decltype(auto) dilatedsubmatrix( const Matrix<MT,SO>& matrix, RSAs... arg
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubmatrix<I,J,M,N,RowDilation,ColumnDilation>( ~matrix, args... );
+   return dilatedsubmatrix<I,J,M,N,RowDilation,ColumnDilation>( *matrix, args... );
 }
 //*************************************************************************************************
 
@@ -285,7 +285,7 @@ inline decltype(auto) dilatedsubmatrix( Matrix<MT,SO>&& matrix, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubmatrix<I,J,M,N,RowDilation,ColumnDilation>( ~matrix, args... );
+   return dilatedsubmatrix<I,J,M,N,RowDilation,ColumnDilation>( *matrix, args... );
 }
 //*************************************************************************************************
 
@@ -400,7 +400,7 @@ inline decltype(auto)
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DilatedSubmatrix_<MT>;
-   return ReturnType( ~matrix, row, column, m, n, rowdilation, columndilation, args... );
+   return ReturnType( *matrix, row, column, m, n, rowdilation, columndilation, args... );
 }
 //*************************************************************************************************
 
@@ -472,7 +472,7 @@ inline decltype(auto)
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DilatedSubmatrix_<const MT>;
-   return ReturnType( ~matrix, row, column, m, n, rowdilation, columndilation, args... );
+   return ReturnType( *matrix, row, column, m, n, rowdilation, columndilation, args... );
 }
 //*************************************************************************************************
 
@@ -506,7 +506,7 @@ inline decltype(auto)
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DilatedSubmatrix_<MT>;
-   return ReturnType( ~matrix, row, column, m, n, rowdilation, columndilation, args... );
+   return ReturnType( *matrix, row, column, m, n, rowdilation, columndilation, args... );
 }
 
 //=================================================================================================
@@ -534,8 +534,8 @@ inline decltype(auto) dilatedsubmatrix( const MatMatAddExpr<MT>& matrix, RSAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubmatrix<CSAs...>( (~matrix).leftOperand(), args... ) +
-          dilatedsubmatrix<CSAs...>( (~matrix).rightOperand(), args... );
+   return dilatedsubmatrix<CSAs...>( (*matrix).leftOperand(), args... ) +
+          dilatedsubmatrix<CSAs...>( (*matrix).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -560,8 +560,8 @@ inline decltype(auto) dilatedsubmatrix( const MatMatSubExpr<MT>& matrix, RSAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubmatrix<CSAs...>( (~matrix).leftOperand(), args... ) -
-          dilatedsubmatrix<CSAs...>( (~matrix).rightOperand(), args... );
+   return dilatedsubmatrix<CSAs...>( (*matrix).leftOperand(), args... ) -
+          dilatedsubmatrix<CSAs...>( (*matrix).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -586,8 +586,8 @@ inline decltype(auto) dilatedsubmatrix( const SchurExpr<MT>& matrix, RSAs... arg
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubmatrix<CSAs...>( (~matrix).leftOperand(), args... ) %
-          dilatedsubmatrix<CSAs...>( (~matrix).rightOperand(), args... );
+   return dilatedsubmatrix<CSAs...>( (*matrix).leftOperand(), args... ) %
+          dilatedsubmatrix<CSAs...>( (*matrix).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -617,8 +617,8 @@ inline decltype(auto) dilatedsubmatrix( const MatMatMultExpr<MT>& matrix, RSAs..
 
    const DilatedSubmatrixData<CSAs...> sd( args... );
 
-   decltype(auto) left( (~matrix).leftOperand()  );
-   decltype(auto) right( (~matrix).rightOperand() );
+   decltype(auto) left( (*matrix).leftOperand()  );
+   decltype(auto) right( (*matrix).rightOperand() );
 
    const size_t begin( max( ( IsUpper_v<MT1> )
                             ?( ( !IsStrictlyUpper_v<MT1> )
@@ -673,8 +673,8 @@ inline decltype(auto) dilatedsubmatrix( const VecTVecMultExpr<MT>& matrix, RSAs.
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<I,M,RowDilation>( (~matrix).leftOperand(), args... ) *
-          dilatedsubvector<J,N,ColumnDilation>( (~matrix).rightOperand(), args... );
+   return dilatedsubvector<I,M,RowDilation>( (*matrix).leftOperand(), args... ) *
+          dilatedsubvector<J,N,ColumnDilation>( (*matrix).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -703,8 +703,8 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return diltedsubvector( (~matrix).leftOperand(), row, m, rowdilation, args... ) *
-          diltedsubvector( (~matrix).rightOperand(), column, n, columndilation, args... );
+   return diltedsubvector( (*matrix).leftOperand(), row, m, rowdilation, args... ) *
+          diltedsubvector( (*matrix).rightOperand(), column, n, columndilation, args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -729,7 +729,7 @@ inline decltype(auto) dilatedsubmatrix( const MatScalarMultExpr<MT>& matrix, RSA
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubmatrix<CSAs...>( (~matrix).leftOperand(), args... ) * (~matrix).rightOperand();
+   return dilatedsubmatrix<CSAs...>( (*matrix).leftOperand(), args... ) * (*matrix).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -754,7 +754,7 @@ inline decltype(auto) dilatedsubmatrix( const MatScalarDivExpr<MT>& matrix, RSAs
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubmatrix<CSAs...>( (~matrix).leftOperand(), args... ) / (~matrix).rightOperand();
+   return dilatedsubmatrix<CSAs...>( (*matrix).leftOperand(), args... ) / (*matrix).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -779,7 +779,7 @@ inline decltype(auto) dilatedsubmatrix( const MatMapExpr<MT>& matrix, RSAs... ar
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( dilatedsubmatrix<CSAs...>( (~matrix).operand(), args... ), (~matrix).operation() );
+   return map( dilatedsubmatrix<CSAs...>( (*matrix).operand(), args... ), (*matrix).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -804,9 +804,9 @@ inline decltype(auto) dilatedsubmatrix( const MatMatMapExpr<MT>& matrix, RSAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( dilatedsubmatrix<CSAs...>( (~matrix).leftOperand(), args... ),
-               dilatedsubmatrix<CSAs...>( (~matrix).rightOperand(), args... ),
-               (~matrix).operation() );
+   return map( dilatedsubmatrix<CSAs...>( (*matrix).leftOperand(), args... ),
+               dilatedsubmatrix<CSAs...>( (*matrix).rightOperand(), args... ),
+               (*matrix).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -831,7 +831,7 @@ inline decltype(auto) dilatedsubmatrix( const MatEvalExpr<MT>& matrix, RSAs... a
 {
    BLAZE_FUNCTION_TRACE;
 
-   return eval( dilatedsubmatrix<CSAs...>( (~matrix).operand(), args... ) );
+   return eval( dilatedsubmatrix<CSAs...>( (*matrix).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -856,7 +856,7 @@ inline decltype(auto) dilatedsubmatrix( const MatSerialExpr<MT>& matrix, RSAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return serial( dilatedsubmatrix<CSAs...>( (~matrix).operand(), args... ) );
+   return serial( dilatedsubmatrix<CSAs...>( (*matrix).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -881,7 +881,7 @@ inline decltype(auto) dilatedsubmatrix( const DeclExpr<MT>& matrix, RSAs... args
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubmatrix<CSAs...>( (~matrix).operand(), args... );
+   return dilatedsubmatrix<CSAs...>( (*matrix).operand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -911,7 +911,7 @@ inline decltype(auto) dilatedsubmatrix( const MatTransExpr<MT>& matrix, RSAs... 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( dilatedsubmatrix<J,I,N,M,ColumnDilation,RowDilation>( (~matrix).operand(), args... ) );
+   return trans( dilatedsubmatrix<J,I,N,M,ColumnDilation,RowDilation>( (*matrix).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -941,7 +941,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( dilatedsubmatrix( (~matrix).operand(), column, row, n, m, columndilation, rowdilation, args... ) );
+   return trans( dilatedsubmatrix( (*matrix).operand(), column, row, n, m, columndilation, rowdilation, args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -972,7 +972,7 @@ inline decltype(auto) dilatedsubmatrix( const VecExpandExpr<MT,CEAs...>& matrix,
 {
    BLAZE_FUNCTION_TRACE;
 
-   using VT = VectorType_t< RemoveReference_t< decltype( (~matrix).operand() ) > >;
+   using VT = VectorType_t< RemoveReference_t< decltype( (*matrix).operand() ) > >;
 
    constexpr bool TF( TransposeFlag_v<VT> );
 
@@ -981,7 +981,7 @@ inline decltype(auto) dilatedsubmatrix( const VecExpandExpr<MT,CEAs...>& matrix,
    constexpr size_t expansion( TF ? M : N );
    constexpr size_t dilation ( TF ? ColumnDilation : RowDilation );
 
-   return expand<expansion>( dilatedsubvector<index,size,dilation>( (~matrix).operand(), args... ) );
+   return expand<expansion>( dilatedsubvector<index,size,dilation>( (*matrix).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1012,7 +1012,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   using VT = VectorType_t< RemoveReference_t< decltype( (~matrix).operand() ) > >;
+   using VT = VectorType_t< RemoveReference_t< decltype( (*matrix).operand() ) > >;
 
    constexpr bool TF( TransposeFlag_v<VT> );
 
@@ -1021,7 +1021,7 @@ inline decltype(auto)
    const size_t expansion( TF ? m : n );
    const size_t dilation ( TF ? columndilation : rowdilation );
 
-   return expand( dilatedsubvector( (~matrix).operand(), index, size, dilation, args... ), expansion );
+   return expand( dilatedsubvector( (*matrix).operand(), index, size, dilation, args... ), expansion );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1751,8 +1751,8 @@ inline decltype(auto) dilatedsubvector( const MatVecMultExpr<VT>& vector, RSAs..
 
    const DilatedSubvectorData<CSAs...> sd( args... );
 
-   decltype(auto) left( (~vector).leftOperand()  );
-   decltype(auto) right((~vector).rightOperand() );
+   decltype(auto) left( (*vector).leftOperand()  );
+   decltype(auto) right((*vector).rightOperand() );
 
    const size_t column( ( IsUpper_v<MT> )
                         ?( ( !IsStrictlyUpper_v<MT> )?( sd.offset() + 1UL ):( sd.offset() ) )
@@ -1795,8 +1795,8 @@ inline decltype(auto) dilatedsubvector( const TVecMatMultExpr<VT>& vector, RSAs.
 
    const DilatedSubvectorData<CSAs...> sd( args... );
 
-   decltype(auto) left( (~vector).leftOperand()  );
-   decltype(auto) right((~vector).rightOperand() );
+   decltype(auto) left( (*vector).leftOperand()  );
+   decltype(auto) right((*vector).rightOperand() );
 
    const size_t row( ( IsLower_v<MT> )
                      ?( ( !IsStrictlyLower_v<MT> )?( sd.offset() + 1UL ):( sd.offset() ) )
@@ -1835,10 +1835,10 @@ inline decltype(auto) dilatedsubvector( const MatReduceExpr<VT,columnwise>& vect
    BLAZE_FUNCTION_TRACE;
 
    const DilatedSubvectorData<CSAs...> sd( args... );
-   const size_t M( (~vector).operand().rows() );
+   const size_t M( (*vector).operand().rows() );
 
-   decltype(auto) sm( dilatedsubmatrix( (~vector).operand(), 0UL, sd.offset(), M, sd.size(), 1UL, sd.dilation() ) );
-   return reduce<columnwise>( sm, (~vector).operation() );
+   decltype(auto) sm( dilatedsubmatrix( (*vector).operand(), 0UL, sd.offset(), M, sd.size(), 1UL, sd.dilation() ) );
+   return reduce<columnwise>( sm, (*vector).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1864,10 +1864,10 @@ inline decltype(auto) dilatedsubvector( const MatReduceExpr<VT,rowwise>& vector,
    BLAZE_FUNCTION_TRACE;
 
    const DilatedSubvectorData<CSAs...> sd( args... );
-   const size_t N( (~vector).operand().columns() );
+   const size_t N( (*vector).operand().columns() );
 
-   decltype(auto) sm( dilatedsubmatrix( (~vector).operand(), sd.offset(), 0UL, sd.size(), N, sd.dilation(), 1UL ) );
-   return reduce<rowwise>( sm, (~vector).operation() );
+   decltype(auto) sm( dilatedsubmatrix( (*vector).operand(), sd.offset(), 0UL, sd.size(), N, sd.dilation(), 1UL ) );
+   return reduce<rowwise>( sm, (*vector).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -3790,15 +3790,15 @@ inline bool isDefault( const DilatedSubmatrix<MT,SO,true,CSAs...>& sm )
    using blaze::isDefault;
 
    if( SO == rowMajor ) {
-      for( size_t i=0UL; i<(~sm).rows(); ++i )
-         for( size_t j=0UL; j<(~sm).columns(); ++j )
-            if( !isDefault<RF>( (~sm)(i,j) ) )
+      for( size_t i=0UL; i<(*sm).rows(); ++i )
+         for( size_t j=0UL; j<(*sm).columns(); ++j )
+            if( !isDefault<RF>( (*sm)(i,j) ) )
                return false;
    }
    else {
-      for( size_t j=0UL; j<(~sm).columns(); ++j )
-         for( size_t i=0UL; i<(~sm).rows(); ++i )
-            if( !isDefault<RF>( (~sm)(i,j) ) )
+      for( size_t j=0UL; j<(*sm).columns(); ++j )
+         for( size_t i=0UL; i<(*sm).rows(); ++i )
+            if( !isDefault<RF>( (*sm)(i,j) ) )
                return false;
    }
 
@@ -4267,8 +4267,8 @@ template< typename MT       // Type of the matrix
         , size_t... CSAs >  // Compile time DilatedSubmatrix arguments
 inline bool isSame( const DilatedSubmatrix<MT,SO,DF,CSAs...>& a, const Matrix<MT,SO>& b ) noexcept
 {
-   return ( isSame( a.operand(), ~b ) && ( a.rows() == ( ~b ).rows() ) &&
-      ( a.columns() == ( ~b ).columns() ) && ( a.rowdilation() == 1UL ) &&
+   return ( isSame( a.operand(), *b ) && ( a.rows() == ( *b ).rows() ) &&
+      ( a.columns() == ( *b ).columns() ) && ( a.rowdilation() == 1UL ) &&
       ( a.columndilation() == 1UL ) );
 }
 /*! \endcond */
@@ -4294,8 +4294,8 @@ template< typename MT       // Type of the matrix
         , size_t... CSAs >  // Compile time DilatedSubmatrix arguments
 inline bool isSame( const Matrix<MT,SO>& a, const DilatedSubmatrix<MT,SO,DF,CSAs...>& b ) noexcept
 {
-   return ( isSame( ~a, b.operand() ) && ( ( ~a ).rows() == b.rows() ) &&
-      ( ( ~a ).columns() == b.columns() ) && ( b.rowdilation() == 1UL ) &&
+   return ( isSame( *a, b.operand() ) && ( ( *a ).rows() == b.rows() ) &&
+      ( ( *a ).columns() == b.columns() ) && ( b.rowdilation() == 1UL ) &&
       ( b.columndilation() == 1UL ) );
 }
 /*! \endcond */
@@ -4550,10 +4550,10 @@ BLAZE_ALWAYS_INLINE bool
 {
    MAYBE_UNUSED( column );
 
-   BLAZE_INTERNAL_ASSERT( row <= (~sm).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~sm).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + m <= (~sm).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + n <= (~sm).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row <= (*sm).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*sm).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( row + m <= (*sm).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + n <= (*sm).columns(), "Invalid number of columns" );
 
    return tryMult( sm.operand(), sm.row()+row*sm.rowdilation(), sm.column(), m*sm.rowdilation(), n, value );
 }
@@ -4621,10 +4621,10 @@ BLAZE_ALWAYS_INLINE bool
 {
    MAYBE_UNUSED( column );
 
-   BLAZE_INTERNAL_ASSERT( row <= (~sm).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~sm).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + m <= (~sm).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + n <= (~sm).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row <= (*sm).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*sm).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( row + m <= (*sm).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + n <= (*sm).columns(), "Invalid number of columns" );
 
    return tryDiv( sm.operand(), sm.row()+row*sm.rowdilation(), sm.column(), m*sm.rowdilation(), n, value );
 }
@@ -4659,10 +4659,10 @@ inline bool tryAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( TF || ( row + (~rhs).size() <= lhs.rows() ), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( !TF || ( column + (~rhs).size() <= lhs.columns() ), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( TF || ( row + (*rhs).size() <= lhs.rows() ), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( !TF || ( column + (*rhs).size() <= lhs.columns() ), "Invalid number of columns" );
 
-   return tryAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+   return tryAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4696,10 +4696,10 @@ inline bool tryAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                      lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
@@ -4733,10 +4733,10 @@ inline bool tryAssign( const DilatedSubmatrix<MT1,SO1,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+   return tryAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4769,10 +4769,10 @@ inline bool tryAddAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( TF || ( row + (~rhs).size() <= lhs.rows() ), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( !TF || ( column + (~rhs).size() <= lhs.columns() ), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( TF || ( row + (*rhs).size() <= lhs.rows() ), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( !TF || ( column + (*rhs).size() <= lhs.columns() ), "Invalid number of columns" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+   return tryAddAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4807,10 +4807,10 @@ inline bool tryAddAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryAddAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                         lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
@@ -4844,10 +4844,10 @@ inline bool tryAddAssign( const DilatedSubmatrix<MT1,SO1,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+   return tryAddAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4880,10 +4880,10 @@ inline bool trySubAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( TF || ( row + (~rhs).size() <= lhs.rows() ), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( !TF || ( column + (~rhs).size() <= lhs.columns() ), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( TF || ( row + (*rhs).size() <= lhs.rows() ), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( !TF || ( column + (*rhs).size() <= lhs.columns() ), "Invalid number of columns" );
 
-   return trySubAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+   return trySubAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4918,10 +4918,10 @@ inline bool trySubAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 
-   return trySubAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return trySubAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                         lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
@@ -4955,10 +4955,10 @@ inline bool trySubAssign( const DilatedSubmatrix<MT1,SO1,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return trySubAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+   return trySubAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4991,10 +4991,10 @@ inline bool tryMultAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( TF || ( row + (~rhs).size() <= lhs.rows() ), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( !TF || ( column + (~rhs).size() <= lhs.columns() ), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( TF || ( row + (*rhs).size() <= lhs.rows() ), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( !TF || ( column + (*rhs).size() <= lhs.columns() ), "Invalid number of columns" );
 
-   return tryMultAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+   return tryMultAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5029,10 +5029,10 @@ inline bool tryMultAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryMultAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryMultAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                          lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
@@ -5066,10 +5066,10 @@ inline bool trySchurAssign( const DilatedSubmatrix<MT1,SO1,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return trySchurAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+   return trySchurAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5102,10 +5102,10 @@ inline bool tryDivAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( TF || ( row + (~rhs).size() <= lhs.rows() ), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( !TF || ( column + (~rhs).size() <= lhs.columns() ), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( TF || ( row + (*rhs).size() <= lhs.rows() ), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( !TF || ( column + (*rhs).size() <= lhs.columns() ), "Invalid number of columns" );
 
-   return tryDivAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+   return tryDivAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5140,10 +5140,10 @@ inline bool tryDivAssign( const DilatedSubmatrix<MT,SO,DF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryDivAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryDivAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                         lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 }
 /*! \endcond */

--- a/blaze_tensor/math/views/DilatedSubtensor.h
+++ b/blaze_tensor/math/views/DilatedSubtensor.h
@@ -190,7 +190,7 @@ inline decltype(auto) dilatedsubtensor( Tensor<TT>& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubtensor<K,I,J,O,M,N,PageDilation,RowDilation,ColumnDilation>( ~tensor, args... );
+   return dilatedsubtensor<K,I,J,O,M,N,PageDilation,RowDilation,ColumnDilation>( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -263,7 +263,7 @@ inline decltype(auto) dilatedsubtensor( const Tensor<TT>& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubtensor<K,I,J,O,M,N,PageDilation,RowDilation,ColumnDilation>( ~tensor, args... );
+   return dilatedsubtensor<K,I,J,O,M,N,PageDilation,RowDilation,ColumnDilation>( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -298,7 +298,7 @@ inline decltype(auto) dilatedsubtensor( Tensor<TT>&& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubtensor<K,I,J,O,M,N,PageDilation,RowDilation,ColumnDilation>( ~tensor, args... );
+   return dilatedsubtensor<K,I,J,O,M,N,PageDilation,RowDilation,ColumnDilation>( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -413,7 +413,7 @@ inline decltype(auto)
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DilatedSubtensor_<TT>;
-   return ReturnType( ~tensor, page, row, column, o, m, n, pagedilation, rowdilation, columndilation, args... );
+   return ReturnType( *tensor, page, row, column, o, m, n, pagedilation, rowdilation, columndilation, args... );
 }
 //*************************************************************************************************
 
@@ -484,7 +484,7 @@ inline decltype(auto)
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DilatedSubtensor_<const TT>;
-   return ReturnType( ~tensor, page, row, column, o, m, n, pagedilation, rowdilation, columndilation, args... );
+   return ReturnType( *tensor, page, row, column, o, m, n, pagedilation, rowdilation, columndilation, args... );
 }
 //*************************************************************************************************
 
@@ -517,7 +517,7 @@ inline decltype(auto)
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DilatedSubtensor_<TT>;
-   return ReturnType( ~tensor, page, row, column, o, m, n, pagedilation, rowdilation, columndilation, args... );
+   return ReturnType( *tensor, page, row, column, o, m, n, pagedilation, rowdilation, columndilation, args... );
 }
 
 //=================================================================================================
@@ -545,8 +545,8 @@ inline decltype(auto) dilatedsubtensor( const TensTensAddExpr<TT>& tensor, RSAs.
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubtensor<CSAs...>( (~tensor).leftOperand(), args... ) +
-          dilatedsubtensor<CSAs...>( (~tensor).rightOperand(), args... );
+   return dilatedsubtensor<CSAs...>( (*tensor).leftOperand(), args... ) +
+          dilatedsubtensor<CSAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -571,8 +571,8 @@ inline decltype(auto) dilatedsubtensor( const TensTensSubExpr<TT>& tensor, RSAs.
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubtensor<CSAs...>( (~tensor).leftOperand(), args... ) -
-          dilatedsubtensor<CSAs...>( (~tensor).rightOperand(), args... );
+   return dilatedsubtensor<CSAs...>( (*tensor).leftOperand(), args... ) -
+          dilatedsubtensor<CSAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -597,8 +597,8 @@ inline decltype(auto) dilatedsubtensor( const SchurExpr<TT>& tensor, RSAs... arg
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubtensor<CSAs...>( (~tensor).leftOperand(), args... ) %
-          dilatedsubtensor<CSAs...>( (~tensor).rightOperand(), args... );
+   return dilatedsubtensor<CSAs...>( (*tensor).leftOperand(), args... ) %
+          dilatedsubtensor<CSAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -623,7 +623,7 @@ inline decltype(auto) dilatedsubtensor( const TensScalarMultExpr<TT>& tensor, RS
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubtensor<CSAs...>( (~tensor).leftOperand(), args... ) * (~tensor).rightOperand();
+   return dilatedsubtensor<CSAs...>( (*tensor).leftOperand(), args... ) * (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -648,7 +648,7 @@ inline decltype(auto) dilatedsubtensor( const TensScalarDivExpr<TT>& tensor, RSA
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubtensor<CSAs...>( (~tensor).leftOperand(), args... ) / (~tensor).rightOperand();
+   return dilatedsubtensor<CSAs...>( (*tensor).leftOperand(), args... ) / (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -673,7 +673,7 @@ inline decltype(auto) dilatedsubtensor( const TensMapExpr<TT>& tensor, RSAs... a
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( dilatedsubtensor<CSAs...>( (~tensor).operand(), args... ), (~tensor).operation() );
+   return map( dilatedsubtensor<CSAs...>( (*tensor).operand(), args... ), (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -698,9 +698,9 @@ inline decltype(auto) dilatedsubtensor( const TensTensMapExpr<TT>& tensor, RSAs.
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( dilatedsubtensor<CSAs...>( (~tensor).leftOperand(), args... ),
-               dilatedsubtensor<CSAs...>( (~tensor).rightOperand(), args... ),
-               (~tensor).operation() );
+   return map( dilatedsubtensor<CSAs...>( (*tensor).leftOperand(), args... ),
+               dilatedsubtensor<CSAs...>( (*tensor).rightOperand(), args... ),
+               (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -725,7 +725,7 @@ inline decltype(auto) dilatedsubtensor( const TensEvalExpr<TT>& tensor, RSAs... 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return eval( dilatedsubtensor<CSAs...>( (~tensor).operand(), args... ) );
+   return eval( dilatedsubtensor<CSAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -750,7 +750,7 @@ inline decltype(auto) dilatedsubtensor( const TensSerialExpr<TT>& tensor, RSAs..
 {
    BLAZE_FUNCTION_TRACE;
 
-   return serial( dilatedsubtensor<CSAs...>( (~tensor).operand(), args... ) );
+   return serial( dilatedsubtensor<CSAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -783,7 +783,7 @@ inline decltype(auto) dilatedsubtensor( const TensSerialExpr<TT>& tensor, RSAs..
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return trans( dilatedsubtensor<J,I,K,N,M,O,ColumnDilation,RowDilation,PageDilation>( (~tensor).operand(), args... ) );
+//   return trans( dilatedsubtensor<J,I,K,N,M,O,ColumnDilation,RowDilation,PageDilation>( (*tensor).operand(), args... ) );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -813,7 +813,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( dilatedsubtensor( (~tensor).operand(), page, column, row, n, m, o, pagedilation, columndilation, rowdilation, args... ) );
+   return trans( dilatedsubtensor( (*tensor).operand(), page, column, row, n, m, o, pagedilation, columndilation, rowdilation, args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -847,7 +847,7 @@ inline decltype(auto) dilatedsubtensor( const MatExpandExpr<TT,CEAs...>& tensor,
 {
    BLAZE_FUNCTION_TRACE;
 
-   using MT = MatrixType_t< RemoveReference_t< decltype( (~tensor).operand() ) > >;
+   using MT = MatrixType_t< RemoveReference_t< decltype( (*tensor).operand() ) > >;
 
    constexpr bool SO( StorageOrder_v<MT> );
 
@@ -858,7 +858,7 @@ inline decltype(auto) dilatedsubtensor( const MatExpandExpr<TT,CEAs...>& tensor,
    constexpr size_t rowdilation   ( SO ? ColumnDilation : RowDilation );
    constexpr size_t columndilation( SO ? RowDilation : ColumnDilation );
 
-   return expand<O>( dilatedsubmatrix<row,column,rows,columns,rowdilation,columndilation>( (~tensor).operand(), args... ) );
+   return expand<O>( dilatedsubmatrix<row,column,rows,columns,rowdilation,columndilation>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -890,7 +890,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   using MT = MatrixType_t< RemoveReference_t< decltype( (~tensor).operand() ) > >;
+   using MT = MatrixType_t< RemoveReference_t< decltype( (*tensor).operand() ) > >;
 
    constexpr bool SO( StorageOrder_v<MT> );
 
@@ -901,7 +901,7 @@ inline decltype(auto)
    constexpr size_t RowDilation   ( SO ? columndilation : rowdilation );
    constexpr size_t ColumnDilation( SO ? rowdilation : columndilation );
 
-   return expand( dilatedsubmatrix( (~tensor).operand(), I,J,M,N,RowDilation,ColumnDilation, args... ), o );
+   return expand( dilatedsubmatrix( (*tensor).operand(), I,J,M,N,RowDilation,ColumnDilation, args... ), o );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1547,8 +1547,8 @@ inline decltype(auto)
 //
 //   const DilatedSubmatrixData<CSAs...> sm( args... );
 //
-//   BLAZE_DECLTYPE_AUTO( left , (~matrix).leftOperand()  );
-//   BLAZE_DECLTYPE_AUTO( right, (~matrix).rightOperand() );
+//   BLAZE_DECLTYPE_AUTO( left , (*matrix).leftOperand()  );
+//   BLAZE_DECLTYPE_AUTO( right, (*matrix).rightOperand() );
 //
 //   const size_t column( 0UL );
 //   const size_t n( left.columns() );
@@ -1583,8 +1583,8 @@ inline decltype(auto)
 //
 //   const DilatedSubvectorData<CSAs...> sd( args... );
 //
-//   BLAZE_DECLTYPE_AUTO( left , (~vector).leftOperand()  );
-//   BLAZE_DECLTYPE_AUTO( right, (~vector).rightOperand() );
+//   BLAZE_DECLTYPE_AUTO( left , (*vector).leftOperand()  );
+//   BLAZE_DECLTYPE_AUTO( right, (*vector).rightOperand() );
 //
 //   const size_t row( ( IsLower_v<TT> )
 //                     ?( ( !IsStrictlyLower_v<TT> )?( sd.offset() + 1UL ):( sd.offset() ) )
@@ -1623,10 +1623,10 @@ inline decltype(auto) dilatedsubmatrix( const TensReduceExpr<MT,pagewise>& matri
    BLAZE_FUNCTION_TRACE;
 
    const DilatedSubmatrixData<CSAs...> sm( args... );
-   const size_t M( (~matrix).operand().rows() );
+   const size_t M( (*matrix).operand().rows() );
 
-   decltype(auto) st( dilatedsubtensor( (~matrix).operand(), sm.row(), 0UL, sm.column(), sm.rows(), M, sm.columns(), sm.rowdilation(), 1UL, sm.columndilation() ) );
-   return reduce<pagewise>( st, (~matrix).operation() );
+   decltype(auto) st( dilatedsubtensor( (*matrix).operand(), sm.row(), 0UL, sm.column(), sm.rows(), M, sm.columns(), sm.rowdilation(), 1UL, sm.columndilation() ) );
+   return reduce<pagewise>( st, (*matrix).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1652,11 +1652,11 @@ inline decltype(auto) dilatedsubmatrix( const TensReduceExpr<MT,columnwise>& mat
    BLAZE_FUNCTION_TRACE;
 
    const DilatedSubmatrixData<CSAs...> sm( args... );
-   const size_t O( (~matrix).operand().rows() );
+   const size_t O( (*matrix).operand().rows() );
 
-   decltype(auto) st( dilatedsubtensor( (~matrix).operand(), 0UL, sm.row(), sm.column(), O, sm.rows(),
+   decltype(auto) st( dilatedsubtensor( (*matrix).operand(), 0UL, sm.row(), sm.column(), O, sm.rows(),
       sm.columns(), 1UL, sm.rowdilation(), sm.columndilation() ) );
-   return reduce<columnwise>( st, (~matrix).operation() );
+   return reduce<columnwise>( st, (*matrix).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1682,11 +1682,11 @@ inline decltype(auto) dilatedsubmatrix( const TensReduceExpr<MT,rowwise>& matrix
    BLAZE_FUNCTION_TRACE;
 
    const DilatedSubmatrixData<CSAs...> sm( args... );
-   const size_t N( (~matrix).operand().rows() );
+   const size_t N( (*matrix).operand().rows() );
 
-   decltype(auto) st( dilatedsubtensor( (~matrix).operand(), sm.row(), sm.column(), 0UL, sm.rows(), sm.columns(), N,
+   decltype(auto) st( dilatedsubtensor( (*matrix).operand(), sm.row(), sm.column(), 0UL, sm.rows(), sm.columns(), N,
       sm.rowdilation(), sm.columndilation(), 1UL ) );
-   return reduce<rowwise>( st, (~matrix).operation() );
+   return reduce<rowwise>( st, (*matrix).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -2995,10 +2995,10 @@ inline bool isDefault( const DilatedSubtensor<TT,true,CSAs...>& st )
 {
    using blaze::isDefault;
 
-   for( size_t k=0UL; k<(~st).pages(); ++k )
-      for( size_t i=0UL; i<(~st).rows(); ++i )
-         for( size_t j=0UL; j<(~st).columns(); ++j )
-            if( !isDefault<RF>( (~st)(k,i,j) ) )
+   for( size_t k=0UL; k<(*st).pages(); ++k )
+      for( size_t i=0UL; i<(*st).rows(); ++i )
+         for( size_t j=0UL; j<(*st).columns(); ++j )
+            if( !isDefault<RF>( (*st)(k,i,j) ) )
                return false;
 
    return true;
@@ -3386,8 +3386,8 @@ template< typename TT       // Type of the tensor
         , size_t... CSAs >  // Compile time DilatedSubtensor arguments
 inline bool isSame( const DilatedSubtensor<TT,DF,CSAs...>& a, const Tensor<TT>& b ) noexcept
 {
-   return ( isSame( a.operand(), ~b ) && ( a.pages() == ( ~b ).pages() ) && ( a.rows() == ( ~b ).rows() ) &&
-      ( a.columns() == ( ~b ).columns() ) && ( a.pagedilation() == 1UL ) && ( a.rowdilation() == 1UL ) &&
+   return ( isSame( a.operand(), *b ) && ( a.pages() == ( *b ).pages() ) && ( a.rows() == ( *b ).rows() ) &&
+      ( a.columns() == ( *b ).columns() ) && ( a.pagedilation() == 1UL ) && ( a.rowdilation() == 1UL ) &&
       ( a.columndilation() == 1UL ) );
 }
 /*! \endcond */
@@ -3666,12 +3666,12 @@ BLAZE_ALWAYS_INLINE bool
 {
    MAYBE_UNUSED( column );
 
-   BLAZE_INTERNAL_ASSERT( page <= (~st).pages(),         "Invalid page access index"  );
-   BLAZE_INTERNAL_ASSERT( row <= (~st).rows(),           "Invalid row access index"   );
-   BLAZE_INTERNAL_ASSERT( column <= (~st).columns(),     "Invalid column access index");
-   BLAZE_INTERNAL_ASSERT( page + o <= (~st).pages(),     "Invalid number of pages"    );
-   BLAZE_INTERNAL_ASSERT( row + m <= (~st).rows(),       "Invalid number of rows"     );
-   BLAZE_INTERNAL_ASSERT( column + n <= (~st).columns(), "Invalid number of columns"  );
+   BLAZE_INTERNAL_ASSERT( page <= (*st).pages(),         "Invalid page access index"  );
+   BLAZE_INTERNAL_ASSERT( row <= (*st).rows(),           "Invalid row access index"   );
+   BLAZE_INTERNAL_ASSERT( column <= (*st).columns(),     "Invalid column access index");
+   BLAZE_INTERNAL_ASSERT( page + o <= (*st).pages(),     "Invalid number of pages"    );
+   BLAZE_INTERNAL_ASSERT( row + m <= (*st).rows(),       "Invalid number of rows"     );
+   BLAZE_INTERNAL_ASSERT( column + n <= (*st).columns(), "Invalid number of columns"  );
 
 
    return tryMult( st.operand(), st.row()+row*st.rowdilation(), st.column(), st.page(), m*st.rowdilation(), n, o, value );
@@ -3739,12 +3739,12 @@ BLAZE_ALWAYS_INLINE bool
 {
    MAYBE_UNUSED( column );
 
-   BLAZE_INTERNAL_ASSERT( page <= (~st).pages(),         "Invalid page access index"  );
-   BLAZE_INTERNAL_ASSERT( row <= (~st).rows(),           "Invalid row access index"   );
-   BLAZE_INTERNAL_ASSERT( column <= (~st).columns(),     "Invalid column access index");
-   BLAZE_INTERNAL_ASSERT( page + o <= (~st).pages(),     "Invalid number of pages"    );
-   BLAZE_INTERNAL_ASSERT( row + m <= (~st).rows(),       "Invalid number of rows"     );
-   BLAZE_INTERNAL_ASSERT( column + n <= (~st).columns(), "Invalid number of columns"  );
+   BLAZE_INTERNAL_ASSERT( page <= (*st).pages(),         "Invalid page access index"  );
+   BLAZE_INTERNAL_ASSERT( row <= (*st).rows(),           "Invalid row access index"   );
+   BLAZE_INTERNAL_ASSERT( column <= (*st).columns(),     "Invalid column access index");
+   BLAZE_INTERNAL_ASSERT( page + o <= (*st).pages(),     "Invalid number of pages"    );
+   BLAZE_INTERNAL_ASSERT( row + m <= (*st).rows(),       "Invalid number of rows"     );
+   BLAZE_INTERNAL_ASSERT( column + n <= (*st).columns(), "Invalid number of columns"  );
 
    return tryDiv( st.operand(), st.row()+row*st.rowdilation(), st.column(), st.page(), m*st.rowdilation(), n, o, value );
 }
@@ -3779,10 +3779,10 @@ inline bool tryAssign( const DilatedSubtensor<TT,DF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(),      "Invalid row access index"   );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(),"Invalid column access index");
 
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(),
+   return tryAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(),
                     lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
 }
 /*! \endcond */
@@ -3817,10 +3817,10 @@ inline bool tryAssign( const DilatedSubtensor<TT,DF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(),      "Invalid row access index"   );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(),"Invalid column access index");
 
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                      lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
 }
 /*! \endcond */
@@ -3853,11 +3853,11 @@ inline bool tryAssign( const DilatedSubtensor<TT1,DF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + (~rhs).pages() <= lhs.pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + (*rhs).pages() <= lhs.pages(), "Invalid number of pages" );
 
-   return tryAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
+   return tryAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -3889,10 +3889,10 @@ inline bool tryAddAssign( const DilatedSubtensor<TT,DF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
+   return tryAddAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -3926,10 +3926,10 @@ inline bool tryAddAssign( const DilatedSubtensor<TT,DF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryAddAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                         lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
 }
 /*! \endcond */
@@ -3962,11 +3962,11 @@ inline bool tryAddAssign( const DilatedSubtensor<TT1,DF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + (~rhs).pages() <= lhs.pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + (*rhs).pages() <= lhs.pages(), "Invalid number of pages" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
+   return tryAddAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -3998,10 +3998,10 @@ inline bool trySubAssign( const DilatedSubtensor<TT,DF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return trySubAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
+   return trySubAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4035,10 +4035,10 @@ inline bool trySubAssign( const DilatedSubtensor<TT,DF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return trySubAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return trySubAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                         lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
 }
 /*! \endcond */
@@ -4071,11 +4071,11 @@ inline bool trySubAssign( const DilatedSubtensor<TT1,DF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + (~rhs).pages() <= lhs.pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + (*rhs).pages() <= lhs.pages(), "Invalid number of pages" );
 
-   return trySubAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
+   return trySubAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation(), lhs.page() + page * lhs.pagedilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4108,10 +4108,10 @@ inline bool trySubAssign( const DilatedSubtensor<TT1,DF,CSAs...>& lhs,
 //{
 //   BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
 //   BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-//   BLAZE_INTERNAL_ASSERT( TF || ( row + (~rhs).size() <= lhs.rows() ), "Invalid number of rows" );
-//   BLAZE_INTERNAL_ASSERT( !TF || ( column + (~rhs).size() <= lhs.columns() ), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( TF || ( row + (*rhs).size() <= lhs.rows() ), "Invalid number of rows" );
+//   BLAZE_INTERNAL_ASSERT( !TF || ( column + (*rhs).size() <= lhs.columns() ), "Invalid number of columns" );
 //
-//   return tryMultAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+//   return tryMultAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -4146,10 +4146,10 @@ inline bool trySubAssign( const DilatedSubtensor<TT1,DF,CSAs...>& lhs,
 //{
 //   BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
 //   BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-//   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-//   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+//   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 //
-//   return tryMultAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+//   return tryMultAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
 //                         lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 //}
 /*! \endcond */
@@ -4183,10 +4183,10 @@ inline bool trySubAssign( const DilatedSubtensor<TT1,DF,CSAs...>& lhs,
 //{
 //   BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
 //   BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-//   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-//   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+//   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 //
-//   return trySchurAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+//   return trySchurAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -4219,10 +4219,10 @@ inline bool trySubAssign( const DilatedSubtensor<TT1,DF,CSAs...>& lhs,
 //{
 //   BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
 //   BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-//   BLAZE_INTERNAL_ASSERT( TF || ( row + (~rhs).size() <= lhs.rows() ), "Invalid number of rows" );
-//   BLAZE_INTERNAL_ASSERT( !TF || ( column + (~rhs).size() <= lhs.columns() ), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( TF || ( row + (*rhs).size() <= lhs.rows() ), "Invalid number of rows" );
+//   BLAZE_INTERNAL_ASSERT( !TF || ( column + (*rhs).size() <= lhs.columns() ), "Invalid number of columns" );
 //
-//   return tryDivAssign( lhs.operand(), ~rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
+//   return tryDivAssign( lhs.operand(), *rhs, lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -4257,10 +4257,10 @@ inline bool trySubAssign( const DilatedSubtensor<TT1,DF,CSAs...>& lhs,
 //{
 //   BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
 //   BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-//   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-//   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+//   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 //
-//   return tryDivAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+//   return tryDivAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
 //                        lhs.row() + row * lhs.rowdilation(), lhs.column() + column * lhs.columndilation() );
 //}
 /*! \endcond */

--- a/blaze_tensor/math/views/DilatedSubvector.h
+++ b/blaze_tensor/math/views/DilatedSubvector.h
@@ -152,7 +152,7 @@ inline decltype(auto) dilatedsubvector( Vector<VT,TF>& vector, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<I,N,Dilation>( ~vector, args... );
+   return dilatedsubvector<I,N,Dilation>( *vector, args... );
 }
 //*************************************************************************************************
 
@@ -209,7 +209,7 @@ inline decltype(auto) dilatedsubvector( const Vector<VT,TF>& vector, RSAs... arg
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<I,N,Dilation>( ~vector, args... );
+   return dilatedsubvector<I,N,Dilation>( *vector, args... );
 }
 //*************************************************************************************************
 
@@ -238,7 +238,7 @@ inline decltype(auto) dilatedsubvector( Vector<VT,TF>&& vector, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<I,N,Dilation>( ~vector, args... );
+   return dilatedsubvector<I,N,Dilation>( *vector, args... );
 }
 //*************************************************************************************************
 
@@ -307,7 +307,7 @@ inline decltype(auto) dilatedsubvector( Vector<VT,TF>& vector, size_t index, siz
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DilatedSubvector_<VT>;
-   return ReturnType( ~vector, index, size, dilation, args... );
+   return ReturnType( *vector, index, size, dilation, args... );
 }
 //*************************************************************************************************
 
@@ -376,7 +376,7 @@ inline decltype(auto) dilatedsubvector( const Vector<VT,TF>& vector, size_t inde
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const DilatedSubvector_<const VT>;
-   return ReturnType( ~vector, index, size, dilation, args... );
+   return ReturnType( *vector, index, size, dilation, args... );
 }
 //*************************************************************************************************
 
@@ -405,7 +405,7 @@ inline decltype(auto) dilatedsubvector( Vector<VT,TF>&& vector, size_t index, si
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DilatedSubvector_<VT>;
-   return ReturnType( ~vector, index, size, dilation, args... );
+   return ReturnType( *vector, index, size, dilation, args... );
 }
 //*************************************************************************************************
 
@@ -435,8 +435,8 @@ inline decltype(auto) dilatedsubvector( const VecVecAddExpr<VT>& vector, RSAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<CSAs...>( (~vector).leftOperand(), args... ) +
-          dilatedsubvector<CSAs...>( (~vector).rightOperand(), args... );
+   return dilatedsubvector<CSAs...>( (*vector).leftOperand(), args... ) +
+          dilatedsubvector<CSAs...>( (*vector).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -461,8 +461,8 @@ inline decltype(auto) dilatedsubvector( const VecVecSubExpr<VT>& vector, RSAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<CSAs...>( (~vector).leftOperand(), args... ) -
-          dilatedsubvector<CSAs...>( (~vector).rightOperand(), args... );
+   return dilatedsubvector<CSAs...>( (*vector).leftOperand(), args... ) -
+          dilatedsubvector<CSAs...>( (*vector).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -487,8 +487,8 @@ inline decltype(auto) dilatedsubvector( const VecVecMultExpr<VT>& vector, RSAs..
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<CSAs...>( (~vector).leftOperand(), args... ) *
-          dilatedsubvector<CSAs...>( (~vector).rightOperand(), args... );
+   return dilatedsubvector<CSAs...>( (*vector).leftOperand(), args... ) *
+          dilatedsubvector<CSAs...>( (*vector).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -513,8 +513,8 @@ inline decltype(auto) dilatedsubvector( const VecVecDivExpr<VT>& vector, RSAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<CSAs...>( (~vector).leftOperand(), args... ) /
-          dilatedsubvector<CSAs...>( (~vector).rightOperand(), args... );
+   return dilatedsubvector<CSAs...>( (*vector).leftOperand(), args... ) /
+          dilatedsubvector<CSAs...>( (*vector).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -540,7 +540,7 @@ inline decltype(auto) dilatedsubvector( const CrossExpr<VT>& vector, RSAs... arg
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = DilatedSubvector_< VectorType_t<VT>, CSAs... >;
-   return ReturnType( ~vector, args... );
+   return ReturnType( *vector, args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -565,7 +565,7 @@ inline decltype(auto) dilatedsubvector( const VecScalarMultExpr<VT>& vector, RSA
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<CSAs...>( (~vector).leftOperand(), args... ) * (~vector).rightOperand();
+   return dilatedsubvector<CSAs...>( (*vector).leftOperand(), args... ) * (*vector).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -590,7 +590,7 @@ inline decltype(auto) dilatedsubvector( const VecScalarDivExpr<VT>& vector, RSAs
 {
    BLAZE_FUNCTION_TRACE;
 
-   return dilatedsubvector<CSAs...>( (~vector).leftOperand(), args... ) / (~vector).rightOperand();
+   return dilatedsubvector<CSAs...>( (*vector).leftOperand(), args... ) / (*vector).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -615,7 +615,7 @@ inline decltype(auto) dilatedsubvector( const VecMapExpr<VT>& vector, RSAs... ar
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( dilatedsubvector<CSAs...>( (~vector).operand(), args... ), (~vector).operation() );
+   return map( dilatedsubvector<CSAs...>( (*vector).operand(), args... ), (*vector).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -640,9 +640,9 @@ inline decltype(auto) dilatedsubvector( const VecVecMapExpr<VT>& vector, RSAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( dilatedsubvector<CSAs...>( (~vector).leftOperand(), args... ),
-               dilatedsubvector<CSAs...>( (~vector).rightOperand(), args... ),
-               (~vector).operation() );
+   return map( dilatedsubvector<CSAs...>( (*vector).leftOperand(), args... ),
+               dilatedsubvector<CSAs...>( (*vector).rightOperand(), args... ),
+               (*vector).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -667,7 +667,7 @@ inline decltype(auto) dilatedsubvector( const VecEvalExpr<VT>& vector, RSAs... a
 {
    BLAZE_FUNCTION_TRACE;
 
-   return eval( dilatedsubvector<CSAs...>( (~vector).operand(), args... ) );
+   return eval( dilatedsubvector<CSAs...>( (*vector).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -692,7 +692,7 @@ inline decltype(auto) dilatedsubvector( const VecSerialExpr<VT>& vector, RSAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return serial( dilatedsubvector<CSAs...>( (~vector).operand(), args... ) );
+   return serial( dilatedsubvector<CSAs...>( (*vector).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -717,7 +717,7 @@ inline decltype(auto) dilatedsubvector( const VecTransExpr<VT>& vector, RSAs... 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( dilatedsubvector<CSAs...>( (~vector).operand(), args... ) );
+   return trans( dilatedsubvector<CSAs...>( (*vector).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1731,7 +1731,7 @@ inline bool isDefault( const DilatedSubvector<VT,TF,false,CSAs...>& sv )
 {
    using blaze::isDefault;
 
-   for( const auto& element : ~sv )
+   for( const auto& element : *sv )
       if( !isDefault<RF>( element.value() ) ) return false;
    return true;
 }
@@ -1789,7 +1789,7 @@ template< typename VT       // Type of the vector
         , size_t... CSAs >  // Compile time dilatedsubvector arguments
 inline bool isSame( const DilatedSubvector<VT,TF,DF,CSAs...>& a, const Vector<VT,TF>& b ) noexcept
 {
-   return ( isSame( a.operand(), ~b ) && ( a.size() == (~b).size() ) && a.dilation() == 1 );
+   return ( isSame( a.operand(), *b ) && ( a.size() == (*b).size() ) && a.dilation() == 1 );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1997,8 +1997,8 @@ template< typename VT       // Type of the vector
 BLAZE_ALWAYS_INLINE bool
    tryMult( const DilatedSubvector<VT,TF,DF,CSAs...>& sv, size_t index, size_t size, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( index <= (~sv).size(), "Invalid vector access index" );
-   BLAZE_INTERNAL_ASSERT( index + size <= (~sv).size(), "Invalid range size" );
+   BLAZE_INTERNAL_ASSERT( index <= (*sv).size(), "Invalid vector access index" );
+   BLAZE_INTERNAL_ASSERT( index + size <= (*sv).size(), "Invalid range size" );
 
    return tryMult( sv.operand(), sv.offset()+index*sv.dilation(), size*sv.dilation(), value );
 }
@@ -2060,8 +2060,8 @@ template< typename VT       // Type of the vector
 BLAZE_ALWAYS_INLINE bool
    tryDiv( const DilatedSubvector<VT,TF,DF,CSAs...>& sv, size_t index, size_t size, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( index <= (~sv).size(), "Invalid vector access index" );
-   BLAZE_INTERNAL_ASSERT( index + size <= (~sv).size(), "Invalid range size" );
+   BLAZE_INTERNAL_ASSERT( index <= (*sv).size(), "Invalid vector access index" );
+   BLAZE_INTERNAL_ASSERT( index + size <= (*sv).size(), "Invalid range size" );
 
    return tryDiv( sv.operand(), sv.offset()+index*sv.dilation(), size*sv.dilation(), value );
 }
@@ -2093,9 +2093,9 @@ inline bool tryAssign( const DilatedSubvector<VT1,TF,DF,CSAs...>& lhs,
                        const Vector<VT2,TF>& rhs, size_t index )
 {
    BLAZE_INTERNAL_ASSERT( index <= lhs.size(), "Invalid vector access index" );
-   BLAZE_INTERNAL_ASSERT( index + (~rhs).size() <= lhs.size(), "Invalid vector size" );
+   BLAZE_INTERNAL_ASSERT( index + (*rhs).size() <= lhs.size(), "Invalid vector size" );
 
-   return tryAssign( lhs.operand(), ~rhs, lhs.offset() + index * lhs.dilation() );
+   return tryAssign( lhs.operand(), *rhs, lhs.offset() + index * lhs.dilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -2125,9 +2125,9 @@ inline bool tryAddAssign( const DilatedSubvector<VT1,TF,DF,CSAs...>& lhs,
                           const Vector<VT2,TF>& rhs, size_t index )
 {
    BLAZE_INTERNAL_ASSERT( index <= lhs.size(), "Invalid vector access index" );
-   BLAZE_INTERNAL_ASSERT( index + (~rhs).size() <= lhs.size(), "Invalid vector size" );
+   BLAZE_INTERNAL_ASSERT( index + (*rhs).size() <= lhs.size(), "Invalid vector size" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, lhs.offset() + index * lhs.dilation() );
+   return tryAddAssign( lhs.operand(), *rhs, lhs.offset() + index * lhs.dilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -2157,9 +2157,9 @@ inline bool trySubAssign( const DilatedSubvector<VT1,TF,DF,CSAs...>& lhs,
                           const Vector<VT2,TF>& rhs, size_t index )
 {
    BLAZE_INTERNAL_ASSERT( index <= lhs.size(), "Invalid vector access index" );
-   BLAZE_INTERNAL_ASSERT( index + (~rhs).size() <= lhs.size(), "Invalid vector size" );
+   BLAZE_INTERNAL_ASSERT( index + (*rhs).size() <= lhs.size(), "Invalid vector size" );
 
-   return trySubAssign( lhs.operand(), ~rhs, lhs.offset() + index * lhs.dilation() );
+   return trySubAssign( lhs.operand(), *rhs, lhs.offset() + index * lhs.dilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -2189,9 +2189,9 @@ inline bool tryMultAssign( const DilatedSubvector<VT1,TF,DF,CSAs...>& lhs,
                            const Vector<VT2,TF>& rhs, size_t index )
 {
    BLAZE_INTERNAL_ASSERT( index <= lhs.size(), "Invalid vector access index" );
-   BLAZE_INTERNAL_ASSERT( index + (~rhs).size() <= lhs.size(), "Invalid vector size" );
+   BLAZE_INTERNAL_ASSERT( index + (*rhs).size() <= lhs.size(), "Invalid vector size" );
 
-   return tryMultAssign(lhs.operand(), ~rhs, lhs.offset() + index * lhs.dilation() );
+   return tryMultAssign(lhs.operand(), *rhs, lhs.offset() + index * lhs.dilation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -2221,9 +2221,9 @@ inline bool tryDivAssign( const DilatedSubvector<VT1,TF,DF,CSAs...>& lhs,
                           const Vector<VT2,TF>& rhs, size_t index )
 {
    BLAZE_INTERNAL_ASSERT( index <= lhs.size(), "Invalid vector access index" );
-   BLAZE_INTERNAL_ASSERT( index + (~rhs).size() <= lhs.size(), "Invalid vector size" );
+   BLAZE_INTERNAL_ASSERT( index + (*rhs).size() <= lhs.size(), "Invalid vector size" );
 
-   return tryDivAssign(lhs.operand(), ~rhs, lhs.offset() + index * lhs.dilation() );
+   return tryDivAssign(lhs.operand(), *rhs, lhs.offset() + index * lhs.dilation() );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/views/PageSlice.h
+++ b/blaze_tensor/math/views/PageSlice.h
@@ -114,7 +114,7 @@ inline decltype(auto) pageslice( Tensor<MT>& tensor, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = PageSlice_<MT,I>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -161,7 +161,7 @@ inline decltype(auto) pageslice( const Tensor<MT>& tensor, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const PageSlice_<const MT,I>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -188,7 +188,7 @@ inline decltype(auto) pageslice( Tensor<MT>&& tensor, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = PageSlice_<MT,I>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -234,7 +234,7 @@ inline decltype(auto) pageslice( Tensor<MT>& tensor, size_t index, RRAs... args 
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = PageSlice_<MT>;
-   return ReturnType( ~tensor, index, args... );
+   return ReturnType( *tensor, index, args... );
 }
 //*************************************************************************************************
 
@@ -280,7 +280,7 @@ inline decltype(auto) pageslice( const Tensor<MT>& tensor, size_t index, RRAs...
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const PageSlice_<const MT>;
-   return ReturnType( ~tensor, index, args... );
+   return ReturnType( *tensor, index, args... );
 }
 //*************************************************************************************************
 
@@ -307,7 +307,7 @@ inline decltype(auto) pageslice( Tensor<MT>&& tensor, size_t index, RRAs... args
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = PageSlice_<MT>;
-   return ReturnType( ~tensor, index, args... );
+   return ReturnType( *tensor, index, args... );
 }
 //*************************************************************************************************
 
@@ -339,8 +339,8 @@ inline decltype(auto) pageslice( const TensTensAddExpr<MT>& tensor, RRAs... args
 {
    BLAZE_FUNCTION_TRACE;
 
-   return pageslice<CRAs...>( (~tensor).leftOperand(), args... ) +
-          pageslice<CRAs...>( (~tensor).rightOperand(), args... );
+   return pageslice<CRAs...>( (*tensor).leftOperand(), args... ) +
+          pageslice<CRAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -365,8 +365,8 @@ inline decltype(auto) pageslice( const TensTensSubExpr<MT>& tensor, RRAs... args
 {
    BLAZE_FUNCTION_TRACE;
 
-   return pageslice<CRAs...>( (~tensor).leftOperand(), args... ) -
-          pageslice<CRAs...>( (~tensor).rightOperand(), args... );
+   return pageslice<CRAs...>( (*tensor).leftOperand(), args... ) -
+          pageslice<CRAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -390,8 +390,8 @@ inline decltype(auto) pageslice( const SchurExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return pageslice<CRAs...>( (~tensor).leftOperand(), args... ) %
-          pageslice<CRAs...>( (~tensor).rightOperand(), args... );
+   return pageslice<CRAs...>( (*tensor).leftOperand(), args... ) %
+          pageslice<CRAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -415,8 +415,8 @@ inline decltype(auto) pageslice( const TensMatSchurExpr<TT>& tensor, RRAs... arg
 {
    BLAZE_FUNCTION_TRACE;
 
-   return pageslice<CRAs...>( (~tensor).leftOperand(), args... ) %
-                              (~tensor).rightOperand();
+   return pageslice<CRAs...>( (*tensor).leftOperand(), args... ) %
+                              (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -441,7 +441,7 @@ inline decltype(auto) pageslice( const TensTensMultExpr<MT>& tensor, RRAs... arg
 {
    BLAZE_FUNCTION_TRACE;
 
-   return pageslice<CRAs...>( (~tensor).leftOperand(), args... ) * (~tensor).rightOperand();
+   return pageslice<CRAs...>( (*tensor).leftOperand(), args... ) * (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -469,12 +469,12 @@ inline decltype(auto) pageslice( const TensTensMultExpr<MT>& tensor, RRAs... arg
 //    MAYBE_UNUSED( args... );
 //
 //    if( !Contains_v< TypeList<RRAs...>, Unchecked > ) {
-//       if( (~tensor).pageslices() <= I ) {
+//       if( (*tensor).pageslices() <= I ) {
 //          BLAZE_THPAGESLICE_INVALID_ARGUMENT( "Invalid pageslice access index" );
 //       }
 //    }
 //
-//    return (~tensor).leftOperand()[I] * (~tensor).rightOperand();
+//    return (*tensor).leftOperand()[I] * (*tensor).rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -502,12 +502,12 @@ inline decltype(auto) pageslice( const TensTensMultExpr<MT>& tensor, RRAs... arg
 //    MAYBE_UNUSED( args... );
 //
 //    if( !Contains_v< TypeList<RRAs...>, Unchecked > ) {
-//       if( (~tensor).pageslices() <= index ) {
+//       if( (*tensor).pageslices() <= index ) {
 //          BLAZE_THPAGESLICE_INVALID_ARGUMENT( "Invalid pageslice access index" );
 //       }
 //    }
 //
-//    return (~tensor).leftOperand()[index] * (~tensor).rightOperand();
+//    return (*tensor).leftOperand()[index] * (*tensor).rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -532,7 +532,7 @@ inline decltype(auto) pageslice( const TensScalarMultExpr<MT>& tensor, RRAs... a
 {
    BLAZE_FUNCTION_TRACE;
 
-   return pageslice<CRAs...>( (~tensor).leftOperand(), args... ) * (~tensor).rightOperand();
+   return pageslice<CRAs...>( (*tensor).leftOperand(), args... ) * (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -557,7 +557,7 @@ inline decltype(auto) pageslice( const TensScalarDivExpr<MT>& tensor, RRAs... ar
 {
    BLAZE_FUNCTION_TRACE;
 
-   return pageslice<CRAs...>( (~tensor).leftOperand(), args... ) / (~tensor).rightOperand();
+   return pageslice<CRAs...>( (*tensor).leftOperand(), args... ) / (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -582,7 +582,7 @@ inline decltype(auto) pageslice( const TensMapExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( pageslice<CRAs...>( (~tensor).operand(), args... ), (~tensor).operation() );
+   return map( pageslice<CRAs...>( (*tensor).operand(), args... ), (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -607,9 +607,9 @@ inline decltype(auto) pageslice( const TensTensMapExpr<MT>& tensor, RRAs... args
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( pageslice<CRAs...>( (~tensor).leftOperand(), args... ),
-               pageslice<CRAs...>( (~tensor).rightOperand(), args... ),
-               (~tensor).operation() );
+   return map( pageslice<CRAs...>( (*tensor).leftOperand(), args... ),
+               pageslice<CRAs...>( (*tensor).rightOperand(), args... ),
+               (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -634,7 +634,7 @@ inline decltype(auto) pageslice( const TensEvalExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return eval( pageslice<CRAs...>( (~tensor).operand(), args... ) );
+   return eval( pageslice<CRAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -659,7 +659,7 @@ inline decltype(auto) pageslice( const TensSerialExpr<MT>& tensor, RRAs... args 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return serial( pageslice<CRAs...>( (~tensor).operand(), args... ) );
+   return serial( pageslice<CRAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -684,7 +684,7 @@ inline decltype(auto) pageslice( const DeclExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return pageslice<CRAs...>( (~tensor).operand(), args... );
+   return pageslice<CRAs...>( (*tensor).operand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -713,7 +713,7 @@ inline decltype(auto) pageslice( const MatExpandExpr<MT,CEAs...>& tensor, RSAs..
 
    MAYBE_UNUSED( args... );
 
-   return submatrix( (~tensor).operand(), 0UL, 0UL, (~tensor).rows(), (~tensor).columns() );
+   return submatrix( (*tensor).operand(), 0UL, 0UL, (*tensor).rows(), (*tensor).columns() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -746,7 +746,7 @@ inline decltype(auto) row( const TensVecMultExpr<MT>& matrix, REAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans(pageslice<CEAs...>( (~matrix).leftOperand(), args... ) * (~matrix).rightOperand());
+   return trans(pageslice<CEAs...>( (*matrix).leftOperand(), args... ) * (*matrix).rightOperand());
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1083,10 +1083,10 @@ template< typename MT     // Type of the tensor
 BLAZE_ALWAYS_INLINE bool
    tryMult( const PageSlice<MT,CRAs...>& pageslice, size_t row, size_t col, size_t rows, size_t cols, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~pageslice).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( row + rows <= (~pageslice).rows(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( col <= (~pageslice).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( col + cols <= (~pageslice).columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( row <= (*pageslice).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( row + rows <= (*pageslice).rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( col <= (*pageslice).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( col + cols <= (*pageslice).columns(), "Invalid columns range size" );
 
    return tryMult( pageslice.operand(), row, col, pageslice.page(), rows, cols, 1UL, value );
 }
@@ -1145,10 +1145,10 @@ template< typename MT     // Type of the tensor
 BLAZE_ALWAYS_INLINE bool
    tryDiv( const PageSlice<MT,CRAs...>& pageslice, size_t row, size_t col, size_t rows, size_t cols, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~pageslice).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( row + rows <= (~pageslice).rows(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( col <= (~pageslice).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( col + cols <= (~pageslice).columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( row <= (*pageslice).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( row + rows <= (*pageslice).rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( col <= (*pageslice).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( col + cols <= (*pageslice).columns(), "Invalid columns range size" );
 
    return tryDiv( pageslice.operand(), row, col, pageslice.page(), rows, cols, 1UL, value );
 }
@@ -1178,11 +1178,11 @@ inline bool tryAssign( const PageSlice<MT,CRAs...>& lhs,
                        const Matrix<VT,false>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryAssign( lhs.operand(), ~rhs, i, j, lhs.page() );
+   return tryAssign( lhs.operand(), *rhs, i, j, lhs.page() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1210,11 +1210,11 @@ inline bool tryAddAssign( const PageSlice<MT,CRAs...>& lhs,
                           const Matrix<VT,false>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, i, j, lhs.page() );
+   return tryAddAssign( lhs.operand(), *rhs, i, j, lhs.page() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1242,11 +1242,11 @@ inline bool trySubAssign( const PageSlice<MT,CRAs...>& lhs,
                           const Matrix<VT,false>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return trySubAssign( lhs.operand(), ~rhs, i, j, lhs.page() );
+   return trySubAssign( lhs.operand(), *rhs, i, j, lhs.page() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1274,11 +1274,11 @@ inline bool tryMultAssign( const PageSlice<MT,CRAs...>& lhs,
                            const Vector<VT,true>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryMultAssign( lhs.operand(), ~rhs, i, j, lhs.page() );
+   return tryMultAssign( lhs.operand(), *rhs, i, j, lhs.page() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1306,11 +1306,11 @@ inline bool tryDivAssign( const PageSlice<MT,CRAs...>& lhs,
                           const Matrix<VT,false>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryDivAssign( lhs.operand(), ~rhs, i, j, lhs.page() );
+   return tryDivAssign( lhs.operand(), *rhs, i, j, lhs.page() );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/views/QuatSlice.h
+++ b/blaze_tensor/math/views/QuatSlice.h
@@ -116,7 +116,7 @@ inline decltype(auto) quatslice( Array<AT>& quaternion, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = QuatSlice_<AT,I>;
-   return ReturnType( ~quaternion, args... );
+   return ReturnType( *quaternion, args... );
 }
 //*************************************************************************************************
 
@@ -163,7 +163,7 @@ inline decltype(auto) quatslice( const Array<AT>& quaternion, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const QuatSlice_<const AT,I>;
-   return ReturnType( ~quaternion, args... );
+   return ReturnType( *quaternion, args... );
 }
 //*************************************************************************************************
 
@@ -190,7 +190,7 @@ inline decltype(auto) quatslice( Array<AT>&& quaternion, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = QuatSlice_<AT,I>;
-   return ReturnType( ~quaternion, args... );
+   return ReturnType( *quaternion, args... );
 }
 //*************************************************************************************************
 
@@ -236,7 +236,7 @@ inline decltype(auto) quatslice( Array<AT>& quaternion, size_t index, RRAs... ar
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = QuatSlice_<AT>;
-   return ReturnType( ~quaternion, index, args... );
+   return ReturnType( *quaternion, index, args... );
 }
 //*************************************************************************************************
 
@@ -282,7 +282,7 @@ inline decltype(auto) quatslice( const Array<AT>& quaternion, size_t index, RRAs
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const QuatSlice_<const AT>;
-   return ReturnType( ~quaternion, index, args... );
+   return ReturnType( *quaternion, index, args... );
 }
 //*************************************************************************************************
 
@@ -309,7 +309,7 @@ inline decltype(auto) quatslice( Array<AT>&& quaternion, size_t index, RRAs... a
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = QuatSlice_<AT>;
-   return ReturnType( ~quaternion, index, args... );
+   return ReturnType( *quaternion, index, args... );
 }
 //*************************************************************************************************
 
@@ -341,8 +341,8 @@ inline decltype(auto) quatslice( Array<AT>&& quaternion, size_t index, RRAs... a
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return quatslice<CRAs...>( (~quaternion).leftOperand(), args... ) +
-//          quatslice<CRAs...>( (~quaternion).rightOperand(), args... );
+//   return quatslice<CRAs...>( (*quaternion).leftOperand(), args... ) +
+//          quatslice<CRAs...>( (*quaternion).rightOperand(), args... );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -367,8 +367,8 @@ inline decltype(auto) quatslice( Array<AT>&& quaternion, size_t index, RRAs... a
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return quatslice<CRAs...>( (~quaternion).leftOperand(), args... ) -
-//          quatslice<CRAs...>( (~quaternion).rightOperand(), args... );
+//   return quatslice<CRAs...>( (*quaternion).leftOperand(), args... ) -
+//          quatslice<CRAs...>( (*quaternion).rightOperand(), args... );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -392,8 +392,8 @@ inline decltype(auto) quatslice( Array<AT>&& quaternion, size_t index, RRAs... a
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return quatslice<CRAs...>( (~quaternion).leftOperand(), args... ) *
-//          quatslice<CRAs...>( (~quaternion).rightOperand(), args... );
+//   return quatslice<CRAs...>( (*quaternion).leftOperand(), args... ) *
+//          quatslice<CRAs...>( (*quaternion).rightOperand(), args... );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -418,7 +418,7 @@ inline decltype(auto) quatslice( Array<AT>&& quaternion, size_t index, RRAs... a
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return quatslice<CRAs...>( (~quaternion).leftOperand(), args... ) * (~quaternion).rightOperand();
+//   return quatslice<CRAs...>( (*quaternion).leftOperand(), args... ) * (*quaternion).rightOperand();
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -446,12 +446,12 @@ inline decltype(auto) quatslice( Array<AT>&& quaternion, size_t index, RRAs... a
 //    MAYBE_UNUSED( args... );
 //
 //    if( !Contains_v< TypeList<RRAs...>, Unchecked > ) {
-//       if( (~quaternion).quatslices() <= I ) {
+//       if( (*quaternion).quatslices() <= I ) {
 //          BLAZE_THQUATSLICE_INVALID_ARGUMENT( "Invalid quatslice access index" );
 //       }
 //    }
 //
-//    return (~quaternion).leftOperand()[I] * (~quaternion).rightOperand();
+//    return (*quaternion).leftOperand()[I] * (*quaternion).rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -479,12 +479,12 @@ inline decltype(auto) quatslice( Array<AT>&& quaternion, size_t index, RRAs... a
 //    MAYBE_UNUSED( args... );
 //
 //    if( !Contains_v< TypeList<RRAs...>, Unchecked > ) {
-//       if( (~quaternion).quatslices() <= index ) {
+//       if( (*quaternion).quatslices() <= index ) {
 //          BLAZE_THQUATSLICE_INVALID_ARGUMENT( "Invalid quatslice access index" );
 //       }
 //    }
 //
-//    return (~quaternion).leftOperand()[index] * (~quaternion).rightOperand();
+//    return (*quaternion).leftOperand()[index] * (*quaternion).rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -509,7 +509,7 @@ inline decltype(auto) quatslice( const ArrScalarMultExpr<AT>& quaternion, RRAs..
 {
    BLAZE_FUNCTION_TRACE;
 
-   return quatslice<CRAs...>( (~quaternion).leftOperand(), args... ) * (~quaternion).rightOperand();
+   return quatslice<CRAs...>( (*quaternion).leftOperand(), args... ) * (*quaternion).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -534,7 +534,7 @@ inline decltype(auto) quatslice( const ArrScalarDivExpr<AT>& quaternion, RRAs...
 {
    BLAZE_FUNCTION_TRACE;
 
-   return quatslice<CRAs...>( (~quaternion).leftOperand(), args... ) / (~quaternion).rightOperand();
+   return quatslice<CRAs...>( (*quaternion).leftOperand(), args... ) / (*quaternion).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -559,7 +559,7 @@ inline decltype(auto) quatslice( const ArrMapExpr<AT>& quaternion, RRAs... args 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( quatslice<CRAs...>( (~quaternion).operand(), args... ), (~quaternion).operation() );
+   return map( quatslice<CRAs...>( (*quaternion).operand(), args... ), (*quaternion).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -584,9 +584,9 @@ inline decltype(auto) quatslice( const ArrArrMapExpr<AT>& quaternion, RRAs... ar
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( quatslice<CRAs...>( (~quaternion).leftOperand(), args... ),
-               quatslice<CRAs...>( (~quaternion).rightOperand(), args... ),
-               (~quaternion).operation() );
+   return map( quatslice<CRAs...>( (*quaternion).leftOperand(), args... ),
+               quatslice<CRAs...>( (*quaternion).rightOperand(), args... ),
+               (*quaternion).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -611,7 +611,7 @@ inline decltype(auto) quatslice( const ArrArrMapExpr<AT>& quaternion, RRAs... ar
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return eval( quatslice<CRAs...>( (~quaternion).operand(), args... ) );
+//   return eval( quatslice<CRAs...>( (*quaternion).operand(), args... ) );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -636,7 +636,7 @@ inline decltype(auto) quatslice( const ArrArrMapExpr<AT>& quaternion, RRAs... ar
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return serial( quatslice<CRAs...>( (~quaternion).operand(), args... ) );
+//   return serial( quatslice<CRAs...>( (*quaternion).operand(), args... ) );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -661,7 +661,7 @@ inline decltype(auto) quatslice( const ArrArrMapExpr<AT>& quaternion, RRAs... ar
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return quatslice<CRAs...>( (~quaternion).operand(), args... );
+//   return quatslice<CRAs...>( (*quaternion).operand(), args... );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -689,7 +689,7 @@ inline decltype(auto) quatslice( const ArrArrMapExpr<AT>& quaternion, RRAs... ar
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return quatslice<ML, MK, MI, MJ>( evaluate( ~quaternion ), index, args... );
+//   return quatslice<ML, MK, MI, MJ>( evaluate( *quaternion ), index, args... );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -713,7 +713,7 @@ inline decltype(auto) quatslice( const ArrArrMapExpr<AT>& quaternion, RRAs... ar
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return quatslice( evaluate( ~quaternion ), index, args... );
+//   return quatslice( evaluate( *quaternion ), index, args... );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -742,7 +742,7 @@ inline decltype(auto) quatslice( const ArrArrMapExpr<AT>& quaternion, RRAs... ar
 //
 //   MAYBE_UNUSED( args... );
 //
-//   return submatrix( (~quaternion).operand(), 0UL, 0UL, (~quaternion).rows(), (~quaternion).columns() );
+//   return submatrix( (*quaternion).operand(), 0UL, 0UL, (*quaternion).rows(), (*quaternion).columns() );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -775,7 +775,7 @@ inline decltype(auto) quatslice( const ArrArrMapExpr<AT>& quaternion, RRAs... ar
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return trans(quatslice<CEAs...>( (~matrix).leftOperand(), args... ) * (~matrix).rightOperand());
+//   return trans(quatslice<CEAs...>( (*matrix).leftOperand(), args... ) * (*matrix).rightOperand());
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -1118,12 +1118,12 @@ template< typename AT     // Type of the quaternion
 BLAZE_ALWAYS_INLINE bool
    tryMult( const QuatSlice<AT,CRAs...>& quatslice, size_t page, size_t row, size_t col, size_t pages, size_t rows, size_t cols, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( page <= (~quatslice).pages(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( page + pages <= (~quatslice).pages(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( row <= (~quatslice).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( row + rows <= (~quatslice).rows(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( col <= (~quatslice).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( col + cols <= (~quatslice).columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( page <= (*quatslice).pages(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( page + pages <= (*quatslice).pages(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( row <= (*quatslice).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( row + rows <= (*quatslice).rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( col <= (*quatslice).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( col + cols <= (*quatslice).columns(), "Invalid columns range size" );
 
    return true;
 }
@@ -1183,12 +1183,12 @@ template< typename AT     // Type of the quaternion
 BLAZE_ALWAYS_INLINE bool
    tryDiv( const QuatSlice<AT,CRAs...>& quatslice, size_t page, size_t row, size_t col, size_t pages, size_t rows, size_t cols, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( page <= (~quatslice).pages(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( page + pages <= (~quatslice).pages(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( row <= (~quatslice).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( row + rows <= (~quatslice).rows(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( col <= (~quatslice).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( col + cols <= (~quatslice).columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( page <= (*quatslice).pages(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( page + pages <= (*quatslice).pages(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( row <= (*quatslice).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( row + rows <= (*quatslice).rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( col <= (*quatslice).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( col + cols <= (*quatslice).columns(), "Invalid columns range size" );
 
    return true;
 }
@@ -1218,11 +1218,11 @@ inline bool tryAssign( const QuatSlice<AT,CRAs...>& lhs,
                        const Tensor<TT>& rhs, size_t k, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( k <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( k + (~rhs).pages() <= lhs.pages(), "Invalid page range size" );
+   BLAZE_INTERNAL_ASSERT( k + (*rhs).pages() <= lhs.pages(), "Invalid page range size" );
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
    return true;
 }
@@ -1252,11 +1252,11 @@ inline bool tryAddAssign( const QuatSlice<AT,CRAs...>& lhs,
                           const Tensor<TT>& rhs, size_t k, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( k <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( k + (~rhs).pages() <= lhs.pages(), "Invalid page range size" );
+   BLAZE_INTERNAL_ASSERT( k + (*rhs).pages() <= lhs.pages(), "Invalid page range size" );
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
    return true;
 }
@@ -1286,11 +1286,11 @@ inline bool trySubAssign( const QuatSlice<AT,CRAs...>& lhs,
                           const Tensor<TT>& rhs, size_t k, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( k <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( k + (~rhs).pages() <= lhs.pages(), "Invalid page range size" );
+   BLAZE_INTERNAL_ASSERT( k + (*rhs).pages() <= lhs.pages(), "Invalid page range size" );
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
    return true;
 }
@@ -1320,11 +1320,11 @@ inline bool tryMultAssign( const QuatSlice<AT,CRAs...>& lhs,
                            const Vector<VT,true>& rhs, size_t k, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( k <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( k + (~rhs).pages() <= lhs.pages(), "Invalid page range size" );
+   BLAZE_INTERNAL_ASSERT( k + (*rhs).pages() <= lhs.pages(), "Invalid page range size" );
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
    return true;
 }
@@ -1354,11 +1354,11 @@ inline bool tryDivAssign( const QuatSlice<AT,CRAs...>& lhs,
                           const Tensor<TT>& rhs, size_t k, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( k <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( k + (~rhs).pages() <= lhs.pages(), "Invalid page range size" );
+   BLAZE_INTERNAL_ASSERT( k + (*rhs).pages() <= lhs.pages(), "Invalid page range size" );
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
    return true;
 }

--- a/blaze_tensor/math/views/RowSlice.h
+++ b/blaze_tensor/math/views/RowSlice.h
@@ -114,7 +114,7 @@ inline decltype(auto) rowslice( Tensor<MT>& tensor, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = RowSlice_<MT,I>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -161,7 +161,7 @@ inline decltype(auto) rowslice( const Tensor<MT>& tensor, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const RowSlice_<const MT,I>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -188,7 +188,7 @@ inline decltype(auto) rowslice( Tensor<MT>&& tensor, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = RowSlice_<MT,I>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -234,7 +234,7 @@ inline decltype(auto) rowslice( Tensor<MT>& tensor, size_t index, RRAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = RowSlice_<MT>;
-   return ReturnType( ~tensor, index, args... );
+   return ReturnType( *tensor, index, args... );
 }
 //*************************************************************************************************
 
@@ -280,7 +280,7 @@ inline decltype(auto) rowslice( const Tensor<MT>& tensor, size_t index, RRAs... 
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const RowSlice_<const MT>;
-   return ReturnType( ~tensor, index, args... );
+   return ReturnType( *tensor, index, args... );
 }
 //*************************************************************************************************
 
@@ -307,7 +307,7 @@ inline decltype(auto) rowslice( Tensor<MT>&& tensor, size_t index, RRAs... args 
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = RowSlice_<MT>;
-   return ReturnType( ~tensor, index, args... );
+   return ReturnType( *tensor, index, args... );
 }
 //*************************************************************************************************
 
@@ -339,8 +339,8 @@ inline decltype(auto) rowslice( const TensTensAddExpr<MT>& tensor, RRAs... args 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return rowslice<CRAs...>( (~tensor).leftOperand(), args... ) +
-          rowslice<CRAs...>( (~tensor).rightOperand(), args... );
+   return rowslice<CRAs...>( (*tensor).leftOperand(), args... ) +
+          rowslice<CRAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -365,8 +365,8 @@ inline decltype(auto) rowslice( const TensTensSubExpr<MT>& tensor, RRAs... args 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return rowslice<CRAs...>( (~tensor).leftOperand(), args... ) -
-          rowslice<CRAs...>( (~tensor).rightOperand(), args... );
+   return rowslice<CRAs...>( (*tensor).leftOperand(), args... ) -
+          rowslice<CRAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -390,8 +390,8 @@ inline decltype(auto) rowslice( const SchurExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return rowslice<CRAs...>( (~tensor).leftOperand(), args... ) %
-          rowslice<CRAs...>( (~tensor).rightOperand(), args... );
+   return rowslice<CRAs...>( (*tensor).leftOperand(), args... ) %
+          rowslice<CRAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -415,8 +415,8 @@ inline decltype(auto) rowslice( const SchurExpr<MT>& tensor, RRAs... args )
 //{
 //   BLAZE_FUNCTION_TRACE;
 //
-//   return rowslice<CRAs...>( (~tensor).leftOperand(), args... ) %
-//          row<CRAs...>     ( (~tensor).rightOperand(), args... );
+//   return rowslice<CRAs...>( (*tensor).leftOperand(), args... ) %
+//          row<CRAs...>     ( (*tensor).rightOperand(), args... );
 //}
 /*! \endcond */
 //*************************************************************************************************
@@ -441,7 +441,7 @@ inline decltype(auto) rowslice( const TensTensMultExpr<MT>& tensor, RRAs... args
 {
    BLAZE_FUNCTION_TRACE;
 
-   return rowslice<CRAs...>( (~tensor).leftOperand(), args... ) * (~tensor).rightOperand();
+   return rowslice<CRAs...>( (*tensor).leftOperand(), args... ) * (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -469,12 +469,12 @@ inline decltype(auto) rowslice( const TensTensMultExpr<MT>& tensor, RRAs... args
 //    MAYBE_UNUSED( args... );
 //
 //    if( !Contains_v< TypeList<RRAs...>, Unchecked > ) {
-//       if( (~tensor).rowslices() <= I ) {
+//       if( (*tensor).rowslices() <= I ) {
 //          BLAZE_THROWSLICE_INVALID_ARGUMENT( "Invalid rowslice access index" );
 //       }
 //    }
 //
-//    return (~tensor).leftOperand()[I] * (~tensor).rightOperand();
+//    return (*tensor).leftOperand()[I] * (*tensor).rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -502,12 +502,12 @@ inline decltype(auto) rowslice( const TensTensMultExpr<MT>& tensor, RRAs... args
 //    MAYBE_UNUSED( args... );
 //
 //    if( !Contains_v< TypeList<RRAs...>, Unchecked > ) {
-//       if( (~tensor).rowslices() <= index ) {
+//       if( (*tensor).rowslices() <= index ) {
 //          BLAZE_THROWSLICE_INVALID_ARGUMENT( "Invalid rowslice access index" );
 //       }
 //    }
 //
-//    return (~tensor).leftOperand()[index] * (~tensor).rightOperand();
+//    return (*tensor).leftOperand()[index] * (*tensor).rightOperand();
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -532,7 +532,7 @@ inline decltype(auto) rowslice( const TensScalarMultExpr<MT>& tensor, RRAs... ar
 {
    BLAZE_FUNCTION_TRACE;
 
-   return rowslice<CRAs...>( (~tensor).leftOperand(), args... ) * (~tensor).rightOperand();
+   return rowslice<CRAs...>( (*tensor).leftOperand(), args... ) * (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -557,7 +557,7 @@ inline decltype(auto) rowslice( const TensScalarDivExpr<MT>& tensor, RRAs... arg
 {
    BLAZE_FUNCTION_TRACE;
 
-   return rowslice<CRAs...>( (~tensor).leftOperand(), args... ) / (~tensor).rightOperand();
+   return rowslice<CRAs...>( (*tensor).leftOperand(), args... ) / (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -582,7 +582,7 @@ inline decltype(auto) rowslice( const TensMapExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( rowslice<CRAs...>( (~tensor).operand(), args... ), (~tensor).operation() );
+   return map( rowslice<CRAs...>( (*tensor).operand(), args... ), (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -607,9 +607,9 @@ inline decltype(auto) rowslice( const TensTensMapExpr<MT>& tensor, RRAs... args 
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( rowslice<CRAs...>( (~tensor).leftOperand(), args... ),
-               rowslice<CRAs...>( (~tensor).rightOperand(), args... ),
-               (~tensor).operation() );
+   return map( rowslice<CRAs...>( (*tensor).leftOperand(), args... ),
+               rowslice<CRAs...>( (*tensor).rightOperand(), args... ),
+               (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -634,7 +634,7 @@ inline decltype(auto) rowslice( const TensEvalExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return eval( rowslice<CRAs...>( (~tensor).operand(), args... ) );
+   return eval( rowslice<CRAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -659,7 +659,7 @@ inline decltype(auto) rowslice( const TensSerialExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return serial( rowslice<CRAs...>( (~tensor).operand(), args... ) );
+   return serial( rowslice<CRAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -684,7 +684,7 @@ inline decltype(auto) rowslice( const DeclExpr<MT>& tensor, RRAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return rowslice<CRAs...>( (~tensor).operand(), args... );
+   return rowslice<CRAs...>( (*tensor).operand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -714,7 +714,7 @@ inline decltype(auto) rowslice( const MatExpandExpr<TT,CEAs...>& tensor, CSAs...
 
    MAYBE_UNUSED( args... );
 
-   return expand( trans( row( (~tensor).operand(), 0UL ) ), (~tensor).expansion() );
+   return expand( trans( row( (*tensor).operand(), 0UL ) ), (*tensor).expansion() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -746,7 +746,7 @@ inline decltype(auto) column( const TensVecMultExpr<MT>& matrix, REAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans(rowslice<CEAs...>( (~matrix).leftOperand(), args... )) * (~matrix).rightOperand();
+   return trans(rowslice<CEAs...>( (*matrix).leftOperand(), args... )) * (*matrix).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1083,10 +1083,10 @@ template< typename MT     // Type of the tensor
 BLAZE_ALWAYS_INLINE bool
    tryMult( const RowSlice<MT,CRAs...>& rowslice, size_t row, size_t col, size_t rows, size_t cols, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~rowslice).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( row + rows <= (~rowslice).rows(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( col <= (~rowslice).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( col + cols <= (~rowslice).columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( row <= (*rowslice).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( row + rows <= (*rowslice).rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( col <= (*rowslice).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( col + cols <= (*rowslice).columns(), "Invalid columns range size" );
 
    return tryMult( rowslice.operand(), rowslice.row(), col, row, 1UL, cols, rows, value );
 }
@@ -1145,10 +1145,10 @@ template< typename MT     // Type of the tensor
 BLAZE_ALWAYS_INLINE bool
    tryDiv( const RowSlice<MT,CRAs...>& rowslice, size_t row, size_t col, size_t rows, size_t cols, const ET& value )
 {
-   BLAZE_INTERNAL_ASSERT( row <= (~rowslice).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( row + rows <= (~rowslice).rows(), "Invalid rows range size" );
-   BLAZE_INTERNAL_ASSERT( col <= (~rowslice).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( col + cols <= (~rowslice).columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( row <= (*rowslice).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( row + rows <= (*rowslice).rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( col <= (*rowslice).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( col + cols <= (*rowslice).columns(), "Invalid columns range size" );
 
    return tryDiv( rowslice.operand(), rowslice.row(), col, row, 1UL, cols, rows, value );
 }
@@ -1178,11 +1178,11 @@ inline bool tryAssign( const RowSlice<MT,CRAs...>& lhs,
                        const Matrix<VT,columnMajor>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryAssign( lhs.operand(), ~rhs, lhs.row(), j, i );
+   return tryAssign( lhs.operand(), *rhs, lhs.row(), j, i );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1210,11 +1210,11 @@ inline bool tryAddAssign( const RowSlice<MT,CRAs...>& lhs,
                           const Matrix<VT,columnMajor>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, lhs.row(), j, i );
+   return tryAddAssign( lhs.operand(), *rhs, lhs.row(), j, i );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1242,11 +1242,11 @@ inline bool trySubAssign( const RowSlice<MT,CRAs...>& lhs,
                           const Matrix<VT,columnMajor>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return trySubAssign( lhs.operand(), ~rhs, lhs.row(), j, i );
+   return trySubAssign( lhs.operand(), *rhs, lhs.row(), j, i );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1274,11 +1274,11 @@ inline bool tryMultAssign( const RowSlice<MT,CRAs...>& lhs,
                            const Vector<VT,true>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryMultAssign( lhs.operand(), ~rhs, lhs.row(), j, i );
+   return tryMultAssign( lhs.operand(), *rhs, lhs.row(), j, i );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1306,11 +1306,11 @@ inline bool tryDivAssign( const RowSlice<MT,CRAs...>& lhs,
                           const Matrix<VT,columnMajor>& rhs, size_t i, size_t j )
 {
    BLAZE_INTERNAL_ASSERT( i <= lhs.rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( i + (~rhs).rows() <= lhs.rows(), "Invalid rows range size" );
+   BLAZE_INTERNAL_ASSERT( i + (*rhs).rows() <= lhs.rows(), "Invalid rows range size" );
    BLAZE_INTERNAL_ASSERT( j <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( j + (~rhs).columns() <= lhs.columns(), "Invalid columns range size" );
+   BLAZE_INTERNAL_ASSERT( j + (*rhs).columns() <= lhs.columns(), "Invalid columns range size" );
 
-   return tryDivAssign( lhs.operand(), ~rhs, lhs.row(), j, i );
+   return tryDivAssign( lhs.operand(), *rhs, lhs.row(), j, i );
 }
 /*! \endcond */
 //*************************************************************************************************

--- a/blaze_tensor/math/views/Subtensor.h
+++ b/blaze_tensor/math/views/Subtensor.h
@@ -177,7 +177,7 @@ inline decltype(auto) subtensor( Tensor<TT>& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<unaligned,K,I,J,O,M,N>( ~tensor, args... );
+   return subtensor<unaligned,K,I,J,O,M,N>( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -247,7 +247,7 @@ inline decltype(auto) subtensor( const Tensor<TT>& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<unaligned,K,I,J,O,M,N>( ~tensor, args... );
+   return subtensor<unaligned,K,I,J,O,M,N>( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -279,7 +279,7 @@ inline decltype(auto) subtensor( Tensor<TT>&& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<unaligned,K,I,J,O,M,N>( ~tensor, args... );
+   return subtensor<unaligned,K,I,J,O,M,N>( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -364,7 +364,7 @@ inline decltype(auto) subtensor( Tensor<TT>& tensor, RSAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = Subtensor_<TT,AF,K,I,J,O,M,N>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -447,7 +447,7 @@ inline decltype(auto) subtensor( const Tensor<TT>& tensor, RSAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const Subtensor_<const TT,AF,K,I,J,O,M,N>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -482,7 +482,7 @@ inline decltype(auto) subtensor( Tensor<TT>&& tensor, RSAs... args )
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = Subtensor_<TT,AF,K,I,J,O,M,N>;
-   return ReturnType( ~tensor, args... );
+   return ReturnType( *tensor, args... );
 }
 //*************************************************************************************************
 
@@ -552,7 +552,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<unaligned>( ~tensor, page, row, column, o, m, n, args... );
+   return subtensor<unaligned>( *tensor, page, row, column, o, m, n, args... );
 }
 //*************************************************************************************************
 
@@ -621,7 +621,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<unaligned>( ~tensor, page, row, column, o, m, n, args... );
+   return subtensor<unaligned>( *tensor, page, row, column, o, m, n, args... );
 }
 //*************************************************************************************************
 
@@ -652,7 +652,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<unaligned>( ~tensor, page, row, column, o, m, n, args... );
+   return subtensor<unaligned>( *tensor, page, row, column, o, m, n, args... );
 }
 //*************************************************************************************************
 
@@ -736,7 +736,7 @@ inline decltype(auto)
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = Subtensor_<TT,AF>;
-   return ReturnType( ~tensor, page, row, column, o, m, n, args... );
+   return ReturnType( *tensor, page, row, column, o, m, n, args... );
 }
 //*************************************************************************************************
 
@@ -818,7 +818,7 @@ inline decltype(auto)
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = const Subtensor_<const TT,AF>;
-   return ReturnType( ~tensor, page, row, column, o, m, n, args... );
+   return ReturnType( *tensor, page, row, column, o, m, n, args... );
 }
 //*************************************************************************************************
 
@@ -852,7 +852,7 @@ inline decltype(auto)
    BLAZE_FUNCTION_TRACE;
 
    using ReturnType = Subtensor_<TT,AF>;
-   return ReturnType( ~tensor, page, row, column, o, m, n, args... );
+   return ReturnType( *tensor, page, row, column, o, m, n, args... );
 }
 //*************************************************************************************************
 
@@ -885,8 +885,8 @@ inline decltype(auto) subtensor( const TensTensAddExpr<TT>& tensor, RSAs... args
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<AF,CSAs...>( (~tensor).leftOperand(), args... ) +
-          subtensor<AF,CSAs...>( (~tensor).rightOperand(), args... );
+   return subtensor<AF,CSAs...>( (*tensor).leftOperand(), args... ) +
+          subtensor<AF,CSAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -912,8 +912,8 @@ inline decltype(auto) subtensor( const TensTensSubExpr<TT>& tensor, RSAs... args
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<AF,CSAs...>( (~tensor).leftOperand(), args... ) -
-          subtensor<AF,CSAs...>( (~tensor).rightOperand(), args... );
+   return subtensor<AF,CSAs...>( (*tensor).leftOperand(), args... ) -
+          subtensor<AF,CSAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -939,8 +939,8 @@ inline decltype(auto) subtensor( const SchurExpr<TT>& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<AF,CSAs...>( (~tensor).leftOperand(), args... ) %
-          subtensor<AF,CSAs...>( (~tensor).rightOperand(), args... );
+   return subtensor<AF,CSAs...>( (*tensor).leftOperand(), args... ) %
+          subtensor<AF,CSAs...>( (*tensor).rightOperand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -968,8 +968,8 @@ inline decltype(auto) subtensor( const TensMatSchurExpr<TT>& tensor, RSAs... arg
 
    const SubtensorData<CSAs...> st( args... );
 
-   decltype(auto) left( (~tensor).leftOperand()  );
-   decltype(auto) right((~tensor).rightOperand() );
+   decltype(auto) left( (*tensor).leftOperand()  );
+   decltype(auto) right((*tensor).rightOperand() );
 
    return subtensor<AF>( left, st.page(), st.row(), st.column(), st.pages(), st.rows(), st.columns()) %
           submatrix<AF>( right, st.row(), st.column(), st.rows(), st.columns() );
@@ -1003,8 +1003,8 @@ inline decltype(auto) subtensor( const TensMatSchurExpr<TT>& tensor, RSAs... arg
 //
 //    const SubtensorData<CSAs...> sd( args... );
 //
-//    BLAZE_DECLTYPE_AUTO( left , (~tensor).leftOperand()  );
-//    BLAZE_DECLTYPE_AUTO( right, (~tensor).rightOperand() );
+//    BLAZE_DECLTYPE_AUTO( left , (*tensor).leftOperand()  );
+//    BLAZE_DECLTYPE_AUTO( right, (*tensor).rightOperand() );
 //
 //    const size_t begin( 0UL );
 //    const size_t end( left.columns() );
@@ -1040,8 +1040,8 @@ inline decltype(auto) subtensor( const TensMatSchurExpr<TT>& tensor, RSAs... arg
 // {
 //    BLAZE_FUNCTION_TRACE;
 //
-//    return subvector<AF,I,M>( (~tensor).leftOperand(), args... ) *
-//           subvector<AF,J,N>( (~tensor).rightOperand(), args... );
+//    return subvector<AF,I,M>( (*tensor).leftOperand(), args... ) *
+//           subvector<AF,J,N>( (*tensor).rightOperand(), args... );
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1070,8 +1070,8 @@ inline decltype(auto) subtensor( const TensMatSchurExpr<TT>& tensor, RSAs... arg
 // {
 //    BLAZE_FUNCTION_TRACE;
 //
-//    return subvector<AF>( (~tensor).leftOperand(), row, m, args... ) *
-//           subvector<AF>( (~tensor).rightOperand(), column, n, args... );
+//    return subvector<AF>( (*tensor).leftOperand(), row, m, args... ) *
+//           subvector<AF>( (*tensor).rightOperand(), column, n, args... );
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1097,7 +1097,7 @@ inline decltype(auto) subtensor( const TensScalarMultExpr<TT>& tensor, RSAs... a
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<AF,CSAs...>( (~tensor).leftOperand(), args... ) * (~tensor).rightOperand();
+   return subtensor<AF,CSAs...>( (*tensor).leftOperand(), args... ) * (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1123,7 +1123,7 @@ inline decltype(auto) subtensor( const TensScalarDivExpr<TT>& tensor, RSAs... ar
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<AF,CSAs...>( (~tensor).leftOperand(), args... ) / (~tensor).rightOperand();
+   return subtensor<AF,CSAs...>( (*tensor).leftOperand(), args... ) / (*tensor).rightOperand();
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1149,7 +1149,7 @@ inline decltype(auto) subtensor( const TensMapExpr<TT>& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( subtensor<AF,CSAs...>( (~tensor).operand(), args... ), (~tensor).operation() );
+   return map( subtensor<AF,CSAs...>( (*tensor).operand(), args... ), (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1175,9 +1175,9 @@ inline decltype(auto) subtensor( const TensTensMapExpr<TT>& tensor, RSAs... args
 {
    BLAZE_FUNCTION_TRACE;
 
-   return map( subtensor<AF,CSAs...>( (~tensor).leftOperand(), args... ),
-               subtensor<AF,CSAs...>( (~tensor).rightOperand(), args... ),
-               (~tensor).operation() );
+   return map( subtensor<AF,CSAs...>( (*tensor).leftOperand(), args... ),
+               subtensor<AF,CSAs...>( (*tensor).rightOperand(), args... ),
+               (*tensor).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1203,7 +1203,7 @@ inline decltype(auto) subtensor( const TensEvalExpr<TT>& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return eval( subtensor<AF,CSAs...>( (~tensor).operand(), args... ) );
+   return eval( subtensor<AF,CSAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1229,7 +1229,7 @@ inline decltype(auto) subtensor( const MatSerialExpr<TT>& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return serial( subtensor<AF,CSAs...>( (~tensor).operand(), args... ) );
+   return serial( subtensor<AF,CSAs...>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1255,7 +1255,7 @@ inline decltype(auto) subtensor( const DeclExpr<TT>& tensor, RSAs... args )
 {
    BLAZE_FUNCTION_TRACE;
 
-   return subtensor<AF,CSAs...>( (~tensor).operand(), args... );
+   return subtensor<AF,CSAs...>( (*tensor).operand(), args... );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1286,7 +1286,7 @@ inline decltype(auto) subtensor( const DeclExpr<TT>& tensor, RSAs... args )
 // {
 //    BLAZE_FUNCTION_TRACE;
 //
-//    return trans( subtensor<AF,K,I,J,O,M,N>( (~tensor).operand(), args... ), (~tensor).idces() );
+//    return trans( subtensor<AF,K,I,J,O,M,N>( (*tensor).operand(), args... ), (*tensor).idces() );
 // }
 /*! \endcond */
 //*************************************************************************************************
@@ -1316,7 +1316,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return trans( subtensor<AF>( (~tensor).operand(), page, column, row, n, m, o, args... ), (~tensor).idces() );
+   return trans( subtensor<AF>( (*tensor).operand(), page, column, row, n, m, o, args... ), (*tensor).idces() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1754,8 +1754,8 @@ inline decltype(auto) submatrix( const TensVecMultExpr<MT>& matrix, RSAs... args
 
    const SubmatrixData<CSAs...> sm( args... );
 
-   decltype(auto) left( (~matrix).leftOperand() );
-   decltype(auto) right( (~matrix).rightOperand() );
+   decltype(auto) left( (*matrix).leftOperand() );
+   decltype(auto) right( (*matrix).rightOperand() );
 
    const size_t column( 0UL );
    const size_t n( left.columns() );
@@ -1790,8 +1790,8 @@ inline decltype(auto) submatrix( const TensVecMultExpr<MT>& matrix, RSAs... args
 //
 //    const SubvectorData<CSAs...> sd( args... );
 //
-//    BLAZE_DECLTYPE_AUTO( left , (~vector).leftOperand()  );
-//    BLAZE_DECLTYPE_AUTO( right, (~vector).rightOperand() );
+//    BLAZE_DECLTYPE_AUTO( left , (*vector).leftOperand()  );
+//    BLAZE_DECLTYPE_AUTO( right, (*vector).rightOperand() );
 //
 //    const size_t row( ( IsLower_v<TT> )
 //                      ?( ( !AF && IsStrictlyLower_v<TT> )?( sd.offset() + 1UL ):( sd.offset() ) )
@@ -1831,10 +1831,10 @@ inline decltype(auto) submatrix( const TensReduceExpr<MT,columnwise>& matrix, RS
    BLAZE_FUNCTION_TRACE;
 
    const SubmatrixData<CSAs...> sm( args... );
-   const size_t O( (~matrix).operand().rows() );
+   const size_t O( (*matrix).operand().rows() );
 
-   decltype(auto) st( subtensor<AF>( (~matrix).operand(), 0UL, sm.row(), sm.column(), O, sm.rows(), sm.columns() ) );
-   return reduce<columnwise>( st, (~matrix).operation() );
+   decltype(auto) st( subtensor<AF>( (*matrix).operand(), 0UL, sm.row(), sm.column(), O, sm.rows(), sm.columns() ) );
+   return reduce<columnwise>( st, (*matrix).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1861,10 +1861,10 @@ inline decltype(auto) submatrix( const TensReduceExpr<MT,rowwise>& matrix, RSAs.
    BLAZE_FUNCTION_TRACE;
 
    const SubmatrixData<CSAs...> sm( args... );
-   const size_t N( (~matrix).operand().rows() );
+   const size_t N( (*matrix).operand().rows() );
 
-   decltype(auto) st( subtensor<AF>( (~matrix).operand(), sm.row(), sm.column(), 0UL, sm.rows(), sm.columns(), N ) );
-   return reduce<rowwise>( st, (~matrix).operation() );
+   decltype(auto) st( subtensor<AF>( (*matrix).operand(), sm.row(), sm.column(), 0UL, sm.rows(), sm.columns(), N ) );
+   return reduce<rowwise>( st, (*matrix).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -1891,10 +1891,10 @@ inline decltype(auto) submatrix( const TensReduceExpr<MT,pagewise>& matrix, RSAs
    BLAZE_FUNCTION_TRACE;
 
    const SubmatrixData<CSAs...> sm( args... );
-   const size_t M( (~matrix).operand().rows() );
+   const size_t M( (*matrix).operand().rows() );
 
-   decltype(auto) st( subtensor<AF>( (~matrix).operand(), sm.row(), 0UL, sm.column(), sm.rows(), M, sm.columns() ) );
-   return reduce<pagewise>( st, (~matrix).operation() );
+   decltype(auto) st( subtensor<AF>( (*matrix).operand(), sm.row(), 0UL, sm.column(), sm.rows(), M, sm.columns() ) );
+   return reduce<pagewise>( st, (*matrix).operation() );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4136,7 +4136,7 @@ inline decltype(auto) subtensor( const MatExpandExpr<TT,CEAs...>& tensor, RSAs..
 {
    BLAZE_FUNCTION_TRACE;
 
-   return expand<O>( submatrix<AF,I,J,M,N>( (~tensor).operand(), args... ) );
+   return expand<O>( submatrix<AF,I,J,M,N>( (*tensor).operand(), args... ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4170,7 +4170,7 @@ inline decltype(auto)
 {
    BLAZE_FUNCTION_TRACE;
 
-   return expand( submatrix( (~tensor).operand(), row, column, m, n, args... ), o );
+   return expand( submatrix( (*tensor).operand(), row, column, m, n, args... ), o );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4323,10 +4323,10 @@ inline bool isDefault( const Subtensor<TT,AF,CSAs...>& sm )
 {
    using blaze::isDefault;
 
-   for( size_t k=0UL; k<(~sm).pages(); ++k )
-      for( size_t i=0UL; i<(~sm).rows(); ++i )
-         for( size_t j=0UL; j<(~sm).columns(); ++j )
-            if( !isDefault<RF>( (~sm)(k,i,j) ) )
+   for( size_t k=0UL; k<(*sm).pages(); ++k )
+      for( size_t i=0UL; i<(*sm).rows(); ++i )
+         for( size_t j=0UL; j<(*sm).columns(); ++j )
+            if( !isDefault<RF>( (*sm)(k,i,j) ) )
                return false;
 
    return true;
@@ -4716,10 +4716,10 @@ template< typename TT       // Type of the tensor
         , size_t... CSAs >  // Compile time subtensor arguments
 inline bool isSame( const Subtensor<TT,AF,CSAs...>& a, const Tensor<TT>& b ) noexcept
 {
-   return ( isSame( a.operand(), ~b ) &&
-            ( a.rows() == (~b).rows() ) &&
-            ( a.columns() == (~b).columns() ) &&
-            ( a.pages() == (~b).pages() ) );
+   return ( isSame( a.operand(), *b ) &&
+            ( a.rows() == (*b).rows() ) &&
+            ( a.columns() == (*b).columns() ) &&
+            ( a.pages() == (*b).pages() ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4743,10 +4743,10 @@ template< typename TT       // Type of the tensor
         , size_t... CSAs >  // Compile time subtensor arguments
 inline bool isSame( const Tensor<TT>& a, const Subtensor<TT,AF,CSAs...>& b ) noexcept
 {
-   return ( isSame( ~a, b.operand() ) &&
-            ( (~a).rows() == b.rows() ) &&
-            ( (~a).columns() == b.columns() ) &&
-            ( (~a).pages() == b.pages() ) );
+   return ( isSame( *a, b.operand() ) &&
+            ( (*a).rows() == b.rows() ) &&
+            ( (*a).columns() == b.columns() ) &&
+            ( (*a).pages() == b.pages() ) );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -4997,12 +4997,12 @@ BLAZE_ALWAYS_INLINE bool
 {
    MAYBE_UNUSED( column );
 
-   BLAZE_INTERNAL_ASSERT( row <= (~sm).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~sm).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~sm).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + m <= (~sm).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + n <= (~sm).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + o <= (~sm).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*sm).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*sm).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*sm).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + m <= (*sm).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + n <= (*sm).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + o <= (*sm).pages(), "Invalid number of pages" );
 
    return tryMult( sm.operand(), sm.row()+row, sm.column(), sm.page(), m, n, o, value );
 }
@@ -5069,12 +5069,12 @@ BLAZE_ALWAYS_INLINE bool
 {
    MAYBE_UNUSED( column );
 
-   BLAZE_INTERNAL_ASSERT( row <= (~sm).rows(), "Invalid row access index" );
-   BLAZE_INTERNAL_ASSERT( column <= (~sm).columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( page <= (~sm).pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + m <= (~sm).rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + n <= (~sm).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + o <= (~sm).pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row <= (*sm).rows(), "Invalid row access index" );
+   BLAZE_INTERNAL_ASSERT( column <= (*sm).columns(), "Invalid column access index" );
+   BLAZE_INTERNAL_ASSERT( page <= (*sm).pages(), "Invalid page access index" );
+   BLAZE_INTERNAL_ASSERT( row + m <= (*sm).rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + n <= (*sm).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + o <= (*sm).pages(), "Invalid number of pages" );
 
    return tryDiv( sm.operand(), sm.row()+row, sm.column(), sm.page(), m, n, o, value );
 }
@@ -5108,10 +5108,10 @@ inline bool tryAssign( const Subtensor<TT,AF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAssign( lhs.operand(), ~rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
+   return tryAssign( lhs.operand(), *rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5144,10 +5144,10 @@ inline bool tryAssign( const Subtensor<TT,AF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                      lhs.row() + row, lhs.column() + column, lhs.page() + page );
 }
 /*! \endcond */
@@ -5180,11 +5180,11 @@ inline bool tryAssign( const Subtensor<TT1,AF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + (~rhs).pages() <= lhs.pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + (*rhs).pages() <= lhs.pages(), "Invalid number of pages" );
 
-   return tryAssign( lhs.operand(), ~rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
+   return tryAssign( lhs.operand(), *rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5216,10 +5216,10 @@ inline bool tryAddAssign( const Subtensor<TT,AF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
+   return tryAddAssign( lhs.operand(), *rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5253,10 +5253,10 @@ inline bool tryAddAssign( const Subtensor<TT,AF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryAddAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                         lhs.row() + row, lhs.column() + column, lhs.page() + page );
 }
 /*! \endcond */
@@ -5289,11 +5289,11 @@ inline bool tryAddAssign( const Subtensor<TT1,AF,CSAs...>& lhs,
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
    BLAZE_INTERNAL_ASSERT( page <= lhs.pages(), "Invalid page access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( page + (~rhs).pages() <= lhs.pages(), "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( page + (*rhs).pages() <= lhs.pages(), "Invalid number of pages" );
 
-   return tryAddAssign( lhs.operand(), ~rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
+   return tryAddAssign( lhs.operand(), *rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5326,10 +5326,10 @@ inline bool trySubAssign( const Subtensor<TT,AF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( TF || ( row + (~rhs).size() <= lhs.rows() ), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( !TF || ( column + (~rhs).size() <= lhs.columns() ), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( TF || ( row + (*rhs).size() <= lhs.rows() ), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( !TF || ( column + (*rhs).size() <= lhs.columns() ), "Invalid number of columns" );
 
-   return trySubAssign( lhs.operand(), ~rhs, lhs.row() + row, lhs.column() + column );
+   return trySubAssign( lhs.operand(), *rhs, lhs.row() + row, lhs.column() + column );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5365,10 +5365,10 @@ inline bool trySubAssign( const Subtensor<TT,AF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 
-   return trySubAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return trySubAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                         lhs.row() + row, lhs.column() + column );
 }
 /*! \endcond */
@@ -5401,10 +5401,10 @@ inline bool trySubAssign( const Subtensor<TT1,AF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return trySubAssign( lhs.operand(), ~rhs, lhs.row() + row, lhs.column() + column );
+   return trySubAssign( lhs.operand(), *rhs, lhs.row() + row, lhs.column() + column );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5436,10 +5436,10 @@ inline bool tryMultAssign( const Subtensor<TT,AF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( TF || ( row + (~rhs).size() <= lhs.rows() ), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( !TF || ( column + (~rhs).size() <= lhs.columns() ), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( TF || ( row + (*rhs).size() <= lhs.rows() ), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( !TF || ( column + (*rhs).size() <= lhs.columns() ), "Invalid number of columns" );
 
-   return tryMultAssign( lhs.operand(), ~rhs, lhs.row() + row, lhs.column() + column );
+   return tryMultAssign( lhs.operand(), *rhs, lhs.row() + row, lhs.column() + column );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5473,10 +5473,10 @@ inline bool tryMultAssign( const Subtensor<TT,AF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryMultAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryMultAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                          lhs.row() + row, lhs.column() + column );
 }
 /*! \endcond */
@@ -5508,10 +5508,10 @@ inline bool trySchurAssign( const Subtensor<TT1,AF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).rows() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).columns() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).rows() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).columns() <= lhs.columns(), "Invalid number of columns" );
 
-   return trySchurAssign( lhs.operand(), ~rhs, lhs.row() + row, lhs.column() + column );
+   return trySchurAssign( lhs.operand(), *rhs, lhs.row() + row, lhs.column() + column );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5542,10 +5542,10 @@ inline bool tryDivAssign( const Subtensor<TT,AF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryDivAssign( lhs.operand(), ~rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
+   return tryDivAssign( lhs.operand(), *rhs, lhs.row() + row, lhs.column() + column, lhs.page() + page );
 }
 /*! \endcond */
 //*************************************************************************************************
@@ -5578,10 +5578,10 @@ inline bool tryDivAssign( const Subtensor<TT,AF,CSAs...>& lhs,
 {
    BLAZE_INTERNAL_ASSERT( row <= lhs.rows(), "Invalid row access index" );
    BLAZE_INTERNAL_ASSERT( column <= lhs.columns(), "Invalid column access index" );
-   BLAZE_INTERNAL_ASSERT( row + (~rhs).size() <= lhs.rows(), "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( column + (~rhs).size() <= lhs.columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( row + (*rhs).size() <= lhs.rows(), "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( column + (*rhs).size() <= lhs.columns(), "Invalid number of columns" );
 
-   return tryDivAssign( lhs.operand(), ~rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
+   return tryDivAssign( lhs.operand(), *rhs, band + ptrdiff_t( lhs.column() - lhs.row() ),
                         lhs.row() + row, lhs.column() + column, lhs.page() + page );
 }
 /*! \endcond */

--- a/blaze_tensor/math/views/columnslice/Dense.h
+++ b/blaze_tensor/math/views/columnslice/Dense.h
@@ -1123,12 +1123,12 @@ inline ColumnSlice<MT,CRAs...>&
    //BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType_t<VT> );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType_t<VT> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<VT>, const VT& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAssign( tensor_, right, 0UL, column(), 0UL ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1176,12 +1176,12 @@ inline ColumnSlice<MT,CRAs...>&
    //BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType_t<VT> );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType_t<VT> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<VT>, const VT& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAddAssign( tensor_, right, 0UL, column(), 0UL ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1229,12 +1229,12 @@ inline ColumnSlice<MT,CRAs...>&
    //BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType_t<VT> );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType_t<VT> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<VT>, const VT& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !trySubAssign( tensor_, right, 0UL, column(), 0UL ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1286,22 +1286,22 @@ inline ColumnSlice<MT,CRAs...>&
 
    using SchurType = SchurTrait_t< ResultType, ResultType_t<VT> >;
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   if( !trySchurAssign( tensor_, (~rhs), 0UL, column(), 0UL ) ) {
+   if( !trySchurAssign( tensor_, (*rhs), 0UL, column(), 0UL ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( IsReference_v<MT> && (~rhs).canAlias( &tensor_ ) ) {
-      const SchurType tmp( *this % (~rhs) );
+   if( IsReference_v<MT> && (*rhs).canAlias( &tensor_ ) ) {
+      const SchurType tmp( *this % (*rhs) );
       smpSchurAssign( left, tmp );
    }
    else {
-      smpSchurAssign( left, ~rhs );
+      smpSchurAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1715,12 +1715,12 @@ template< typename VT       // Type of the right-hand side dense matrix
         , bool SO >         // Storage order
 inline auto ColumnSlice<MT,CRAs...>::assign( const DenseMatrix<VT,SO>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows() == (~rhs).rows(), "Invalid matrix sizes" );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid matrix sizes" );
+   BLAZE_INTERNAL_ASSERT( rows() == (*rhs).rows(), "Invalid matrix sizes" );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid matrix sizes" );
 
-   for( size_t k = 0UL; k < (~rhs).rows(); ++k ) {
-      for( size_t i=0UL; i<(~rhs).columns(); ++i ) {
-         tensor_(k,i,column()) = (~rhs)(k,i);
+   for( size_t k = 0UL; k < (*rhs).rows(); ++k ) {
+      for( size_t i=0UL; i<(*rhs).columns(); ++i ) {
+         tensor_(k,i,column()) = (*rhs)(k,i);
       }
    }
 }
@@ -1746,12 +1746,12 @@ template< typename VT       // Type of the right-hand side dense matrix
         , bool SO >         // Storage order
 inline auto ColumnSlice<MT,CRAs...>::addAssign( const DenseMatrix<VT,SO>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
-   for( size_t k = 0UL; k < (~rhs).rows(); ++k ) {
-      for( size_t i=0UL; i<(~rhs).columns(); ++i ) {
-         tensor_(k,i,column()) += (~rhs)(k,i);
+   for( size_t k = 0UL; k < (*rhs).rows(); ++k ) {
+      for( size_t i=0UL; i<(*rhs).columns(); ++i ) {
+         tensor_(k,i,column()) += (*rhs)(k,i);
       }
    }
 }
@@ -1777,12 +1777,12 @@ template< typename VT       // Type of the right-hand side dense matrix
         , bool SO >         // Storage order
 inline auto ColumnSlice<MT,CRAs...>::subAssign( const DenseMatrix<VT,SO>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
-   for( size_t k = 0UL; k < (~rhs).rows(); ++k ) {
-      for( size_t i=0UL; i<(~rhs).columns(); ++i ) {
-         tensor_(k,i,column()) -= (~rhs)(k,i);
+   for( size_t k = 0UL; k < (*rhs).rows(); ++k ) {
+      for( size_t i=0UL; i<(*rhs).columns(); ++i ) {
+         tensor_(k,i,column()) -= (*rhs)(k,i);
       }
    }
 }
@@ -1808,12 +1808,12 @@ template< typename MT2      // Type of the right-hand side dense matrix
         , bool SO >         // Storage order
 inline auto ColumnSlice<MT,CRAs...>::schurAssign( const DenseMatrix<MT2,SO>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
-   for( size_t k = 0UL; k < (~rhs).rows(); ++k ) {
-      for( size_t i=0UL; i<(~rhs).columns(); ++i ) {
-         tensor_(k,i,column()) *= (~rhs)(k,i);
+   for( size_t k = 0UL; k < (*rhs).rows(); ++k ) {
+      for( size_t i=0UL; i<(*rhs).columns(); ++i ) {
+         tensor_(k,i,column()) *= (*rhs)(k,i);
       }
    }
 }

--- a/blaze_tensor/math/views/dilatedsubmatrix/Dense.h
+++ b/blaze_tensor/math/views/dilatedsubmatrix/Dense.h
@@ -1239,12 +1239,12 @@ inline DilatedSubmatrix<MT,false,true,CSAs...>&
 {
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<MT2> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<MT2>, const MT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAssign( matrix_, right, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
@@ -1302,23 +1302,23 @@ inline auto DilatedSubmatrix<MT,false,true,CSAs...>::operator+=( const Matrix<MT
    BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   if( !tryAddAssign( matrix_, ~rhs, row(), column() ) ) {
+   if( !tryAddAssign( matrix_, *rhs, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
    if( ( ( IsSymmetric_v<MT> || IsHermitian_v<MT> ) && hasOverlap() ) ||
-       (~rhs).canAlias( &matrix_ ) ) {
-      const AddType tmp( *this + (~rhs) );
+       (*rhs).canAlias( &matrix_ ) ) {
+      const AddType tmp( *this + (*rhs) );
       smpAssign( left, tmp );
    }
    else {
-      smpAddAssign( left, ~rhs );
+      smpAddAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( matrix_ ), "Invariant violation detected" );
@@ -1359,11 +1359,11 @@ inline auto DilatedSubmatrix<MT,false,true,CSAs...>::operator+=( const Matrix<MT
    BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   const AddType tmp( *this + (~rhs) );
+   const AddType tmp( *this + (*rhs) );
 
    if( !tryAssign( matrix_, tmp, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
@@ -1411,23 +1411,23 @@ inline auto DilatedSubmatrix<MT,false,true,CSAs...>::operator-=( const Matrix<MT
    BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   if( !trySubAssign( matrix_, ~rhs, row(), column() ) ) {
+   if( !trySubAssign( matrix_, *rhs, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
    if( ( ( IsSymmetric_v<MT> || IsHermitian_v<MT> ) && hasOverlap() ) ||
-       (~rhs).canAlias( &matrix_ ) ) {
-      const SubType tmp( *this - (~rhs ) );
+       (*rhs).canAlias( &matrix_ ) ) {
+      const SubType tmp( *this - (*rhs ) );
       smpAssign( left, tmp );
    }
    else {
-      smpSubAssign( left, ~rhs );
+      smpSubAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( matrix_ ), "Invariant violation detected" );
@@ -1468,11 +1468,11 @@ inline auto DilatedSubmatrix<MT,false,true,CSAs...>::operator-=( const Matrix<MT
    BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   const SubType tmp( *this - (~rhs) );
+   const SubType tmp( *this - (*rhs) );
 
    if( !tryAssign( matrix_, tmp, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
@@ -1519,25 +1519,25 @@ inline auto DilatedSubmatrix<MT,false,true,CSAs...>::operator%=( const Matrix<MT
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   if( !trySchurAssign( matrix_, ~rhs, row(), column() ) ) {
+   if( !trySchurAssign( matrix_, *rhs, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
    if( ( ( IsSymmetric_v<MT> || IsHermitian_v<MT> ) && hasOverlap() ) ||
-       (~rhs).canAlias( &matrix_ ) ) {
-      const SchurType tmp( *this % (~rhs) );
+       (*rhs).canAlias( &matrix_ ) ) {
+      const SchurType tmp( *this % (*rhs) );
       if( IsSparseMatrix_v<SchurType> )
          reset();
       smpAssign( left, tmp );
    }
    else {
-      smpSchurAssign( left, ~rhs );
+      smpSchurAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( matrix_ ), "Invariant violation detected" );
@@ -1577,11 +1577,11 @@ inline auto DilatedSubmatrix<MT,false,true,CSAs...>::operator%=( const Matrix<MT
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   const SchurType tmp( *this % (~rhs) );
+   const SchurType tmp( *this % (*rhs) );
 
    if( !tryAssign( matrix_, tmp, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
@@ -2141,19 +2141,19 @@ template< typename MT       // Type of the dense matrix
 template< typename MT2 >    // Type of the right-hand side dense matrix
 inline void DilatedSubmatrix<MT,false,true,CSAs...>::assign( const DenseMatrix<MT2,false>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
 
    for( size_t i=0UL; i<rows(); ++i ) {
       for( size_t j=0UL; j<jpos; j+=2UL ) {
-         (*this)(i,j    ) = (~rhs)(i,j    );
-         (*this)(i,j+1UL) = (~rhs)(i,j+1UL);
+         (*this)(i,j    ) = (*rhs)(i,j    );
+         (*this)(i,j+1UL) = (*rhs)(i,j+1UL);
       }
       if( jpos < columns() ) {
-         (*this)(i,jpos) = (~rhs)(i,jpos);
+         (*this)(i,jpos) = (*rhs)(i,jpos);
       }
    }
 }
@@ -2179,8 +2179,8 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::assign( const DenseMatrix<M
 {
    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    constexpr size_t block( BLOCK_SIZE );
 
@@ -2190,7 +2190,7 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::assign( const DenseMatrix<M
          const size_t jend( ( columns()<(jj+block) )?( columns() ):( jj+block ) );
          for( size_t i=ii; i<iend; i++ ) {
             for( size_t j=jj; j<jend; j++) {
-               (*this)(i,j) = (~rhs)(i,j);
+               (*this)(i,j) = (*rhs)(i,j);
             }
          }
       }
@@ -2217,8 +2217,8 @@ template< typename MT       // Type of the dense matrix
 template< typename MT2 >    // Type of the right-hand side dense matrix
 inline void DilatedSubmatrix<MT,false,true,CSAs...>::addAssign( const DenseMatrix<MT2,false>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2226,15 +2226,15 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::addAssign( const DenseMatri
    for( size_t i=0UL; i<rows(); ++i )
    {
       if( IsDiagonal_v<MT2> ) {
-         (*this)(i,i) += (~rhs)(i,i);
+         (*this)(i,i) += (*rhs)(i,i);
       }
       else {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            (*this)(i,j    ) += (~rhs)(i,j    );
-            (*this)(i,j+1UL) += (~rhs)(i,j+1UL);
+            (*this)(i,j    ) += (*rhs)(i,j    );
+            (*this)(i,j+1UL) += (*rhs)(i,j+1UL);
          }
          if( jpos < columns() ) {
-            (*this)(i,jpos) += (~rhs)(i,jpos);
+            (*this)(i,jpos) += (*rhs)(i,jpos);
          }
       }
    }
@@ -2262,8 +2262,8 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::addAssign( const DenseMatri
 {
    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    constexpr size_t block( BLOCK_SIZE );
 
@@ -2273,7 +2273,7 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::addAssign( const DenseMatri
          const size_t jend( ( columns()<(jj+block) )?( columns() ):( jj+block ) );
          for( size_t i=ii; i<iend; i++ ) {
             for( size_t j=jj; j<jend; j++ ) {
-               (*this)(i,j) += (~rhs)(i,j);
+               (*this)(i,j) += (*rhs)(i,j);
             }
          }
       }
@@ -2300,8 +2300,8 @@ template< typename MT       // Type of the dense matrix
 template< typename MT2 >    // Type of the right-hand side dense matrix
 inline void DilatedSubmatrix<MT,false,true,CSAs...>::subAssign( const DenseMatrix<MT2,false>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2309,15 +2309,15 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::subAssign( const DenseMatri
    for( size_t i=0UL; i<rows(); ++i )
    {
       if( IsDiagonal_v<MT2> ) {
-         (*this)(i,i) -= (~rhs)(i,i);
+         (*this)(i,i) -= (*rhs)(i,i);
       }
       else {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            (*this)(i,j    ) -= (~rhs)(i,j    );
-            (*this)(i,j+1UL) -= (~rhs)(i,j+1UL);
+            (*this)(i,j    ) -= (*rhs)(i,j    );
+            (*this)(i,j+1UL) -= (*rhs)(i,j+1UL);
          }
          if( jpos < columns() ) {
-            (*this)(i,jpos) -= (~rhs)(i,jpos);
+            (*this)(i,jpos) -= (*rhs)(i,jpos);
          }
       }
    }
@@ -2345,8 +2345,8 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::subAssign( const DenseMatri
 {
    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    constexpr size_t block( BLOCK_SIZE );
 
@@ -2356,7 +2356,7 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::subAssign( const DenseMatri
          const size_t jend( ( columns()<(jj+block) )?( columns() ):( jj+block ) );
          for( size_t i=ii; i<iend; i++ ) {
             for( size_t j=jj; j<jend; j++ ) {
-               (*this)(i,j) -= (~rhs)(i,j);
+               (*this)(i,j) -= (*rhs)(i,j);
             }
          }
       }
@@ -2383,19 +2383,19 @@ template< typename MT       // Type of the dense matrix
 template< typename MT2 >    // Type of the right-hand side dense matrix
 inline void DilatedSubmatrix<MT,false,true,CSAs...>::schurAssign( const DenseMatrix<MT2,false>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
 
    for( size_t i=0UL; i<rows(); ++i ) {
       for( size_t j=0UL; j<jpos; j+=2UL ) {
-         (*this)(i,j    ) *= (~rhs)(i,j    );
-         (*this)(i,j+1UL) *= (~rhs)(i,j+1UL);
+         (*this)(i,j    ) *= (*rhs)(i,j    );
+         (*this)(i,j+1UL) *= (*rhs)(i,j+1UL);
       }
       if( jpos < columns() ) {
-         (*this)(i,jpos) *= (~rhs)(i,jpos);
+         (*this)(i,jpos) *= (*rhs)(i,jpos);
       }
    }
 }
@@ -2422,8 +2422,8 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::schurAssign( const DenseMat
 {
    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    constexpr size_t block( BLOCK_SIZE );
 
@@ -2433,7 +2433,7 @@ inline void DilatedSubmatrix<MT,false,true,CSAs...>::schurAssign( const DenseMat
          const size_t jend( ( columns()<(jj+block) )?( columns() ):( jj+block ) );
          for( size_t i=ii; i<iend; i++ ) {
             for( size_t j=jj; j<jend; j++ ) {
-               (*this)(i,j) *= (~rhs)(i,j);
+               (*this)(i,j) *= (*rhs)(i,j);
             }
          }
       }
@@ -3546,12 +3546,12 @@ inline DilatedSubmatrix<MT,true,true,CSAs...>&
 {
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<MT2> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<MT2>, const MT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAssign( matrix_, right, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
@@ -3609,23 +3609,23 @@ inline auto DilatedSubmatrix<MT,true,true,CSAs...>::operator+=( const Matrix<MT2
    BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   if( !tryAddAssign( matrix_, ~rhs, row(), column() ) ) {
+   if( !tryAddAssign( matrix_, *rhs, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
    if( ( ( IsSymmetric_v<MT> || IsHermitian_v<MT> ) && hasOverlap() ) ||
-       (~rhs).canAlias( &matrix_ ) ) {
-      const AddType tmp( *this + (~rhs) );
+       (*rhs).canAlias( &matrix_ ) ) {
+      const AddType tmp( *this + (*rhs) );
       smpAssign( left, tmp );
    }
    else {
-      smpAddAssign( left, ~rhs );
+      smpAddAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( matrix_ ), "Invariant violation detected" );
@@ -3666,11 +3666,11 @@ inline auto DilatedSubmatrix<MT,true,true,CSAs...>::operator+=( const Matrix<MT2
    BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   const AddType tmp( *this + (~rhs) );
+   const AddType tmp( *this + (*rhs) );
 
    if( !tryAssign( matrix_, tmp, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
@@ -3718,23 +3718,23 @@ inline auto DilatedSubmatrix<MT,true,true,CSAs...>::operator-=( const Matrix<MT2
    BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   if( !trySubAssign( matrix_, ~rhs, row(), column() ) ) {
+   if( !trySubAssign( matrix_, *rhs, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
    if( ( ( IsSymmetric_v<MT> || IsHermitian_v<MT> ) && hasOverlap() ) ||
-       (~rhs).canAlias( &matrix_ ) ) {
-      const SubType tmp( *this - (~rhs ) );
+       (*rhs).canAlias( &matrix_ ) ) {
+      const SubType tmp( *this - (*rhs ) );
       smpAssign( left, tmp );
    }
    else {
-      smpSubAssign( left, ~rhs );
+      smpSubAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( matrix_ ), "Invariant violation detected" );
@@ -3775,11 +3775,11 @@ inline auto DilatedSubmatrix<MT,true,true,CSAs...>::operator-=( const Matrix<MT2
    BLAZE_CONSTRAINT_MUST_BE_DENSE_MATRIX_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   const SubType tmp( *this - (~rhs) );
+   const SubType tmp( *this - (*rhs) );
 
    if( !tryAssign( matrix_, tmp, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
@@ -3826,25 +3826,25 @@ inline auto DilatedSubmatrix<MT,true,true,CSAs...>::operator%=( const Matrix<MT2
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   if( !trySchurAssign( matrix_, ~rhs, row(), column() ) ) {
+   if( !trySchurAssign( matrix_, *rhs, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
    if( ( ( IsSymmetric_v<MT> || IsHermitian_v<MT> ) && hasOverlap() ) ||
-       (~rhs).canAlias( &matrix_ ) ) {
-      const SchurType tmp( *this % (~rhs) );
+       (*rhs).canAlias( &matrix_ ) ) {
+      const SchurType tmp( *this % (*rhs) );
       if( IsSparseMatrix_v<SchurType> )
          reset();
       smpAssign( left, tmp );
    }
    else {
-      smpSchurAssign( left, ~rhs );
+      smpSchurAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( matrix_ ), "Invariant violation detected" );
@@ -3884,11 +3884,11 @@ inline auto DilatedSubmatrix<MT,true,true,CSAs...>::operator%=( const Matrix<MT2
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   const SchurType tmp( *this % (~rhs) );
+   const SchurType tmp( *this % (*rhs) );
 
    if( !tryAssign( matrix_, tmp, row(), column() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted matrix" );
@@ -4434,19 +4434,19 @@ template< typename MT2 >    // Type of the right-hand side dense matrix
 inline void DilatedSubmatrix<MT,true,true,CSAs...>::assign( const DenseMatrix<MT2,true>& rhs )
 
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    const size_t ipos( rows() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( rows() - ( rows() % 2UL ) ) == ipos, "Invalid end calculation" );
 
    for( size_t j=0UL; j<columns(); ++j ) {
       for( size_t i=0UL; i<ipos; i+=2UL ) {
-         (*this)(i    ,j) = (~rhs)(i    ,j);
-         (*this)(i+1UL,j) = (~rhs)(i+1UL,j);
+         (*this)(i    ,j) = (*rhs)(i    ,j);
+         (*this)(i+1UL,j) = (*rhs)(i+1UL,j);
       }
       if( ipos < rows() ) {
-         (*this)(ipos,j) = (~rhs)(ipos,j);
+         (*this)(ipos,j) = (*rhs)(ipos,j);
       }
    }
 }
@@ -4473,8 +4473,8 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::assign( const DenseMatrix<MT
 {
    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    constexpr size_t block( BLOCK_SIZE );
 
@@ -4484,7 +4484,7 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::assign( const DenseMatrix<MT
          const size_t iend( ( rows()<(ii+block) )?( rows() ):( ii+block ) );
          for( size_t j=jj; j<jend; j++ ) {
             for( size_t i=ii; i<iend; i++ ) {
-               (*this)(i,j) = (~rhs)(i,j);
+               (*this)(i,j) = (*rhs)(i,j);
             }
          }
       }
@@ -4513,11 +4513,11 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::assign( const DenseMatrix<MT
 //{
 //   BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 //
-//   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-//   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+//   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 //
 //   for( size_t i=0UL; i<rows(); ++i )
-//      for( ConstIterator_t<MT2> element=(~rhs).begin(i); element!=(~rhs).end(i); ++element )
+//      for( ConstIterator_t<MT2> element=(*rhs).begin(i); element!=(*rhs).end(i); ++element )
 //         matrix_(row()+i,column()+element->index()) = element->value();
 //}
 ///*! \endcond */
@@ -4541,8 +4541,8 @@ template< typename MT       // Type of the dense matrix
 template< typename MT2 >    // Type of the right-hand side dense matrix
 inline void DilatedSubmatrix<MT,true,true,CSAs...>::addAssign( const DenseMatrix<MT2,true>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    const size_t ipos( rows() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( rows() - ( rows() % 2UL ) ) == ipos, "Invalid end calculation" );
@@ -4550,15 +4550,15 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::addAssign( const DenseMatrix
    for( size_t j=0UL; j<columns(); ++j )
    {
       if( IsDiagonal_v<MT2> ) {
-         (*this)(j,j) += (~rhs)(j,j);
+         (*this)(j,j) += (*rhs)(j,j);
       }
       else {
          for( size_t i=0UL; i<ipos; i+=2UL ) {
-            (*this)(i    ,j) += (~rhs)(i    ,j);
-            (*this)(i+1UL,j) += (~rhs)(i+1UL,j);
+            (*this)(i    ,j) += (*rhs)(i    ,j);
+            (*this)(i+1UL,j) += (*rhs)(i+1UL,j);
          }
          if( ipos < rows() ) {
-            (*this)(ipos,j) += (~rhs)(ipos,j);
+            (*this)(ipos,j) += (*rhs)(ipos,j);
          }
       }
    }
@@ -4586,8 +4586,8 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::addAssign( const DenseMatrix
 {
    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    constexpr size_t block( BLOCK_SIZE );
 
@@ -4597,7 +4597,7 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::addAssign( const DenseMatrix
          const size_t iend( ( rows()<(ii+block) )?( rows() ):( ii+block ) );
          for( size_t j=jj; j<jend; j++ ) {
             for( size_t i=ii; i<iend; i++ ) {
-               (*this)(i,j) += (~rhs)(i,j);
+               (*this)(i,j) += (*rhs)(i,j);
             }
          }
       }
@@ -4624,11 +4624,11 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::addAssign( const DenseMatrix
 //template< typename MT2 >    // Type of the right-hand side sparse matrix
 //inline void DilatedSubmatrix<MT,true,true,CSAs...>::addAssign( const SparseMatrix<MT2,true>& rhs )
 //{
-//   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-//   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+//   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 //
 //   for( size_t j=0UL; j<columns(); ++j )
-//      for( ConstIterator_t<MT2> element=(~rhs).begin(j); element!=(~rhs).end(j); ++element )
+//      for( ConstIterator_t<MT2> element=(*rhs).begin(j); element!=(*rhs).end(j); ++element )
 //         matrix_(row()+element->index(),column()+j) += element->value();
 //}
 ///*! \endcond */
@@ -4654,11 +4654,11 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::addAssign( const DenseMatrix
 //{
 //   BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 //
-//   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-//   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+//   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 //
 //   for( size_t i=0UL; i<rows(); ++i )
-//      for( ConstIterator_t<MT2> element=(~rhs).begin(i); element!=(~rhs).end(i); ++element )
+//      for( ConstIterator_t<MT2> element=(*rhs).begin(i); element!=(*rhs).end(i); ++element )
 //         matrix_(row()+i,column()+element->index()) += element->value();
 //}
 ///*! \endcond */
@@ -4682,8 +4682,8 @@ template< typename MT       // Type of the dense matrix
 template< typename MT2 >    // Type of the right-hand side dense matrix
 inline void DilatedSubmatrix<MT,true,true,CSAs...>::subAssign( const DenseMatrix<MT2,true>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    const size_t ipos( rows() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( rows() - ( rows() % 2UL ) ) == ipos, "Invalid end calculation" );
@@ -4691,15 +4691,15 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::subAssign( const DenseMatrix
    for( size_t j=0UL; j<columns(); ++j )
    {
       if( IsDiagonal_v<MT2> ) {
-         (*this)(j,j) -= (~rhs)(j,j);
+         (*this)(j,j) -= (*rhs)(j,j);
       }
       else {
          for( size_t i=0UL; i<ipos; i+=2UL ) {
-            (*this)(i    ,j) -= (~rhs)(i    ,j);
-            (*this)(i+1UL,j) -= (~rhs)(i+1UL,j);
+            (*this)(i    ,j) -= (*rhs)(i    ,j);
+            (*this)(i+1UL,j) -= (*rhs)(i+1UL,j);
          }
          if( ipos < rows() ) {
-            (*this)(ipos,j) -= (~rhs)(ipos,j);
+            (*this)(ipos,j) -= (*rhs)(ipos,j);
          }
       }
    }
@@ -4727,8 +4727,8 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::subAssign( const DenseMatrix
 {
    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    constexpr size_t block( BLOCK_SIZE );
 
@@ -4738,7 +4738,7 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::subAssign( const DenseMatrix
          const size_t iend( ( rows()<(ii+block) )?( rows() ):( ii+block ) );
          for( size_t j=jj; j<jend; j++) {
             for( size_t i=ii; i<iend; i++ ) {
-               (*this)(i,j) -= (~rhs)(i,j);
+               (*this)(i,j) -= (*rhs)(i,j);
             }
          }
       }
@@ -4765,11 +4765,11 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::subAssign( const DenseMatrix
 //template< typename MT2 >    // Type of the right-hand side sparse matrix
 //inline void DilatedSubmatrix<MT,true,true,CSAs...>::subAssign( const SparseMatrix<MT2,true>& rhs )
 //{
-//   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-//   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+//   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 //
 //   for( size_t j=0UL; j<columns(); ++j )
-//      for( ConstIterator_t<MT2> element=(~rhs).begin(j); element!=(~rhs).end(j); ++element )
+//      for( ConstIterator_t<MT2> element=(*rhs).begin(j); element!=(*rhs).end(j); ++element )
 //         matrix_(row()+element->index(),column()+j) -= element->value();
 //}
 ///*! \endcond */
@@ -4795,11 +4795,11 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::subAssign( const DenseMatrix
 //{
 //   BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 //
-//   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-//   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+//   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 //
 //   for( size_t i=0UL; i<rows(); ++i )
-//      for( ConstIterator_t<MT2> element=(~rhs).begin(i); element!=(~rhs).end(i); ++element )
+//      for( ConstIterator_t<MT2> element=(*rhs).begin(i); element!=(*rhs).end(i); ++element )
 //         matrix_(row()+i,column()+element->index()) -= element->value();
 //}
 ///*! \endcond */
@@ -4823,19 +4823,19 @@ template< typename MT       // Type of the dense matrix
 template< typename MT2 >    // Type of the right-hand side dense matrix
 inline void DilatedSubmatrix<MT,true,true,CSAs...>::schurAssign( const DenseMatrix<MT2,true>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    const size_t ipos( rows() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( rows() - ( rows() % 2UL ) ) == ipos, "Invalid end calculation" );
 
    for( size_t j=0UL; j<columns(); ++j ) {
       for( size_t i=0UL; i<ipos; i+=2UL ) {
-         (*this)(i    ,j) *= (~rhs)(i    ,j);
-         (*this)(i+1UL,j) *= (~rhs)(i+1UL,j);
+         (*this)(i    ,j) *= (*rhs)(i    ,j);
+         (*this)(i+1UL,j) *= (*rhs)(i+1UL,j);
       }
       if( ipos < rows() ) {
-         (*this)(ipos,j) *= (~rhs)(ipos,j);
+         (*this)(ipos,j) *= (*rhs)(ipos,j);
       }
    }
 }
@@ -4862,8 +4862,8 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::schurAssign( const DenseMatr
 {
    BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    constexpr size_t block( BLOCK_SIZE );
 
@@ -4873,7 +4873,7 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::schurAssign( const DenseMatr
          const size_t iend( ( rows()<(ii+block) )?( rows() ):( ii+block ) );
          for( size_t j=jj; j<jend; j++ ) {
             for( size_t i=ii; i<iend; i++ ) {
-               (*this)(i,j) *= (~rhs)(i,j);
+               (*this)(i,j) *= (*rhs)(i,j);
             }
          }
       }
@@ -4902,14 +4902,14 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::schurAssign( const DenseMatr
 //{
 //   using blaze::reset;
 //
-//   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-//   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+//   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 //
 //   for( size_t j=0UL; j<columns(); ++j )
 //   {
 //      size_t i( 0UL );
 //
-//      for( ConstIterator_t<MT2> element=(~rhs).begin(j); element!=(~rhs).end(j); ++element ) {
+//      for( ConstIterator_t<MT2> element=(*rhs).begin(j); element!=(*rhs).end(j); ++element ) {
 //         for( ; i<element->index(); ++i )
 //            reset( matrix_(row()+i,column()+j) );
 //         matrix_(row()+i,column()+j) *= element->value();
@@ -4946,14 +4946,14 @@ inline void DilatedSubmatrix<MT,true,true,CSAs...>::schurAssign( const DenseMatr
 //
 //   BLAZE_CONSTRAINT_MUST_NOT_BE_SYMMETRIC_MATRIX_TYPE( MT2 );
 //
-//   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-//   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+//   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+//   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 //
 //   for( size_t i=0UL; i<rows(); ++i )
 //   {
 //      size_t j( 0UL );
 //
-//      for( ConstIterator_t<MT2> element=(~rhs).begin(i); element!=(~rhs).end(i); ++element ) {
+//      for( ConstIterator_t<MT2> element=(*rhs).begin(i); element!=(*rhs).end(i); ++element ) {
 //         for( ; j<element->index(); ++j )
 //            reset( matrix_(row()+i,column()+j) );
 //         matrix_(row()+i,column()+j) *= element->value();

--- a/blaze_tensor/math/views/dilatedsubtensor/Dense.h
+++ b/blaze_tensor/math/views/dilatedsubtensor/Dense.h
@@ -1267,12 +1267,12 @@ inline DilatedSubtensor<TT,true,CSAs...>&
 {
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<TT2> );
 
-   if( pages() != (~rhs).pages() || rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( pages() != (*rhs).pages() || rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<TT>, CompositeType_t<TT2>, const TT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAssign( tensor_, right, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1325,22 +1325,22 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::operator+=( const Tensor<TT2>& rh
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( pages() != (~rhs).pages() || rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( pages() != (*rhs).pages() || rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !tryAddAssign( tensor_, ~rhs, row(), column(), page() ) ) {
+   if( !tryAddAssign( tensor_, *rhs, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( (~rhs).canAlias( &tensor_ ) ) {
-      const AddType tmp( *this + (~rhs) );
+   if( (*rhs).canAlias( &tensor_ ) ) {
+      const AddType tmp( *this + (*rhs) );
       smpAssign( left, tmp );
    }
    else {
-      smpAddAssign( left, ~rhs );
+      smpAddAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1380,11 +1380,11 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::operator+=( const Tensor<TT2>& rh
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( pages() != (~rhs).pages() || rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( pages() != (*rhs).pages() || rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   const AddType tmp( *this + (~rhs) );
+   const AddType tmp( *this + (*rhs) );
 
    if( !tryAssign( tensor_, tmp, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1431,22 +1431,22 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::operator-=( const Tensor<TT2>& rh
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( pages() != (~rhs).pages() || rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( pages() != (*rhs).pages() || rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !trySubAssign( tensor_, ~rhs, row(), column(), page() ) ) {
+   if( !trySubAssign( tensor_, *rhs, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( (~rhs).canAlias( &tensor_ ) ) {
-      const SubType tmp( *this - (~rhs ) );
+   if( (*rhs).canAlias( &tensor_ ) ) {
+      const SubType tmp( *this - (*rhs ) );
       smpAssign( left, tmp );
    }
    else {
-      smpSubAssign( left, ~rhs );
+      smpSubAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1486,11 +1486,11 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::operator-=( const Tensor<TT2>& rh
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( pages() != (~rhs).pages() || rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( pages() != (*rhs).pages() || rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   const SubType tmp( *this - (~rhs) );
+   const SubType tmp( *this - (*rhs) );
 
    if( !tryAssign( tensor_, tmp, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1536,22 +1536,22 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::operator%=( const Tensor<TT2>& rh
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( pages() != (~rhs).pages() || rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( pages() != (*rhs).pages() || rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !trySchurAssign( tensor_, ~rhs, row(), column(), page() ) ) {
+   if( !trySchurAssign( tensor_, *rhs, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( (~rhs).canAlias( &tensor_ ) ) {
-      const SchurType tmp( *this % (~rhs) );
+   if( (*rhs).canAlias( &tensor_ ) ) {
+      const SchurType tmp( *this % (*rhs) );
       smpAssign( left, tmp );
    }
    else {
-      smpSchurAssign( left, ~rhs );
+      smpSchurAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1590,11 +1590,11 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::operator%=( const Tensor<TT2>& rh
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( pages() != (~rhs).pages() || rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( pages() != (*rhs).pages() || rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   const SchurType tmp( *this % (~rhs) );
+   const SchurType tmp( *this % (*rhs) );
 
    if( !tryAssign( tensor_, tmp, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -2134,9 +2134,9 @@ template< typename TT       // Type of the dense tensor
 template< typename TT2 >    // Type of the right-hand side dense tensor
 inline auto DilatedSubtensor<TT,true,CSAs...>::assign( const DenseTensor<TT2>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages"  );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"   );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns");
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages"  );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"   );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns");
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2144,11 +2144,11 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::assign( const DenseTensor<TT2>& r
    for (size_t k = 0UL; k < pages(); ++k) {
       for (size_t i = 0UL; i < rows(); ++i) {
          for (size_t j = 0UL; j < jpos; j += 2UL) {
-            (*this)(k, i, j) = (~rhs)(k, i, j);
-            (*this)(k, i, j + 1UL) = (~rhs)(k, i, j + 1UL);
+            (*this)(k, i, j) = (*rhs)(k, i, j);
+            (*this)(k, i, j + 1UL) = (*rhs)(k, i, j + 1UL);
          }
          if (jpos < columns()) {
-            (*this)(k, i, jpos) = (~rhs)(k, i, jpos);
+            (*this)(k, i, jpos) = (*rhs)(k, i, jpos);
          }
       }
    }
@@ -2174,9 +2174,9 @@ template< typename TT       // Type of the dense tensor
 template< typename TT2 >    // Type of the right-hand side dense tensor
 inline auto DilatedSubtensor<TT,true,CSAs...>::addAssign( const DenseTensor<TT2>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages"  );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"   );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns");
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages"  );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"   );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns");
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2186,11 +2186,11 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::addAssign( const DenseTensor<TT2>
       for (size_t i = 0UL; i < rows(); ++i)
       {
          for (size_t j = 0UL; j < jpos; j += 2UL) {
-            (*this)(k, i, j) += (~rhs)(k, i, j);
-            (*this)(k, i, j + 1UL) += (~rhs)(k, i, j + 1UL);
+            (*this)(k, i, j) += (*rhs)(k, i, j);
+            (*this)(k, i, j + 1UL) += (*rhs)(k, i, j + 1UL);
          }
          if (jpos < columns()) {
-            (*this)(k, i, jpos) += (~rhs)(k, i, jpos);
+            (*this)(k, i, jpos) += (*rhs)(k, i, jpos);
          }
       }
    }
@@ -2216,9 +2216,9 @@ template< typename TT       // Type of the dense tensor
 template< typename TT2 >    // Type of the right-hand side dense tensor
 inline auto DilatedSubtensor<TT,true,CSAs...>::subAssign( const DenseTensor<TT2>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages"  );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"   );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns");
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages"  );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"   );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns");
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2228,11 +2228,11 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::subAssign( const DenseTensor<TT2>
       for (size_t i = 0UL; i < rows(); ++i)
       {
          for (size_t j = 0UL; j < jpos; j += 2UL) {
-            (*this)(k, i, j) -= (~rhs)(k, i, j);
-            (*this)(k, i, j + 1UL) -= (~rhs)(k, i, j + 1UL);
+            (*this)(k, i, j) -= (*rhs)(k, i, j);
+            (*this)(k, i, j + 1UL) -= (*rhs)(k, i, j + 1UL);
          }
          if (jpos < columns()) {
-            (*this)(k, i, jpos) -= (~rhs)(k, i, jpos);
+            (*this)(k, i, jpos) -= (*rhs)(k, i, jpos);
          }
 
       }
@@ -2259,9 +2259,9 @@ template< typename TT       // Type of the dense tensor
 template< typename TT2 >    // Type of the right-hand side dense tensor
 inline auto DilatedSubtensor<TT,true,CSAs...>::schurAssign( const DenseTensor<TT2>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages"  );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"   );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns");
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages"  );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"   );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns");
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2270,11 +2270,11 @@ inline auto DilatedSubtensor<TT,true,CSAs...>::schurAssign( const DenseTensor<TT
    {
       for (size_t i = 0UL; i < rows(); ++i) {
          for (size_t j = 0UL; j < jpos; j += 2UL) {
-            (*this)(k, i, j) *= (~rhs)(k, i, j);
-            (*this)(k, i, j + 1UL) *= (~rhs)(k, i, j + 1UL);
+            (*this)(k, i, j) *= (*rhs)(k, i, j);
+            (*this)(k, i, j + 1UL) *= (*rhs)(k, i, j + 1UL);
          }
          if (jpos < columns()) {
-            (*this)(k, i, jpos) *= (~rhs)(k, i, jpos);
+            (*this)(k, i, jpos) *= (*rhs)(k, i, jpos);
          }
       }
    }

--- a/blaze_tensor/math/views/dilatedsubvector/Dense.h
+++ b/blaze_tensor/math/views/dilatedsubvector/Dense.h
@@ -1049,12 +1049,12 @@ inline DilatedSubvector<VT,TF,true,CSAs...>&
    BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG( ResultType_t<VT2>, TF );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<VT2> );
 
-   if( size() != (~rhs).size() ) {
+   if( size() != (*rhs).size() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Vector sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<VT>, CompositeType_t<VT2>, const VT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAssign( vector_, right, offset() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted vector" );
@@ -1102,12 +1102,12 @@ inline DilatedSubvector<VT,TF,true,CSAs...>&
    BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG( ResultType_t<VT2>, TF );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<VT2> );
 
-   if( size() != (~rhs).size() ) {
+   if( size() != (*rhs).size() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Vector sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<VT>, CompositeType_t<VT2>, const VT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAddAssign( vector_, right, offset() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted vector" );
@@ -1153,12 +1153,12 @@ inline DilatedSubvector<VT,TF,true,CSAs...>&
    BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG( ResultType_t<VT2>, TF );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<VT2> );
 
-   if( size() != (~rhs).size() ) {
+   if( size() != (*rhs).size() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Vector sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<VT>, CompositeType_t<VT2>, const VT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !trySubAssign( vector_, right, offset() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted vector" );
@@ -1205,12 +1205,12 @@ inline DilatedSubvector<VT,TF,true,CSAs...>&
    BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG( ResultType_t<VT2>, TF );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<VT2> );
 
-   if( size() != (~rhs).size() ) {
+   if( size() != (*rhs).size() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Vector sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<VT>, CompositeType_t<VT2>, const VT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryMultAssign( vector_, right, offset() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted vector" );
@@ -1256,12 +1256,12 @@ inline DilatedSubvector<VT,TF,true,CSAs...>&
    BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG( ResultType_t<VT2>, TF );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<VT2> );
 
-   if( size() != (~rhs).size() ) {
+   if( size() != (*rhs).size() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Vector sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<VT>, CompositeType_t<VT2>, const VT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryDivAssign( vector_, right, offset() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted vector" );
@@ -1316,11 +1316,11 @@ inline DilatedSubvector<VT,TF,true,CSAs...>&
    BLAZE_CONSTRAINT_MUST_BE_VECTOR_WITH_TRANSPOSE_FLAG( CrossType, TF );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( CrossType );
 
-   if( size() != 3UL || (~rhs).size() != 3UL ) {
+   if( size() != 3UL || (*rhs).size() != 3UL ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid vector size for cross product" );
    }
 
-   const CrossType tmp( *this % (~rhs) );
+   const CrossType tmp( *this % (*rhs) );
 
    if( !tryAssign( vector_, tmp, offset() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted vector" );
@@ -1652,15 +1652,15 @@ template< typename VT       // Type of the dense vector
 template< typename VT2 >    // Type of the right-hand side dense vector
 inline void DilatedSubvector<VT,TF,true,CSAs...>::assign( const DenseVector<VT2,TF>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( size() == (~rhs).size(), "Invalid vector sizes" );
+   BLAZE_INTERNAL_ASSERT( size() == (*rhs).size(), "Invalid vector sizes" );
 
    const size_t ipos( size() & size_t(-2) );
    for( size_t i=0UL; i<ipos; i+=2 ) {
-      (*this)[i  ] = (~rhs)[i    ];
-      (*this)[i+1] = (~rhs)[i+1UL];
+      (*this)[i  ] = (*rhs)[i    ];
+      (*this)[i+1] = (*rhs)[i+1UL];
    }
    if( ipos < size() ) {
-      (*this)[ipos] = (~rhs)[ipos];
+      (*this)[ipos] = (*rhs)[ipos];
    }
 }
 /*! \endcond */
@@ -1686,9 +1686,9 @@ inline void DilatedSubvector<VT,TF,true,CSAs...>::assign( const DenseVector<VT2,
 // template< typename VT2 >    // Type of the right-hand side sparse vector
 // inline void DilatedSubvector<VT,TF,true,CSAs...>::assign( const SparseVector<VT2,TF>& rhs )
 // {
-//    BLAZE_INTERNAL_ASSERT( size() == (~rhs).size(), "Invalid vector sizes" );
+//    BLAZE_INTERNAL_ASSERT( size() == (*rhs).size(), "Invalid vector sizes" );
 //
-//    for( ConstIterator_t<VT2> element=(~rhs).begin(); element!=(~rhs).end(); ++element )
+//    for( ConstIterator_t<VT2> element=(*rhs).begin(); element!=(*rhs).end(); ++element )
 //       vector_[offset()+element->index()] = element->value();
 // }
 /*! \endcond */
@@ -1713,15 +1713,15 @@ template< typename VT       // Type of the dense vector
 template< typename VT2 >    // Type of the right-hand side dense vector
 inline void DilatedSubvector<VT,TF,true,CSAs...>::addAssign( const DenseVector<VT2,TF>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( size() == (~rhs).size(), "Invalid vector sizes" );
+   BLAZE_INTERNAL_ASSERT( size() == (*rhs).size(), "Invalid vector sizes" );
 
    const size_t ipos( size() & size_t(-2) );
    for( size_t i=0UL; i<ipos; i+=2UL ) {
-      (*this)[i  ] += (~rhs)[i    ];
-      (*this)[i+1] += (~rhs)[i+1UL];
+      (*this)[i  ] += (*rhs)[i    ];
+      (*this)[i+1] += (*rhs)[i+1UL];
    }
    if( ipos < size() ) {
-      (*this)[ipos] += (~rhs)[ipos];
+      (*this)[ipos] += (*rhs)[ipos];
    }
 }
 /*! \endcond */
@@ -1746,9 +1746,9 @@ inline void DilatedSubvector<VT,TF,true,CSAs...>::addAssign( const DenseVector<V
 // template< typename VT2 >    // Type of the right-hand side sparse vector
 // inline void DilatedSubvector<VT,TF,true,CSAs...>::addAssign( const SparseVector<VT2,TF>& rhs )
 // {
-//    BLAZE_INTERNAL_ASSERT( size() == (~rhs).size(), "Invalid vector sizes" );
+//    BLAZE_INTERNAL_ASSERT( size() == (*rhs).size(), "Invalid vector sizes" );
 //
-//    for( ConstIterator_t<VT2> element=(~rhs).begin(); element!=(~rhs).end(); ++element )
+//    for( ConstIterator_t<VT2> element=(*rhs).begin(); element!=(*rhs).end(); ++element )
 //       vector_[offset()+element->index()] += element->value();
 // }
 /*! \endcond */
@@ -1773,15 +1773,15 @@ template< typename VT       // Type of the dense vector
 template< typename VT2 >    // Type of the right-hand side dense vector
 inline void DilatedSubvector<VT,TF,true,CSAs...>::subAssign( const DenseVector<VT2,TF>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( size() == (~rhs).size(), "Invalid vector sizes" );
+   BLAZE_INTERNAL_ASSERT( size() == (*rhs).size(), "Invalid vector sizes" );
 
    const size_t ipos( size() & size_t(-2) );
    for( size_t i=0UL; i<ipos; i+=2UL ) {
-      (*this)[i  ] -= (~rhs)[i    ];
-      (*this)[i+1] -= (~rhs)[i+1UL];
+      (*this)[i  ] -= (*rhs)[i    ];
+      (*this)[i+1] -= (*rhs)[i+1UL];
    }
    if( ipos < size() ) {
-      (*this)[ipos] -= (~rhs)[ipos];
+      (*this)[ipos] -= (*rhs)[ipos];
    }
 }
 /*! \endcond */
@@ -1806,9 +1806,9 @@ inline void DilatedSubvector<VT,TF,true,CSAs...>::subAssign( const DenseVector<V
 // template< typename VT2 >    // Type of the right-hand side sparse vector
 // inline void DilatedSubvector<VT,TF,true,CSAs...>::subAssign( const SparseVector<VT2,TF>& rhs )
 // {
-//    BLAZE_INTERNAL_ASSERT( size() == (~rhs).size(), "Invalid vector sizes" );
+//    BLAZE_INTERNAL_ASSERT( size() == (*rhs).size(), "Invalid vector sizes" );
 //
-//    for( ConstIterator_t<VT2> element=(~rhs).begin(); element!=(~rhs).end(); ++element )
+//    for( ConstIterator_t<VT2> element=(*rhs).begin(); element!=(*rhs).end(); ++element )
 //       vector_[offset()+element->index()] -= element->value();
 // }
 /*! \endcond */
@@ -1833,15 +1833,15 @@ template< typename VT       // Type of the dense vector
 template< typename VT2 >    // Type of the right-hand side dense vector
 inline void DilatedSubvector<VT,TF,true,CSAs...>::multAssign( const DenseVector<VT2,TF>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( size() == (~rhs).size(), "Invalid vector sizes" );
+   BLAZE_INTERNAL_ASSERT( size() == (*rhs).size(), "Invalid vector sizes" );
 
    const size_t ipos( size() & size_t(-2) );
    for( size_t i=0UL; i<ipos; i+=2UL ) {
-      (*this)[i  ] *= (~rhs)[i    ];
-      (*this)[i+1] *= (~rhs)[i+1UL];
+      (*this)[i  ] *= (*rhs)[i    ];
+      (*this)[i+1] *= (*rhs)[i+1UL];
    }
    if( ipos < size() ) {
-      (*this)[ipos] *= (~rhs)[ipos];
+      (*this)[ipos] *= (*rhs)[ipos];
    }
 }
 /*! \endcond */
@@ -1868,11 +1868,11 @@ inline void DilatedSubvector<VT,TF,true,CSAs...>::multAssign( const DenseVector<
 // {
 //    using blaze::reset;
 //
-//    BLAZE_INTERNAL_ASSERT( size() == (~rhs).size(), "Invalid vector sizes" );
+//    BLAZE_INTERNAL_ASSERT( size() == (*rhs).size(), "Invalid vector sizes" );
 //
 //    size_t i( 0UL );
 //
-//    for( ConstIterator_t<VT2> element=(~rhs).begin(); element!=(~rhs).end(); ++element ) {
+//    for( ConstIterator_t<VT2> element=(*rhs).begin(); element!=(*rhs).end(); ++element ) {
 //       const size_t index( element->index() );
 //       for( ; i<index; ++i )
 //          reset( vector_[offset()+i] );
@@ -1906,15 +1906,15 @@ template< typename VT       // Type of the dense vector
 template< typename VT2 >    // Type of the right-hand side dense vector
 inline void DilatedSubvector<VT,TF,true,CSAs...>::divAssign( const DenseVector<VT2,TF>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( size() == (~rhs).size(), "Invalid vector sizes" );
+   BLAZE_INTERNAL_ASSERT( size() == (*rhs).size(), "Invalid vector sizes" );
 
    const size_t ipos( size() & size_t(-2) );
    for( size_t i=0UL; i<ipos; i+=2UL ) {
-      (*this)[i  ] /= (~rhs)[i    ];
-      (*this)[i+1] /= (~rhs)[i+1UL];
+      (*this)[i  ] /= (*rhs)[i    ];
+      (*this)[i+1] /= (*rhs)[i+1UL];
    }
    if( ipos < size() ) {
-      (*this)[ipos] /= (~rhs)[ipos];
+      (*this)[ipos] /= (*rhs)[ipos];
    }
 }
 /*! \endcond */

--- a/blaze_tensor/math/views/quatslice/Dense.h
+++ b/blaze_tensor/math/views/quatslice/Dense.h
@@ -899,12 +899,12 @@ inline QuatSlice<AT,CRAs...>&
    //BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType_t<AT2> );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType_t<AT2> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<AT>, CompositeType_t<AT2>, const AT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    //if( !tryAssign( quaternion_, right, std::array<size_t, 4>{quat(), 0UL, 0UL, 0UL} ) ) {
    //   BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted quaternion" );
@@ -953,12 +953,12 @@ inline QuatSlice<AT,CRAs...>&
    //BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType_t<AT2> );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType_t<AT2> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<AT>, CompositeType_t<AT2>, const AT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    //if( !tryAddAssign( quaternion_, right, quat(), 0UL, 0UL, 0UL ) ) {
    //   BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted quaternion" );
@@ -1005,12 +1005,12 @@ inline QuatSlice<AT,CRAs...>&
    //BLAZE_CONSTRAINT_MUST_BE_ROW_MAJOR_MATRIX_TYPE( ResultType_t<AT2> );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType_t<AT2> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<AT>, CompositeType_t<AT2>, const AT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    //if( !trySubAssign( quaternion_, right, quat(), 0UL, 0UL, 0UL ) ) {
    //   BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted quaternion" );
@@ -1061,22 +1061,22 @@ inline QuatSlice<AT,CRAs...>&
 
    using SchurType = SchurTrait_t< ResultType, ResultType_t<AT2> >;
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages()  ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages()  ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   //if( !trySchurAssign( quaternion_, (~rhs), quat(), 0UL, 0UL, 0UL ) ) {
+   //if( !trySchurAssign( quaternion_, (*rhs), quat(), 0UL, 0UL, 0UL ) ) {
    //   BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted quaternion" );
    //}
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( IsReference_v<AT> && (~rhs).canAlias( &quaternion_ ) ) {
-      const SchurType tmp( *this % (~rhs) );
+   if( IsReference_v<AT> && (*rhs).canAlias( &quaternion_ ) ) {
+      const SchurType tmp( *this % (*rhs) );
       smpSchurAssign( left, tmp );
    }
    else {
-      smpSchurAssign( left, ~rhs );
+      smpSchurAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( quaternion_ ), "Invariant violation detected" );
@@ -1678,21 +1678,21 @@ template< typename AT2 >     // Type of the right-hand side dense matrix
 inline auto QuatSlice<AT,CRAs...>::assign( const DenseTensor<AT2>& rhs )
    -> EnableIf_t< !VectorizedAssign_v<AT2> >
 {
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages(),   "Invalid number of pages" );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows(),    "Invalid number of rows" );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages(),   "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows(),    "Invalid number of rows" );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
-   const size_t jpos((~rhs).columns() & size_t(-2));
+   const size_t jpos((*rhs).columns() & size_t(-2));
    for (size_t k = 0UL; k < pages(); ++k)
    {
-      for (size_t i = 0UL; i < (~rhs).rows(); ++i)
+      for (size_t i = 0UL; i < (*rhs).rows(); ++i)
       {
          for (size_t j = 0UL; j < jpos; j += 2UL) {
-            quaternion_(quat(), k, i, j) = (~rhs)(k, i, j);
-            quaternion_(quat(), k, i, j + 1UL) = (~rhs)(k, i, j + 1UL);
+            quaternion_(quat(), k, i, j) = (*rhs)(k, i, j);
+            quaternion_(quat(), k, i, j + 1UL) = (*rhs)(k, i, j + 1UL);
          }
-         if (jpos < (~rhs).columns())
-            quaternion_(quat(), k, i, jpos) = (~rhs)(k, i, jpos);
+         if (jpos < (*rhs).columns())
+            quaternion_(quat(), k, i, jpos) = (*rhs)(k, i, jpos);
       }
    }
 }
@@ -1720,9 +1720,9 @@ inline auto QuatSlice<AT,CRAs...>::assign( const DenseTensor<AT2>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages"  );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"   );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns");
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages"  );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"   );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns");
 
    constexpr bool remainder( !IsPadded_v<AT> || !IsPadded_v<AT2> );
 
@@ -1735,9 +1735,9 @@ inline auto QuatSlice<AT,CRAs...>::assign( const DenseTensor<AT2>& rhs )
       {
          size_t j(0UL);
          Iterator left(begin(i, k));
-         ConstIterator_t<AT2> right((~rhs).begin(i, k));
+         ConstIterator_t<AT2> right((*rhs).begin(i, k));
 
-         if (useStreaming && cols > (cacheSize / (sizeof(ElementType) * 3UL)) && !(~rhs).isAliased(&quaternion_))
+         if (useStreaming && cols > (cacheSize / (sizeof(ElementType) * 3UL)) && !(*rhs).isAliased(&quaternion_))
          {
             for (; j < jpos; j += SIMDSIZE) {
                left.stream(right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -1786,19 +1786,19 @@ template< typename AT2 >     // Type of the right-hand side dense matrix
 inline auto QuatSlice<AT,CRAs...>::addAssign( const DenseTensor<AT2>& rhs )
    -> EnableIf_t< !VectorizedAddAssign_v<AT2> >
 {
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    for (size_t k = 0UL; k < pages(); ++k) {
-      for (size_t i = 0UL; i < (~rhs).rows(); ++i) {
-         const size_t jpos((~rhs).columns() & size_t(-2));
+      for (size_t i = 0UL; i < (*rhs).rows(); ++i) {
+         const size_t jpos((*rhs).columns() & size_t(-2));
          for (size_t j = 0UL; j < jpos; j += 2UL) {
-            quaternion_(quat(), k, i, j)       += (~rhs)(k, i, j);
-            quaternion_(quat(), k, i, j + 1UL) += (~rhs)(k, i, j + 1UL);
+            quaternion_(quat(), k, i, j)       += (*rhs)(k, i, j);
+            quaternion_(quat(), k, i, j + 1UL) += (*rhs)(k, i, j + 1UL);
          }
-         if (jpos < (~rhs).columns())
-            quaternion_(quat(), k, i, jpos) += (~rhs)(k, i, jpos);
+         if (jpos < (*rhs).columns())
+            quaternion_(quat(), k, i, jpos) += (*rhs)(k, i, jpos);
       }
    }
 }
@@ -1826,9 +1826,9 @@ inline auto QuatSlice<AT,CRAs...>::addAssign( const DenseTensor<AT2>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages"  );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"   );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns");
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages"  );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"   );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns");
 
    constexpr bool remainder( !IsPadded_v<AT> || !IsPadded_v<AT2> );
 
@@ -1841,7 +1841,7 @@ inline auto QuatSlice<AT,CRAs...>::addAssign( const DenseTensor<AT2>& rhs )
       {
          size_t j(0UL);
          Iterator left(begin(i, k));
-         ConstIterator_t<AT2> right((~rhs).begin(i, k));
+         ConstIterator_t<AT2> right((*rhs).begin(i, k));
 
          for (; (j + SIMDSIZE * 3UL) < jpos; j += SIMDSIZE * 4UL) {
             left.store(left.load() + right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -1880,19 +1880,19 @@ template< typename AT2 >     // Type of the right-hand side dense matrix
 inline auto QuatSlice<AT,CRAs...>::subAssign( const DenseTensor<AT2>& rhs )
    -> EnableIf_t< !VectorizedSubAssign_v<AT2> >
 {
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    for (size_t k = 0UL; k < pages(); ++k) {
-      for (size_t i = 0UL; i < (~rhs).rows(); ++i) {
-         const size_t jpos((~rhs).columns() & size_t(-2));
+      for (size_t i = 0UL; i < (*rhs).rows(); ++i) {
+         const size_t jpos((*rhs).columns() & size_t(-2));
          for (size_t j = 0UL; j < jpos; j += 2UL) {
-            quaternion_(quat(), k, i, j)       -= (~rhs)(k, i, j);
-            quaternion_(quat(), k, i, j + 1UL) -= (~rhs)(k, i, j + 1UL);
+            quaternion_(quat(), k, i, j)       -= (*rhs)(k, i, j);
+            quaternion_(quat(), k, i, j + 1UL) -= (*rhs)(k, i, j + 1UL);
          }
-         if (jpos < (~rhs).columns())
-            quaternion_(quat(), k, i, jpos) -= (~rhs)(k, i, jpos);
+         if (jpos < (*rhs).columns())
+            quaternion_(quat(), k, i, jpos) -= (*rhs)(k, i, jpos);
       }
    }
 }
@@ -1920,9 +1920,9 @@ inline auto QuatSlice<AT,CRAs...>::subAssign( const DenseTensor<AT2>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages"  );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"   );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns");
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages"  );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"   );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns");
 
    constexpr bool remainder( !IsPadded_v<AT> || !IsPadded_v<AT2> );
 
@@ -1935,7 +1935,7 @@ inline auto QuatSlice<AT,CRAs...>::subAssign( const DenseTensor<AT2>& rhs )
       {
          size_t j(0UL);
          Iterator left(begin(i, k));
-         ConstIterator_t<AT2> right((~rhs).begin(i, k));
+         ConstIterator_t<AT2> right((*rhs).begin(i, k));
 
          for (; (j + SIMDSIZE * 3UL) < jpos; j += SIMDSIZE * 4UL) {
             left.store(left.load() - right.load()); left += SIMDSIZE; right += SIMDSIZE;
@@ -1974,19 +1974,19 @@ template< typename AT2 >    // Type of the right-hand side dense matrix
 inline auto QuatSlice<AT,CSAs...>::schurAssign( const DenseTensor<AT2>& rhs )
    -> EnableIf_t< !VectorizedSchurAssign_v<AT2> >
 {
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    for (size_t k = 0UL; k < pages(); ++k) {
-      for (size_t i = 0UL; i < (~rhs).rows(); ++i) {
-         const size_t jpos((~rhs).columns() & size_t(-2));
+      for (size_t i = 0UL; i < (*rhs).rows(); ++i) {
+         const size_t jpos((*rhs).columns() & size_t(-2));
          for (size_t j = 0UL; j < jpos; j += 2UL) {
-            quaternion_(quat(), k, i, j)       *= (~rhs)(k, i, j);
-            quaternion_(quat(), k, i, j + 1UL) *= (~rhs)(k, i, j + 1UL);
+            quaternion_(quat(), k, i, j)       *= (*rhs)(k, i, j);
+            quaternion_(quat(), k, i, j + 1UL) *= (*rhs)(k, i, j + 1UL);
          }
-         if (jpos < (~rhs).columns())
-            quaternion_(quat(), k, i, jpos) *= (~rhs)(k, i, jpos);
+         if (jpos < (*rhs).columns())
+            quaternion_(quat(), k, i, jpos) *= (*rhs)(k, i, jpos);
       }
    }
 }
@@ -2014,9 +2014,9 @@ inline auto QuatSlice<AT,CSAs...>::schurAssign( const DenseTensor<AT2>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages"  );
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"   );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns");
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages"  );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"   );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns");
 
    constexpr bool remainder( !IsPadded_v<AT> || !IsPadded_v<AT2> );
 
@@ -2029,7 +2029,7 @@ inline auto QuatSlice<AT,CSAs...>::schurAssign( const DenseTensor<AT2>& rhs )
       {
          size_t j(0UL);
          Iterator left(begin(i, k));
-         ConstIterator_t<AT2> right((~rhs).begin(i, k));
+         ConstIterator_t<AT2> right((*rhs).begin(i, k));
 
          for (; (j + SIMDSIZE * 3UL) < jpos; j += SIMDSIZE * 4UL) {
             left.store(left.load() * right.load()); left += SIMDSIZE; right += SIMDSIZE;

--- a/blaze_tensor/math/views/rowslice/Dense.h
+++ b/blaze_tensor/math/views/rowslice/Dense.h
@@ -822,12 +822,12 @@ inline RowSlice<MT,CRAs...>&
    //BLAZE_CONSTRAINT_MUST_BE_COLUMN_MAJOR_MATRIX_TYPE( ResultType_t<VT> );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType_t<VT> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<VT>, const VT& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAssign( tensor_, right, row(), 0UL, 0UL ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -875,12 +875,12 @@ inline RowSlice<MT,CRAs...>&
    //BLAZE_CONSTRAINT_MUST_BE_COLUMN_MAJOR_MATRIX_TYPE( ResultType_t<VT> );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType_t<VT> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<VT>, const VT& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAddAssign( tensor_, right, row(), 0UL, 0UL ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -928,12 +928,12 @@ inline RowSlice<MT,CRAs...>&
    //BLAZE_CONSTRAINT_MUST_BE_COLUMN_MAJOR_MATRIX_TYPE( ResultType_t<VT> );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION  ( ResultType_t<VT> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<VT>, const VT& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !trySubAssign( tensor_, right, row(), 0UL, 0UL ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -985,22 +985,22 @@ inline RowSlice<MT,CRAs...>&
 
    using SchurType = SchurTrait_t< ResultType, ResultType_t<VT> >;
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Matrix sizes do not match" );
    }
 
-   if( !trySchurAssign( tensor_, (~rhs), row(), 0UL, 0UL ) ) {
+   if( !trySchurAssign( tensor_, (*rhs), row(), 0UL, 0UL ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( IsReference_v<MT> && (~rhs).canAlias( &tensor_ ) ) {
-      const SchurType tmp( *this % (~rhs) );
+   if( IsReference_v<MT> && (*rhs).canAlias( &tensor_ ) ) {
+      const SchurType tmp( *this % (*rhs) );
       smpSchurAssign( left, tmp );
    }
    else {
-      smpSchurAssign( left, ~rhs );
+      smpSchurAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1407,17 +1407,17 @@ template< typename VT       // Type of the right-hand side dense matrix
         , bool SO >         // Storage order
 inline void RowSlice<MT,CRAs...>::assign( const DenseMatrix<VT,SO>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows() == (~rhs).rows(), "Invalid matrix sizes" );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid matrix sizes" );
+   BLAZE_INTERNAL_ASSERT( rows() == (*rhs).rows(), "Invalid matrix sizes" );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid matrix sizes" );
 
-   for (size_t i = 0UL; i < (~rhs).rows(); ++i ) {
-      const size_t jpos( (~rhs).columns() & size_t(-2) );
+   for (size_t i = 0UL; i < (*rhs).rows(); ++i ) {
+      const size_t jpos( (*rhs).columns() & size_t(-2) );
       for( size_t j=0UL; j<jpos; j+=2UL ) {
-         tensor_(j    ,row(),i) = (~rhs)(i,j);
-         tensor_(j+1UL,row(),i) = (~rhs)(i,j+1UL);
+         tensor_(j    ,row(),i) = (*rhs)(i,j);
+         tensor_(j+1UL,row(),i) = (*rhs)(i,j+1UL);
       }
-      if( jpos < (~rhs).columns() )
-         tensor_(jpos,row(),i) = (~rhs)(i,jpos);
+      if( jpos < (*rhs).columns() )
+         tensor_(jpos,row(),i) = (*rhs)(i,jpos);
    }
 }
 /*! \endcond */
@@ -1442,17 +1442,17 @@ template< typename VT       // Type of the right-hand side dense matrix
         , bool SO >         // Storage order
 inline void RowSlice<MT,CRAs...>::addAssign( const DenseMatrix<VT,SO>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
-   for (size_t i = 0UL; i < (~rhs).rows(); ++i ) {
-      const size_t jpos( (~rhs).columns() & size_t(-2) );
+   for (size_t i = 0UL; i < (*rhs).rows(); ++i ) {
+      const size_t jpos( (*rhs).columns() & size_t(-2) );
       for( size_t j=0UL; j<jpos; j+=2UL ) {
-         tensor_(j    ,row(),i) += (~rhs)(i,j);
-         tensor_(j+1UL,row(),i) += (~rhs)(i,j+1UL);
+         tensor_(j    ,row(),i) += (*rhs)(i,j);
+         tensor_(j+1UL,row(),i) += (*rhs)(i,j+1UL);
       }
-      if( jpos < (~rhs).columns() )
-         tensor_(jpos,row(),i) += (~rhs)(i,jpos);
+      if( jpos < (*rhs).columns() )
+         tensor_(jpos,row(),i) += (*rhs)(i,jpos);
    }
 }
 /*! \endcond */
@@ -1477,17 +1477,17 @@ template< typename VT       // Type of the right-hand side dense matrix
         , bool SO >         // Storage order
 inline void RowSlice<MT,CRAs...>::subAssign( const DenseMatrix<VT,SO>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
-   for (size_t i = 0UL; i < (~rhs).rows(); ++i ) {
-      const size_t jpos( (~rhs).columns() & size_t(-2) );
+   for (size_t i = 0UL; i < (*rhs).rows(); ++i ) {
+      const size_t jpos( (*rhs).columns() & size_t(-2) );
       for( size_t j=0UL; j<jpos; j+=2UL ) {
-         tensor_(j    ,row(),i) -= (~rhs)(i,j);
-         tensor_(j+1UL,row(),i) -= (~rhs)(i,j+1UL);
+         tensor_(j    ,row(),i) -= (*rhs)(i,j);
+         tensor_(j+1UL,row(),i) -= (*rhs)(i,j+1UL);
       }
-      if( jpos < (~rhs).columns() )
-         tensor_(jpos,row(),i) -= (~rhs)(i,jpos);
+      if( jpos < (*rhs).columns() )
+         tensor_(jpos,row(),i) -= (*rhs)(i,jpos);
    }
 }
 /*! \endcond */
@@ -1512,19 +1512,19 @@ template< typename MT2      // Type of the right-hand side dense matrix
         , bool SO >         // Storage order
 inline void RowSlice<MT,CRAs...>::schurAssign( const DenseMatrix<MT2,SO>& rhs )
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
 
    for( size_t i=0UL; i<rows(); ++i ) {
       for( size_t j=0UL; j<jpos; j+=2UL ) {
-         tensor_(j    ,row(),i) *= (~rhs)(i,j    );
-         tensor_(j+1UL,row(),i) *= (~rhs)(i,j+1UL);
+         tensor_(j    ,row(),i) *= (*rhs)(i,j    );
+         tensor_(j+1UL,row(),i) *= (*rhs)(i,j+1UL);
       }
       if( jpos < columns() ) {
-         tensor_(jpos,row(),i) *= (~rhs)(i,jpos);
+         tensor_(jpos,row(),i) *= (*rhs)(i,jpos);
       }
    }
 }

--- a/blaze_tensor/math/views/subtensor/DenseAligned.h
+++ b/blaze_tensor/math/views/subtensor/DenseAligned.h
@@ -989,12 +989,12 @@ inline Subtensor<MT,aligned,CSAs...>&
 {
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<MT2> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<MT2>, const MT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAssign( tensor_, right, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1047,22 +1047,22 @@ inline auto Subtensor<MT,aligned,CSAs...>::operator+=( const Tensor<MT2>& rhs )
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !tryAddAssign( tensor_, ~rhs, row(), column(), page() ) ) {
+   if( !tryAddAssign( tensor_, *rhs, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( (~rhs).canAlias( &tensor_ ) ) {
-      const AddType tmp( *this + (~rhs) );
+   if( (*rhs).canAlias( &tensor_ ) ) {
+      const AddType tmp( *this + (*rhs) );
       smpAssign( left, tmp );
    }
    else {
-      smpAddAssign( left, ~rhs );
+      smpAddAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1102,11 +1102,11 @@ inline auto Subtensor<MT,aligned,CSAs...>::operator+=( const Tensor<MT2>& rhs )
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   const AddType tmp( *this + (~rhs) );
+   const AddType tmp( *this + (*rhs) );
 
    if( !tryAssign( tensor_, tmp, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1153,22 +1153,22 @@ inline auto Subtensor<MT,aligned,CSAs...>::operator-=( const Tensor<MT2>& rhs )
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !trySubAssign( tensor_, ~rhs, row(), column(), page() ) ) {
+   if( !trySubAssign( tensor_, *rhs, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( (~rhs).canAlias( &tensor_ ) ) {
-      const SubType tmp( *this - (~rhs ) );
+   if( (*rhs).canAlias( &tensor_ ) ) {
+      const SubType tmp( *this - (*rhs ) );
       smpAssign( left, tmp );
    }
    else {
-      smpSubAssign( left, ~rhs );
+      smpSubAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1208,11 +1208,11 @@ inline auto Subtensor<MT,aligned,CSAs...>::operator-=( const Tensor<MT2>& rhs )
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   const SubType tmp( *this - (~rhs) );
+   const SubType tmp( *this - (*rhs) );
 
    if( !tryAssign( tensor_, tmp, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1258,22 +1258,22 @@ inline auto Subtensor<MT,aligned,CSAs...>::operator%=( const Tensor<MT2>& rhs )
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !trySchurAssign( tensor_, ~rhs, row(), column(), page() ) ) {
+   if( !trySchurAssign( tensor_, *rhs, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( (~rhs).canAlias( &tensor_ ) ) {
-      const SchurType tmp( *this % (~rhs) );
+   if( (*rhs).canAlias( &tensor_ ) ) {
+      const SchurType tmp( *this % (*rhs) );
       smpAssign( left, tmp );
    }
    else {
-      smpSchurAssign( left, ~rhs );
+      smpSchurAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1312,11 +1312,11 @@ inline auto Subtensor<MT,aligned,CSAs...>::operator%=( const Tensor<MT2>& rhs )
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   const SchurType tmp( *this % (~rhs) );
+   const SchurType tmp( *this % (*rhs) );
 
    if( !tryAssign( tensor_, tmp, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -2174,9 +2174,9 @@ template< typename MT2 >    // Type of the right-hand side dense tensor
 inline auto Subtensor<MT,aligned,CSAs...>::assign( const DenseTensor<MT2>& rhs )
    -> EnableIf_t< !VectorizedAssign_v<MT2> >
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2184,11 +2184,11 @@ inline auto Subtensor<MT,aligned,CSAs...>::assign( const DenseTensor<MT2>& rhs )
    for( size_t k=0UL; k<pages(); ++k ) {
       for( size_t i=0UL; i<rows(); ++i ) {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            tensor_(page()+k,row()+i,column()+j) = (~rhs)(k,i,j);
-            tensor_(page()+k,row()+i,column()+j+1UL) = (~rhs)(k,i,j+1UL);
+            tensor_(page()+k,row()+i,column()+j) = (*rhs)(k,i,j);
+            tensor_(page()+k,row()+i,column()+j+1UL) = (*rhs)(k,i,j+1UL);
          }
          if( jpos < columns() ) {
-            tensor_(page()+k,row()+i,column()+jpos) = (~rhs)(k,i,jpos);
+            tensor_(page()+k,row()+i,column()+jpos) = (*rhs)(k,i,jpos);
          }
       }
    }
@@ -2217,16 +2217,16 @@ inline auto Subtensor<MT,aligned,CSAs...>::assign( const DenseTensor<MT2>& rhs )
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-SIMDSIZE) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
    if( useStreaming &&
        rows()*columns()*pages() > ( cacheSize / ( sizeof(ElementType) * 3UL ) ) &&
-       !(~rhs).isAliased( &tensor_ ) )
+       !(*rhs).isAliased( &tensor_ ) )
    {
       for( size_t k=0UL; k<pages(); ++k )
       {
@@ -2234,7 +2234,7 @@ inline auto Subtensor<MT,aligned,CSAs...>::assign( const DenseTensor<MT2>& rhs )
          {
             size_t j( 0UL );
             Iterator left( begin(i, k) );
-            ConstIterator_t<MT2> right( (~rhs).begin(i, k) );
+            ConstIterator_t<MT2> right( (*rhs).begin(i, k) );
 
             for( ; j<jpos; j+=SIMDSIZE ) {
                left.stream( right.load() ); left += SIMDSIZE; right += SIMDSIZE;
@@ -2253,7 +2253,7 @@ inline auto Subtensor<MT,aligned,CSAs...>::assign( const DenseTensor<MT2>& rhs )
          {
             size_t j( 0UL );
             Iterator left( begin(i, k) );
-            ConstIterator_t<MT2> right( (~rhs).begin(i, k) );
+            ConstIterator_t<MT2> right( (*rhs).begin(i, k) );
 
             for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
                left.store( right.load() ); left += SIMDSIZE; right += SIMDSIZE;
@@ -2293,9 +2293,9 @@ template< typename MT2 >    // Type of the right-hand side dense tensor
 inline auto Subtensor<MT,aligned,CSAs...>::addAssign( const DenseTensor<MT2>& rhs )
    -> EnableIf_t< !VectorizedAddAssign_v<MT2> >
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2305,11 +2305,11 @@ inline auto Subtensor<MT,aligned,CSAs...>::addAssign( const DenseTensor<MT2>& rh
       for( size_t i=0UL; i<rows(); ++i )
       {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            tensor_(page()+k,row()+i,column()+j) += (~rhs)(k,i,j);
-            tensor_(page()+k,row()+i,column()+j+1UL) += (~rhs)(k,i,j+1UL);
+            tensor_(page()+k,row()+i,column()+j) += (*rhs)(k,i,j);
+            tensor_(page()+k,row()+i,column()+j+1UL) += (*rhs)(k,i,j+1UL);
          }
          if( jpos < columns() ) {
-            tensor_(page()+k,row()+i,column()+jpos) += (~rhs)(k,i,jpos);
+            tensor_(page()+k,row()+i,column()+jpos) += (*rhs)(k,i,jpos);
          }
       }
    }
@@ -2338,9 +2338,9 @@ inline auto Subtensor<MT,aligned,CSAs...>::addAssign( const DenseTensor<MT2>& rh
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    for( size_t k=0UL; k<pages(); ++k )
    {
@@ -2355,7 +2355,7 @@ inline auto Subtensor<MT,aligned,CSAs...>::addAssign( const DenseTensor<MT2>& rh
 
          size_t j( jbegin );
          Iterator left( begin(i, k) + jbegin );
-         ConstIterator_t<MT2> right( (~rhs).begin(i, k) + jbegin );
+         ConstIterator_t<MT2> right( (*rhs).begin(i, k) + jbegin );
 
          for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
             left.store( left.load() + right.load() ); left += SIMDSIZE; right += SIMDSIZE;
@@ -2394,9 +2394,9 @@ template< typename MT2 >    // Type of the right-hand side dense tensor
 inline auto Subtensor<MT,aligned,CSAs...>::subAssign( const DenseTensor<MT2>& rhs )
    -> EnableIf_t< !VectorizedSubAssign_v<MT2> >
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2406,11 +2406,11 @@ inline auto Subtensor<MT,aligned,CSAs...>::subAssign( const DenseTensor<MT2>& rh
       for( size_t i=0UL; i<rows(); ++i )
       {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            tensor_(page()+k,row()+i,column()+j) -= (~rhs)(k,i,j);
-            tensor_(page()+k,row()+i,column()+j+1UL) -= (~rhs)(k,i,j+1UL);
+            tensor_(page()+k,row()+i,column()+j) -= (*rhs)(k,i,j);
+            tensor_(page()+k,row()+i,column()+j+1UL) -= (*rhs)(k,i,j+1UL);
          }
          if( jpos < columns() ) {
-            tensor_(page()+k,row()+i,column()+jpos) -= (~rhs)(k,i,jpos);
+            tensor_(page()+k,row()+i,column()+jpos) -= (*rhs)(k,i,jpos);
          }
       }
    }
@@ -2439,9 +2439,9 @@ inline auto Subtensor<MT,aligned,CSAs...>::subAssign( const DenseTensor<MT2>& rh
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    for( size_t k=0UL; k<pages(); ++k )
    {
@@ -2456,7 +2456,7 @@ inline auto Subtensor<MT,aligned,CSAs...>::subAssign( const DenseTensor<MT2>& rh
 
          size_t j( jbegin );
          Iterator left( begin(i, k) + jbegin );
-         ConstIterator_t<MT2> right( (~rhs).begin(i, k) + jbegin );
+         ConstIterator_t<MT2> right( (*rhs).begin(i, k) + jbegin );
 
          for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
             left.store( left.load() - right.load() ); left += SIMDSIZE; right += SIMDSIZE;
@@ -2495,9 +2495,9 @@ template< typename MT2 >    // Type of the right-hand side dense tensor
 inline auto Subtensor<MT,aligned,CSAs...>::schurAssign( const DenseTensor<MT2>& rhs )
    -> EnableIf_t< !VectorizedSchurAssign_v<MT2> >
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2507,11 +2507,11 @@ inline auto Subtensor<MT,aligned,CSAs...>::schurAssign( const DenseTensor<MT2>& 
       for( size_t i=0UL; i<rows(); ++i )
       {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            tensor_(page()+k,row()+i,column()+j) *= (~rhs)(k,i,j);
-            tensor_(page()+k,row()+i,column()+j+1UL) *= (~rhs)(k,i,j+1UL);
+            tensor_(page()+k,row()+i,column()+j) *= (*rhs)(k,i,j);
+            tensor_(page()+k,row()+i,column()+j+1UL) *= (*rhs)(k,i,j+1UL);
          }
          if( jpos < columns() ) {
-            tensor_(page()+k,row()+i,column()+jpos) *= (~rhs)(k,i,jpos);
+            tensor_(page()+k,row()+i,column()+jpos) *= (*rhs)(k,i,jpos);
          }
       }
    }
@@ -2540,9 +2540,9 @@ inline auto Subtensor<MT,aligned,CSAs...>::schurAssign( const DenseTensor<MT2>& 
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    for( size_t k=0UL; k<pages(); ++k )
    {
@@ -2553,7 +2553,7 @@ inline auto Subtensor<MT,aligned,CSAs...>::schurAssign( const DenseTensor<MT2>& 
 
          size_t j( 0UL );
          Iterator left( begin(i, k) );
-         ConstIterator_t<MT2> right( (~rhs).begin(i, k) );
+         ConstIterator_t<MT2> right( (*rhs).begin(i, k) );
 
          for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
             left.store( left.load() * right.load() ); left += SIMDSIZE; right += SIMDSIZE;

--- a/blaze_tensor/math/views/subtensor/DenseUnaligned.h
+++ b/blaze_tensor/math/views/subtensor/DenseUnaligned.h
@@ -1399,12 +1399,12 @@ inline Subtensor<MT,unaligned,CSAs...>&
 {
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( ResultType_t<MT2> );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
    using Right = If_t< IsRestricted_v<MT>, CompositeType_t<MT2>, const MT2& >;
-   Right right( ~rhs );
+   Right right( *rhs );
 
    if( !tryAssign( tensor_, right, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1457,22 +1457,22 @@ inline auto Subtensor<MT,unaligned,CSAs...>::operator+=( const Tensor<MT2>& rhs 
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !tryAddAssign( tensor_, ~rhs, row(), column(), page() ) ) {
+   if( !tryAddAssign( tensor_, *rhs, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( (~rhs).canAlias( &tensor_ ) ) {
-      const AddType tmp( *this + (~rhs) );
+   if( (*rhs).canAlias( &tensor_ ) ) {
+      const AddType tmp( *this + (*rhs) );
       smpAssign( left, tmp );
    }
    else {
-      smpAddAssign( left, ~rhs );
+      smpAddAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1512,11 +1512,11 @@ inline auto Subtensor<MT,unaligned,CSAs...>::operator+=( const Tensor<MT2>& rhs 
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( AddType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( AddType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   const AddType tmp( *this + (~rhs) );
+   const AddType tmp( *this + (*rhs) );
 
    if( !tryAssign( tensor_, tmp, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1563,22 +1563,22 @@ inline auto Subtensor<MT,unaligned,CSAs...>::operator-=( const Tensor<MT2>& rhs 
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !trySubAssign( tensor_, ~rhs, row(), column(), page() ) ) {
+   if( !trySubAssign( tensor_, *rhs, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( (~rhs).canAlias( &tensor_ ) ) {
-      const SubType tmp( *this - (~rhs ) );
+   if( (*rhs).canAlias( &tensor_ ) ) {
+      const SubType tmp( *this - (*rhs ) );
       smpAssign( left, tmp );
    }
    else {
-      smpSubAssign( left, ~rhs );
+      smpSubAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1618,11 +1618,11 @@ inline auto Subtensor<MT,unaligned,CSAs...>::operator-=( const Tensor<MT2>& rhs 
    BLAZE_CONSTRAINT_MUST_BE_DENSE_TENSOR_TYPE  ( SubType );
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SubType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   const SubType tmp( *this - (~rhs) );
+   const SubType tmp( *this - (*rhs) );
 
    if( !tryAssign( tensor_, tmp, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -1668,22 +1668,22 @@ inline auto Subtensor<MT,unaligned,CSAs...>::operator%=( const Tensor<MT2>& rhs 
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   if( !trySchurAssign( tensor_, ~rhs, row(), column(), page() ) ) {
+   if( !trySchurAssign( tensor_, *rhs, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
    }
 
    decltype(auto) left( derestrict( *this ) );
 
-   if( (~rhs).canAlias( &tensor_ ) ) {
-      const SchurType tmp( *this % (~rhs) );
+   if( (*rhs).canAlias( &tensor_ ) ) {
+      const SchurType tmp( *this % (*rhs) );
       smpAssign( left, tmp );
    }
    else {
-      smpSchurAssign( left, ~rhs );
+      smpSchurAssign( left, *rhs );
    }
 
    BLAZE_INTERNAL_ASSERT( isIntact( tensor_ ), "Invariant violation detected" );
@@ -1722,11 +1722,11 @@ inline auto Subtensor<MT,unaligned,CSAs...>::operator%=( const Tensor<MT2>& rhs 
 
    BLAZE_CONSTRAINT_MUST_NOT_REQUIRE_EVALUATION( SchurType );
 
-   if( rows() != (~rhs).rows() || columns() != (~rhs).columns() || pages() != (~rhs).pages() ) {
+   if( rows() != (*rhs).rows() || columns() != (*rhs).columns() || pages() != (*rhs).pages() ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Tensor sizes do not match" );
    }
 
-   const SchurType tmp( *this % (~rhs) );
+   const SchurType tmp( *this % (*rhs) );
 
    if( !tryAssign( tensor_, tmp, row(), column(), page() ) ) {
       BLAZE_THROW_INVALID_ARGUMENT( "Invalid assignment to restricted tensor" );
@@ -2594,9 +2594,9 @@ template< typename MT2 >    // Type of the right-hand side dense tensor
 inline auto Subtensor<MT,unaligned,CSAs...>::assign( const DenseTensor<MT2>& rhs )
    -> EnableIf_t< !VectorizedAssign_v<MT2> >
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2604,11 +2604,11 @@ inline auto Subtensor<MT,unaligned,CSAs...>::assign( const DenseTensor<MT2>& rhs
    for( size_t k=0UL; k<pages(); ++k ) {
       for( size_t i=0UL; i<rows(); ++i ) {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            tensor_(page()+k,row()+i,column()+j) = (~rhs)(k,i,j);
-            tensor_(page()+k,row()+i,column()+j+1UL) = (~rhs)(k,i,j+1UL);
+            tensor_(page()+k,row()+i,column()+j) = (*rhs)(k,i,j);
+            tensor_(page()+k,row()+i,column()+j+1UL) = (*rhs)(k,i,j+1UL);
          }
          if( jpos < columns() ) {
-            tensor_(page()+k,row()+i,column()+jpos) = (~rhs)(k,i,jpos);
+            tensor_(page()+k,row()+i,column()+jpos) = (*rhs)(k,i,jpos);
          }
       }
    }
@@ -2637,16 +2637,16 @@ inline auto Subtensor<MT,unaligned,CSAs...>::assign( const DenseTensor<MT2>& rhs
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-SIMDSIZE) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % (SIMDSIZE) ) ) == jpos, "Invalid end calculation" );
 
    if( useStreaming && isAligned_ &&
        rows()*columns() > ( cacheSize / ( sizeof(ElementType) * 3UL ) ) &&
-       !(~rhs).isAliased( &tensor_ ) )
+       !(*rhs).isAliased( &tensor_ ) )
    {
       for( size_t k=0UL; k<pages(); ++k )
       {
@@ -2654,7 +2654,7 @@ inline auto Subtensor<MT,unaligned,CSAs...>::assign( const DenseTensor<MT2>& rhs
          {
             size_t j( 0UL );
             Iterator left( begin(i, k) );
-            ConstIterator_t<MT2> right( (~rhs).begin(i, k) );
+            ConstIterator_t<MT2> right( (*rhs).begin(i, k) );
 
             for( ; j<jpos; j+=SIMDSIZE ) {
                left.stream( right.load() ); left += SIMDSIZE; right += SIMDSIZE;
@@ -2673,7 +2673,7 @@ inline auto Subtensor<MT,unaligned,CSAs...>::assign( const DenseTensor<MT2>& rhs
          {
             size_t j( 0UL );
             Iterator left( begin(i, k) );
-            ConstIterator_t<MT2> right( (~rhs).begin(i, k) );
+            ConstIterator_t<MT2> right( (*rhs).begin(i, k) );
 
             for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
                left.store( right.load() ); left += SIMDSIZE; right += SIMDSIZE;
@@ -2713,9 +2713,9 @@ template< typename MT2 >    // Type of the right-hand side dense tensor
 inline auto Subtensor<MT,unaligned,CSAs...>::addAssign( const DenseTensor<MT2>& rhs )
    -> EnableIf_t< !VectorizedAddAssign_v<MT2> >
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2725,11 +2725,11 @@ inline auto Subtensor<MT,unaligned,CSAs...>::addAssign( const DenseTensor<MT2>& 
       for( size_t i=0UL; i<rows(); ++i )
       {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            tensor_(page()+k,row()+i,column()+j) += (~rhs)(k,i,j);
-            tensor_(page()+k,row()+i,column()+j+1UL) += (~rhs)(k,i,j+1UL);
+            tensor_(page()+k,row()+i,column()+j) += (*rhs)(k,i,j);
+            tensor_(page()+k,row()+i,column()+j+1UL) += (*rhs)(k,i,j+1UL);
          }
          if( jpos < columns() ) {
-            tensor_(page()+k,row()+i,column()+jpos) += (~rhs)(k,i,jpos);
+            tensor_(page()+k,row()+i,column()+jpos) += (*rhs)(k,i,jpos);
          }
       }
    }
@@ -2758,9 +2758,9 @@ inline auto Subtensor<MT,unaligned,CSAs...>::addAssign( const DenseTensor<MT2>& 
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    for( size_t k=0UL; k<pages(); ++k )
    {
@@ -2775,7 +2775,7 @@ inline auto Subtensor<MT,unaligned,CSAs...>::addAssign( const DenseTensor<MT2>& 
 
          size_t j( jbegin );
          Iterator left( begin(i, k) + jbegin );
-         ConstIterator_t<MT2> right( (~rhs).begin(i, k) + jbegin );
+         ConstIterator_t<MT2> right( (*rhs).begin(i, k) + jbegin );
 
          for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
             left.store( left.load() + right.load() ); left += SIMDSIZE; right += SIMDSIZE;
@@ -2814,9 +2814,9 @@ template< typename MT2 >    // Type of the right-hand side dense tensor
 inline auto Subtensor<MT,unaligned,CSAs...>::subAssign( const DenseTensor<MT2>& rhs )
    -> EnableIf_t< !VectorizedSubAssign_v<MT2> >
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2826,11 +2826,11 @@ inline auto Subtensor<MT,unaligned,CSAs...>::subAssign( const DenseTensor<MT2>& 
       for( size_t i=0UL; i<rows(); ++i )
       {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            tensor_(page()+k,row()+i,column()+j) -= (~rhs)(k,i,j);
-            tensor_(page()+k,row()+i,column()+j+1UL) -= (~rhs)(k,i,j+1UL);
+            tensor_(page()+k,row()+i,column()+j) -= (*rhs)(k,i,j);
+            tensor_(page()+k,row()+i,column()+j+1UL) -= (*rhs)(k,i,j+1UL);
          }
          if( jpos < columns() ) {
-            tensor_(page()+k,row()+i,column()+jpos) -= (~rhs)(k,i,jpos);
+            tensor_(page()+k,row()+i,column()+jpos) -= (*rhs)(k,i,jpos);
          }
       }
    }
@@ -2859,9 +2859,9 @@ inline auto Subtensor<MT,unaligned,CSAs...>::subAssign( const DenseTensor<MT2>& 
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    for( size_t k=0UL; k<pages(); ++k )
    {
@@ -2876,7 +2876,7 @@ inline auto Subtensor<MT,unaligned,CSAs...>::subAssign( const DenseTensor<MT2>& 
 
          size_t j( jbegin );
          Iterator left( begin(i, k) + jbegin );
-         ConstIterator_t<MT2> right( (~rhs).begin(i, k) + jbegin );
+         ConstIterator_t<MT2> right( (*rhs).begin(i, k) + jbegin );
 
          for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
             left.store( left.load() - right.load() ); left += SIMDSIZE; right += SIMDSIZE;
@@ -2915,9 +2915,9 @@ template< typename MT2 >    // Type of the right-hand side dense tensor
 inline auto Subtensor<MT,unaligned,CSAs...>::schurAssign( const DenseTensor<MT2>& rhs )
    -> EnableIf_t< !VectorizedSchurAssign_v<MT2> >
 {
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    const size_t jpos( columns() & size_t(-2) );
    BLAZE_INTERNAL_ASSERT( ( columns() - ( columns() % 2UL ) ) == jpos, "Invalid end calculation" );
@@ -2927,11 +2927,11 @@ inline auto Subtensor<MT,unaligned,CSAs...>::schurAssign( const DenseTensor<MT2>
       for( size_t i=0UL; i<rows(); ++i )
       {
          for( size_t j=0UL; j<jpos; j+=2UL ) {
-            tensor_(page()+k,row()+i,column()+j) *= (~rhs)(k,i,j);
-            tensor_(page()+k,row()+i,column()+j+1UL) *= (~rhs)(k,i,j+1UL);
+            tensor_(page()+k,row()+i,column()+j) *= (*rhs)(k,i,j);
+            tensor_(page()+k,row()+i,column()+j+1UL) *= (*rhs)(k,i,j+1UL);
          }
          if( jpos < columns() ) {
-            tensor_(page()+k,row()+i,column()+jpos) *= (~rhs)(k,i,jpos);
+            tensor_(page()+k,row()+i,column()+jpos) *= (*rhs)(k,i,jpos);
          }
       }
    }
@@ -2960,9 +2960,9 @@ inline auto Subtensor<MT,unaligned,CSAs...>::schurAssign( const DenseTensor<MT2>
 {
    BLAZE_CONSTRAINT_MUST_BE_VECTORIZABLE_TYPE( ElementType );
 
-   BLAZE_INTERNAL_ASSERT( rows()    == (~rhs).rows()   , "Invalid number of rows"    );
-   BLAZE_INTERNAL_ASSERT( columns() == (~rhs).columns(), "Invalid number of columns" );
-   BLAZE_INTERNAL_ASSERT( pages()   == (~rhs).pages()  , "Invalid number of pages" );
+   BLAZE_INTERNAL_ASSERT( rows()    == (*rhs).rows()   , "Invalid number of rows"    );
+   BLAZE_INTERNAL_ASSERT( columns() == (*rhs).columns(), "Invalid number of columns" );
+   BLAZE_INTERNAL_ASSERT( pages()   == (*rhs).pages()  , "Invalid number of pages" );
 
    for( size_t k=0UL; k<pages(); ++k )
    {
@@ -2973,7 +2973,7 @@ inline auto Subtensor<MT,unaligned,CSAs...>::schurAssign( const DenseTensor<MT2>
 
          size_t j( 0UL );
          Iterator left( begin(i, k) );
-         ConstIterator_t<MT2> right( (~rhs).begin(i, k) );
+         ConstIterator_t<MT2> right( (*rhs).begin(i, k) );
 
          for( ; (j+SIMDSIZE*3UL) < jpos; j+=SIMDSIZE*4UL ) {
             left.store( left.load() * right.load() ); left += SIMDSIZE; right += SIMDSIZE;

--- a/blazetest/blazetest/mathtest/dmatexpand/OperationTest.h
+++ b/blazetest/blazetest/mathtest/dmatexpand/OperationTest.h
@@ -11142,7 +11142,7 @@ void OperationTest<MT,E>::convertException( const std::exception& ex )
 template< typename MT >  // Type of the dense Matrix
 void runTest( const Creator<MT>& creator )
 {
-   for( size_t rep=0UL; rep<repetitions; ++rep ) {
+   for( size_t rep=0UL; rep<BLAZETEST_REPETITIONS; ++rep ) {
       OperationTest<MT,3UL>{ creator };
       OperationTest<MT,6UL>{ creator };
       OperationTest<MT,7UL>{ creator };

--- a/blazetest/blazetest/mathtest/dmatravel/OperationTest.h
+++ b/blazetest/blazetest/mathtest/dmatravel/OperationTest.h
@@ -3789,9 +3789,9 @@ void OperationTest<MT>::convertException( const std::exception& ex )
 template< typename MT >  // Type of the dense matrix
 void runTest( const Creator<MT>& creator )
 {
-   for( size_t rep=0UL; rep<repetitions; ++rep ) {
+   //for( size_t rep=0UL; rep<BLAZETEST_REPETITIONS; ++rep ) {
       OperationTest<MT>{ creator };
-   }
+   //}
 }
 //*************************************************************************************************
 

--- a/blazetest/blazetest/mathtest/dtensdmatschur/OperationTest.h
+++ b/blazetest/blazetest/mathtest/dtensdmatschur/OperationTest.h
@@ -6110,7 +6110,7 @@ void runTest( const Creator<TT>& creator1, const Creator<MT>& creator2 )
 #if BLAZETEST_MATHTEST_TEST_MULTIPLICATION
    if( BLAZETEST_MATHTEST_TEST_MULTIPLICATION > 1 )
    {
-      for( size_t rep=0UL; rep<repetitions; ++rep ) {
+      for( size_t rep=0UL; rep<BLAZETEST_REPETITIONS; ++rep ) {
          OperationTest<TT,MT>( creator1, creator2 );
       }
    }

--- a/blazetest/blazetest/mathtest/dtensdtensadd/OperationTest.h
+++ b/blazetest/blazetest/mathtest/dtensdtensadd/OperationTest.h
@@ -13238,7 +13238,7 @@ void runTest( const Creator<MT1>& creator1, const Creator<MT2>& creator2 )
 #if BLAZETEST_MATHTEST_TEST_ADDITION
    if( BLAZETEST_MATHTEST_TEST_ADDITION > 1 )
    {
-      for( size_t rep=0UL; rep<repetitions; ++rep ) {
+      for( size_t rep=0UL; rep<BLAZETEST_REPETITIONS; ++rep ) {
          OperationTest<MT1,MT2>( creator1, creator2 );
       }
    }

--- a/blazetest/blazetest/mathtest/dtensdvecmult/OperationTest.h
+++ b/blazetest/blazetest/mathtest/dtensdvecmult/OperationTest.h
@@ -3167,7 +3167,7 @@ void runTest( const Creator<TT>& creator1, const Creator<VT>& creator2 )
 #if BLAZETEST_MATHTEST_TEST_MULTIPLICATION
    if( BLAZETEST_MATHTEST_TEST_MULTIPLICATION > 1 )
    {
-      for( size_t rep=0UL; rep<repetitions; ++rep ) {
+      for( size_t rep=0UL; rep<BLAZETEST_REPETITIONS; ++rep ) {
          OperationTest<TT,VT>( creator1, creator2 );
       }
    }

--- a/blazetest/blazetest/mathtest/dtensravel/OperationTest.h
+++ b/blazetest/blazetest/mathtest/dtensravel/OperationTest.h
@@ -3788,7 +3788,7 @@ void OperationTest<TT>::convertException( const std::exception& ex )
 template< typename TT >  // Type of the dense tensor
 void runTest( const Creator<TT>& creator )
 {
-   for( size_t rep=0UL; rep<repetitions; ++rep ) {
+   for( size_t rep=0UL; rep<BLAZETEST_REPETITIONS; ++rep ) {
       OperationTest<TT>{ creator };
    }
 }

--- a/blazetest/src/mathtest/dynamictensor/ClassTest2.cpp
+++ b/blazetest/src/mathtest/dynamictensor/ClassTest2.cpp
@@ -2477,7 +2477,7 @@ void ClassTest::testTranspose()
                 << "   Result:\n" << mat << "\n"
                 << "   Expected result:\n"
                         "(( 1 0 2 0 3 )\n( 1 0 2 0 3 )\n"
-                        " ( 0 4 0 5 0 )\n( 0 4 0 5 0 )\n";
+                        " ( 0 4 0 5 0 )\n( 0 4 0 5 0 )\n"
                         " ( 6 0 7 0 8 )\n( 6 0 7 0 8 ))\n";
             throw std::runtime_error( oss.str() );
          }


### PR DESCRIPTION
This pull request adapts blaze_tensor to the latest changes in the blaze library. With commit [8e32af9](https://bitbucket.org/blaze-lib/blaze/commits/8e32af9ad79405048b8918786e628c7ca29d4f3f) all `operator~()`, which serve as operators for the type-safe downcast in a CRTP relationship, will be replaced by `operator*()`. `operator~()` itself will be `[[deprecated]]`.